### PR TITLE
feat: GitHub/Dex OIDC identity connector with role mapping and view-as

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,29 @@
+# TODOs
+
+Deferred work items with full context. Each entry explains what, why, and where to start.
+
+## Investigate capability-scoped tables for ServiceConnection
+
+**What:** Evaluate whether ServiceConnection should only hold bare-minimum fields (user_id, service_type, external_user_id, connected_at, enabled), with capability-specific data living in separate tables joined by connection ID.
+
+**Why:** Identity-only connectors (GitHub/Dex) create ServiceConnection rows with sync-related fields (sync_watermark, last_synced_at, encrypted tokens for API calls) that will always be None. As more connector types are added (each with different capability profiles), the single-table model accumulates nullable fields that only apply to subsets of connectors. Capability-scoped tables would let each capability declare its own storage needs.
+
+**Current state:** ServiceConnection has ~15 fields. Identity-only connectors use ~6 of them. The unused fields are nullable and harmless today, but the pattern doesn't scale cleanly.
+
+**Where to start:** Map each ServiceConnection field to the capability that uses it. Sketch a normalized schema (e.g., `connection_sync_state`, `connection_tokens`, `connection_identity`). Evaluate whether the query complexity of joins outweighs the schema clarity.
+
+**Depends on:** GitHub/Dex auth feature landing first (provides a concrete identity-only connector to test against).
+
+**Source:** /plan-eng-review D15, 2026-05-28. Outside voice flagged ServiceConnection overhead for identity-only connectors.
+
+## Refactor sync dispatch to be connector-capability-aware
+
+**What:** Sync dispatch code (worker, orphan recovery, task dispatch) should check whether a connector declares sync-related capabilities before attempting to dispatch. Currently these call sites assume all connectors have a sync_function.
+
+**Why:** Adding identity-only connectors (no sync) means sync dispatch could encounter None sync_function values. Rather than adding None guards at each call site (which must be repeated for every future sync-less connector), the dispatch code should query connector capabilities and skip non-sync connectors automatically.
+
+**Current state:** Will be partially addressed during the GitHub/Dex auth feature (capability checks added to dispatch). This TODO tracks the broader refactor to make the pattern self-documenting.
+
+**Where to start:** Trace `_TASK_DISPATCH`, orphan recovery in `sync/lifecycle.py`, and worker job dispatch. Add capability checks using `registry.get_by_capability()` to filter connectors before dispatch.
+
+**Source:** /plan-eng-review D12+D17, 2026-05-28. Outside voice caught the call-site audit gap; user requested forward-looking refactor.

--- a/alembic/versions/a5v6w7x8y9z0_add_github_service_type.py
+++ b/alembic/versions/a5v6w7x8y9z0_add_github_service_type.py
@@ -1,0 +1,83 @@
+"""add GITHUB to ServiceType enum values
+
+Revision ID: a5v6w7x8y9z0
+Revises: z3u4v5w6x7y8
+Create Date: 2026-05-28
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a5v6w7x8y9z0"
+down_revision: str = "z3u4v5w6x7y8"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_TABLES_AND_COLUMNS = [
+    ("listening_events", "source_service"),
+    ("events", "source_service"),
+    ("event_artist_candidates", "source_service"),
+    ("event_candidates", "source_service"),
+    ("entity_exclusions", "source_service"),
+    ("venue_candidates", "source_service"),
+    ("user_event_attendance", "source_service"),
+    ("user_artist_relations", "source_service"),
+    ("user_track_relations", "source_service"),
+    ("service_connections", "service_type"),
+]
+
+_OLD_VALUES = (
+    "'SPOTIFY', 'LASTFM', 'LISTENBRAINZ', 'SONGKICK', "
+    "'BANDSINTOWN', 'BANDCAMP', 'SOUNDCLOUD', 'ICAL', "
+    "'CONCERT_ARCHIVES', 'MANUAL', 'TEST'"
+)
+_NEW_VALUES = (
+    "'SPOTIFY', 'LASTFM', 'LISTENBRAINZ', 'SONGKICK', "
+    "'BANDSINTOWN', 'BANDCAMP', 'SOUNDCLOUD', 'ICAL', "
+    "'CONCERT_ARCHIVES', 'GITHUB', 'MANUAL', 'TEST'"
+)
+
+_FIND_CONSTRAINTS_SQL = sa.text("""
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN pg_attribute att ON att.attrelid = rel.oid
+    WHERE con.contype = 'c'
+      AND rel.relname = :table_name
+      AND nsp.nspname = 'public'
+      AND pg_get_constraintdef(con.oid) LIKE '%' || :column_name || '%'
+""")
+
+
+def _replace_constraints(values: str) -> None:
+    conn = op.get_bind()
+    for table, column in _TABLES_AND_COLUMNS:
+        result = conn.execute(
+            _FIND_CONSTRAINTS_SQL,
+            {"table_name": table, "column_name": column},
+        )
+        for (constraint_name,) in result:
+            conn.execute(
+                sa.text(
+                    f'ALTER TABLE "{table}" DROP CONSTRAINT'
+                    f' IF EXISTS "{constraint_name}"'
+                )
+            )
+
+        op.create_check_constraint(
+            f"ck_{table}_{column}_servicetype",
+            table,
+            f"{column} IN ({values})",
+        )
+
+
+def upgrade() -> None:
+    _replace_constraints(_NEW_VALUES)
+
+
+def downgrade() -> None:
+    _replace_constraints(_OLD_VALUES)

--- a/src/resonance/api/v1/auth.py
+++ b/src/resonance/api/v1/auth.py
@@ -71,7 +71,7 @@ async def auth_initiate(
     service_type = _parse_service_type(service)
     connector = _get_connector(request, service_type)
 
-    if not connector.has_capability(base_module.ConnectorCapability.AUTHENTICATION):
+    if not connector.has_capability(base_module.ConnectorCapability.AUTHN):
         raise fastapi.HTTPException(
             status_code=400,
             detail=f"Service {service} does not support authentication",
@@ -141,6 +141,12 @@ async def auth_callback(
             f"{service}: {exc.response.status_code}"
         )
         raise fastapi.HTTPException(status_code=502, detail=detail) from exc
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        logger.exception("Cannot reach auth service for %s", service)
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail="Authentication service is temporarily unavailable",
+        ) from exc
 
     # Encrypt tokens
     settings = request.app.state.settings
@@ -278,11 +284,38 @@ async def auth_callback(
     # Set session
     session["user_id"] = str(user_id)
 
-    # Load and cache the user's role in the session for template access.
+    # Load the user's current role.
     role_result = await db.execute(
         sa.select(user_models.User.role).where(user_models.User.id == user_id)
     )
     user_role = role_result.scalar_one()
+
+    # AUTHZ: if this connector can determine roles, update accordingly.
+    if connector.has_capability(base_module.ConnectorCapability.AUTHZ):
+        derived_role = await connector.get_role(access_token=tokens.access_token)
+        if (
+            derived_role is not None
+            and user_role != types_module.UserRole.OWNER
+            and derived_role != user_role
+        ):
+            logger.info(
+                "Role changed via AUTHZ",
+                user_id=str(user_id),
+                old_role=user_role.value,
+                new_role=derived_role.value,
+                service=service,
+            )
+            await db.execute(
+                sa.update(user_models.User)
+                .where(user_models.User.id == user_id)
+                .values(role=derived_role)
+            )
+            await db.commit()
+            user_role = derived_role
+            # Invalidate stale sessions that still carry the old role.
+            redis = request.app.state.redis
+            await session_module.invalidate_user_sessions(redis, str(user_id))
+
     session["user_role"] = user_role.value
 
     # Load timezone preference into session for templates.

--- a/src/resonance/api/v1/sync.py
+++ b/src/resonance/api/v1/sync.py
@@ -248,6 +248,12 @@ async def trigger_sync_by_connection(
             status_code=400, detail="No sync config for this service"
         )
 
+    if config.sync_function is None:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="This service does not support sync",
+        )
+
     if config.auth_type == "file_upload":
         raise fastapi.HTTPException(
             status_code=400,

--- a/src/resonance/app.py
+++ b/src/resonance/app.py
@@ -16,6 +16,7 @@ import structlog
 import resonance.api.v1 as api_v1_module
 import resonance.config as config_module
 import resonance.connectors.concert_archives as concert_archives_module
+import resonance.connectors.github as github_module
 import resonance.connectors.ical as ical_module
 import resonance.connectors.lastfm as lastfm_module
 import resonance.connectors.listenbrainz as listenbrainz_module
@@ -31,6 +32,7 @@ import resonance.types as types_module
 import resonance.ui.account as ui_account_module
 import resonance.ui.admin as ui_admin_module
 import resonance.ui.artists as ui_artists_module
+import resonance.ui.common as ui_common_module
 import resonance.ui.dashboard as ui_dashboard_module
 import resonance.ui.events as ui_events_module
 import resonance.ui.playground as ui_playground_module
@@ -136,7 +138,10 @@ def create_app() -> fastapi.FastAPI:
     connector_registry.register(songkick_module.SongkickConnector())
     connector_registry.register(ical_module.ICalConnector())
     connector_registry.register(concert_archives_module.ConcertArchivesConnector())
+    if settings.dex_client_id:
+        connector_registry.register(github_module.GitHubConnector(settings=settings))
     application.state.connector_registry = connector_registry
+    ui_common_module.set_connector_registry(connector_registry)
 
     @application.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/src/resonance/config.py
+++ b/src/resonance/config.py
@@ -50,6 +50,17 @@ class Settings(pydantic_settings.BaseSettings):
     # Admin API token (for CLI/programmatic access)
     admin_api_token: str = ""
 
+    # Dex OIDC (GitHub identity via Dex broker)
+    dex_client_id: str = ""
+    dex_client_secret: str = ""
+    dex_issuer_url: str = ""
+    dex_redirect_path: str = "/api/v1/auth/github/callback"
+
+    @property
+    def dex_redirect_uri(self) -> str:
+        """Full Dex OIDC redirect URI."""
+        return f"{self.base_url}{self.dex_redirect_path}"
+
     @property
     def spotify_redirect_uri(self) -> str:
         """Full Spotify OAuth redirect URI."""

--- a/src/resonance/connectors/base.py
+++ b/src/resonance/connectors/base.py
@@ -24,9 +24,9 @@ logger = structlog.get_logger()
 class ConnectionConfig:
     """Declares how a connector authenticates and syncs."""
 
-    auth_type: str  # "oauth", "username", "url"
-    sync_function: str  # arq job name
-    sync_style: str  # "incremental" or "full"
+    auth_type: str  # "oauth", "username", "url", "file_upload"
+    sync_function: str | None = None  # arq job name, None for identity-only connectors
+    sync_style: str | None = None  # "incremental" or "full", None for identity-only
     derive_urls: Callable[[str], list[str]] | None = None
 
 
@@ -45,7 +45,8 @@ class RateLimitExceededError(Exception):
 class ConnectorCapability(enum.StrEnum):
     """Capabilities that a connector can declare support for."""
 
-    AUTHENTICATION = "authentication"
+    AUTHN = "authn"
+    AUTHZ = "authz"
     LISTENING_HISTORY = "listening_history"
     RECOMMENDATIONS = "recommendations"
     PLAYLIST_WRITE = "playlist_write"
@@ -114,6 +115,9 @@ class BaseConnector(abc.ABC):
 
     service_type: types_module.ServiceType
     capabilities: frozenset[ConnectorCapability]
+    display_name: str = ""
+    icon: str = "link"
+    color: str = ""
 
     # Subclasses must set these
     _http_client: httpx.AsyncClient | None
@@ -167,6 +171,14 @@ class BaseConnector(abc.ABC):
     async def get_current_user(self, access_token: str) -> dict[str, str]:
         """Get the current user's profile. Returns dict with 'id' and 'display_name'."""
         ...
+
+    async def get_role(self, access_token: str) -> types_module.UserRole | None:
+        """Derive user role from this connector's authorization source.
+
+        Only connectors with AUTHZ capability should override this.
+        Returns None by default (no role determination).
+        """
+        return None
 
     # Transient errors that should be retried with exponential backoff.
     _TRANSIENT_ERRORS: tuple[type[Exception], ...] = (

--- a/src/resonance/connectors/concert_archives.py
+++ b/src/resonance/connectors/concert_archives.py
@@ -10,6 +10,9 @@ class ConcertArchivesConnector:
     """Minimal connector for Concert Archives CSV import connections."""
 
     service_type = types_module.ServiceType.CONCERT_ARCHIVES
+    display_name = "Concert Archives"
+    icon = "archive"
+    color = ""
 
     @staticmethod
     def connection_config() -> base_module.ConnectionConfig:

--- a/src/resonance/connectors/github.py
+++ b/src/resonance/connectors/github.py
@@ -1,0 +1,126 @@
+"""GitHub/Dex OIDC connector for identity and role assignment."""
+
+import urllib.parse
+
+import structlog
+
+import resonance.config as config_module
+import resonance.connectors.base as base_module
+import resonance.connectors.ratelimit as ratelimit_module
+import resonance.types as types_module
+
+logger = structlog.get_logger()
+
+_SCOPES = "openid profile email groups"
+
+_ADMIN_TEAMS = frozenset(
+    {
+        "megadoomer-io:admins",
+        "megadoomer-io:resonance-admins",
+    }
+)
+
+
+class GitHubConnector(base_module.BaseConnector):
+    """Identity connector using Dex as OIDC broker with GitHub as upstream IdP."""
+
+    service_type = types_module.ServiceType.GITHUB
+    display_name = "GitHub"
+    icon = "github"
+    color = ""
+    capabilities = frozenset(
+        {
+            base_module.ConnectorCapability.AUTHN,
+            base_module.ConnectorCapability.AUTHZ,
+        }
+    )
+
+    @staticmethod
+    def connection_config() -> base_module.ConnectionConfig:
+        return base_module.ConnectionConfig(auth_type="oauth")
+
+    def __init__(self, settings: config_module.Settings) -> None:
+        self._client_id = settings.dex_client_id
+        self._client_secret = settings.dex_client_secret
+        self._issuer_url = settings.dex_issuer_url.rstrip("/")
+        self._redirect_uri = settings.dex_redirect_uri
+        self._http_client = None
+        self._budget = ratelimit_module.RateLimitBudget(
+            default_interval=1.0,
+            window_seconds=30,
+            window_ceiling=20,
+        )
+
+    def get_auth_url(self, state: str) -> str:
+        params = urllib.parse.urlencode(
+            {
+                "client_id": self._client_id,
+                "response_type": "code",
+                "redirect_uri": self._redirect_uri,
+                "scope": _SCOPES,
+                "state": state,
+            }
+        )
+        return f"{self._issuer_url}/auth?{params}"
+
+    async def exchange_code(self, code: str) -> base_module.TokenResponse:
+        logger.info("Exchanging Dex authorization code for tokens")
+        response = await self._request(
+            "POST",
+            f"{self._issuer_url}/token",
+            high_priority=True,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self._redirect_uri,
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            },
+        )
+        logger.info("Dex token exchange successful")
+        return base_module.TokenResponse.model_validate(response.json())
+
+    async def get_current_user(self, access_token: str) -> dict[str, str]:
+        logger.info("Fetching user profile from Dex userinfo")
+        response = await self._request(
+            "GET",
+            f"{self._issuer_url}/userinfo",
+            high_priority=True,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        data = response.json()
+        return {
+            "id": data.get("sub", ""),
+            "display_name": data.get("name") or data.get("preferred_username", ""),
+        }
+
+    async def get_role(self, access_token: str) -> types_module.UserRole | None:
+        """Derive user role from Dex groups claim (GitHub team membership).
+
+        Returns ADMIN if the user belongs to any admin team, USER otherwise.
+        Returns None on parse failure (defensive fallback).
+        """
+        try:
+            response = await self._request(
+                "GET",
+                f"{self._issuer_url}/userinfo",
+                high_priority=True,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            data = response.json()
+            groups = data.get("groups", [])
+
+            if not isinstance(groups, list):
+                logger.warning(
+                    "Unexpected groups claim format",
+                    groups_type=type(groups).__name__,
+                )
+                return types_module.UserRole.USER
+
+            if _ADMIN_TEAMS & set(groups):
+                return types_module.UserRole.ADMIN
+
+            return types_module.UserRole.USER
+        except Exception:
+            logger.exception("Failed to parse groups claim from Dex")
+            return None

--- a/src/resonance/connectors/github.py
+++ b/src/resonance/connectors/github.py
@@ -44,6 +44,7 @@ class GitHubConnector(base_module.BaseConnector):
         self._client_secret = settings.dex_client_secret
         self._issuer_url = settings.dex_issuer_url.rstrip("/")
         self._redirect_uri = settings.dex_redirect_uri
+        self._last_userinfo: dict[str, object] | None = None
         self._http_client = None
         self._budget = ratelimit_module.RateLimitBudget(
             default_interval=1.0,
@@ -80,34 +81,34 @@ class GitHubConnector(base_module.BaseConnector):
         logger.info("Dex token exchange successful")
         return base_module.TokenResponse.model_validate(response.json())
 
-    async def get_current_user(self, access_token: str) -> dict[str, str]:
-        logger.info("Fetching user profile from Dex userinfo")
+    async def _fetch_userinfo(self, access_token: str) -> dict[str, object]:
         response = await self._request(
             "GET",
             f"{self._issuer_url}/userinfo",
             high_priority=True,
             headers={"Authorization": f"Bearer {access_token}"},
         )
-        data = response.json()
+        return response.json()  # type: ignore[no-any-return]
+
+    async def get_current_user(self, access_token: str) -> dict[str, str]:
+        logger.info("Fetching user profile from Dex userinfo")
+        data = await self._fetch_userinfo(access_token)
+        self._last_userinfo = data
         return {
-            "id": data.get("sub", ""),
-            "display_name": data.get("name") or data.get("preferred_username", ""),
+            "id": str(data.get("sub", "")),
+            "display_name": str(data.get("name") or data.get("preferred_username", "")),
         }
 
     async def get_role(self, access_token: str) -> types_module.UserRole | None:
         """Derive user role from Dex groups claim (GitHub team membership).
 
-        Returns ADMIN if the user belongs to any admin team, USER otherwise.
-        Returns None on parse failure (defensive fallback).
+        Uses cached userinfo from get_current_user() if available,
+        otherwise fetches fresh.
         """
         try:
-            response = await self._request(
-                "GET",
-                f"{self._issuer_url}/userinfo",
-                high_priority=True,
-                headers={"Authorization": f"Bearer {access_token}"},
-            )
-            data = response.json()
+            data = getattr(self, "_last_userinfo", None)
+            if data is None:
+                data = await self._fetch_userinfo(access_token)
             groups = data.get("groups", [])
 
             if not isinstance(groups, list):
@@ -124,3 +125,5 @@ class GitHubConnector(base_module.BaseConnector):
         except Exception:
             logger.exception("Failed to parse groups claim from Dex")
             return None
+        finally:
+            self._last_userinfo = None

--- a/src/resonance/connectors/ical.py
+++ b/src/resonance/connectors/ical.py
@@ -10,6 +10,9 @@ class ICalConnector:
     """Minimal connector for generic iCal feed connections."""
 
     service_type = types_module.ServiceType.ICAL
+    display_name = "iCal"
+    icon = "calendar"
+    color = ""
 
     @staticmethod
     def connection_config() -> base_module.ConnectionConfig:

--- a/src/resonance/connectors/lastfm.py
+++ b/src/resonance/connectors/lastfm.py
@@ -31,9 +31,12 @@ class LastFmConnector(base_module.BaseConnector):
     """Connector for the Last.fm API with web authentication."""
 
     service_type = types_module.ServiceType.LASTFM
+    display_name = "Last.fm"
+    icon = "radio"
+    color = "var(--color-lastfm)"
     capabilities = frozenset(
         {
-            base_module.ConnectorCapability.AUTHENTICATION,
+            base_module.ConnectorCapability.AUTHN,
             base_module.ConnectorCapability.LISTENING_HISTORY,
             base_module.ConnectorCapability.TRACK_RATINGS,
         }

--- a/src/resonance/connectors/listenbrainz.py
+++ b/src/resonance/connectors/listenbrainz.py
@@ -32,9 +32,12 @@ class ListenBrainzConnector(base_module.BaseConnector):
     """Connector for the ListenBrainz API with MusicBrainz OAuth."""
 
     service_type = types_module.ServiceType.LISTENBRAINZ
+    display_name = "ListenBrainz"
+    icon = "headphones"
+    color = "var(--color-listenbrainz)"
     capabilities = frozenset(
         {
-            base_module.ConnectorCapability.AUTHENTICATION,
+            base_module.ConnectorCapability.AUTHN,
             base_module.ConnectorCapability.LISTENING_HISTORY,
             base_module.ConnectorCapability.TRACK_DISCOVERY,
         }

--- a/src/resonance/connectors/registry.py
+++ b/src/resonance/connectors/registry.py
@@ -16,6 +16,9 @@ class Connectable(Protocol):
     """
 
     service_type: types_module.ServiceType
+    display_name: str
+    icon: str
+    color: str
 
     @staticmethod
     def connection_config() -> base_module.ConnectionConfig: ...
@@ -90,3 +93,24 @@ class ConnectorRegistry:
             for c in self._connectors.values()
             if isinstance(c, base_module_rt.BaseConnector)
         ]
+
+    def display_name(self, service_type: types_module.ServiceType) -> str:
+        """Return the human-friendly display name for a service type."""
+        connector = self._connectors.get(service_type)
+        if connector is not None and connector.display_name:
+            return connector.display_name
+        return service_type.value.replace("_", " ").title()
+
+    def icon(self, service_type: types_module.ServiceType) -> str:
+        """Return the Lucide icon name for a service type."""
+        connector = self._connectors.get(service_type)
+        if connector is not None and connector.icon:
+            return connector.icon
+        return "link"
+
+    def color(self, service_type: types_module.ServiceType) -> str:
+        """Return the CSS color for a service type, or empty string."""
+        connector = self._connectors.get(service_type)
+        if connector is not None:
+            return connector.color
+        return ""

--- a/src/resonance/connectors/songkick.py
+++ b/src/resonance/connectors/songkick.py
@@ -23,6 +23,9 @@ class SongkickConnector:
     """
 
     service_type = types_module.ServiceType.SONGKICK
+    display_name = "Songkick"
+    icon = "ticket"
+    color = ""
 
     @staticmethod
     def connection_config() -> base_module.ConnectionConfig:

--- a/src/resonance/connectors/spotify.py
+++ b/src/resonance/connectors/spotify.py
@@ -54,9 +54,12 @@ class SpotifyConnector(base_module.BaseConnector):
     """Connector for the Spotify Web API."""
 
     service_type = types_module.ServiceType.SPOTIFY
+    display_name = "Spotify"
+    icon = "music"
+    color = "var(--color-spotify)"
     capabilities = frozenset(
         {
-            base_module.ConnectorCapability.AUTHENTICATION,
+            base_module.ConnectorCapability.AUTHN,
             base_module.ConnectorCapability.LISTENING_HISTORY,
             base_module.ConnectorCapability.FOLLOWS,
             base_module.ConnectorCapability.TRACK_RATINGS,

--- a/src/resonance/connectors/test.py
+++ b/src/resonance/connectors/test.py
@@ -9,6 +9,9 @@ class TestConnector(base_module.BaseConnector):
     """Fake connector for testing the sync pipeline."""
 
     service_type = types_module.ServiceType.TEST
+    display_name = "Test"
+    icon = "flask-conical"
+    color = ""
     capabilities = frozenset(
         {
             base_module.ConnectorCapability.LISTENING_HISTORY,

--- a/src/resonance/static/theme.css
+++ b/src/resonance/static/theme.css
@@ -177,6 +177,24 @@ table {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 24'%3E%3Cpath d='M0 12 Q150 0 300 12 Q450 24 600 12 Q750 0 900 12 Q1050 24 1200 12' fill='none' stroke='%239B9B96' stroke-width='1'/%3E%3C/svg%3E");
 }
 
+/* ── View-as pill ─────────────────────────────────────────── */
+
+.view-as-pill {
+  position: fixed;
+  bottom: var(--space-md);
+  left: var(--space-md);
+  background: var(--pico-card-background-color);
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
 /* ── Reduced motion ───────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/resonance/templates/base.html
+++ b/src/resonance/templates/base.html
@@ -57,6 +57,20 @@
     <main class="container">
         {% block content %}{% endblock %}
     </main>
+    {% if viewing_as %}
+    <div class="view-as-pill">
+        <span>Viewing as <strong>{{ viewing_as }}</strong></span>
+        <form method="post" action="/view-as" style="display:inline">
+            <button type="submit" name="role" value="reset" class="outline contrast" style="margin:0;padding:0.25rem 0.5rem;font-size:0.75rem">Reset</button>
+        </form>
+    </div>
+    {% elif actual_role in ('admin', 'owner') and user_id %}
+    <div class="view-as-pill">
+        <form method="post" action="/view-as" style="display:inline">
+            <button type="submit" name="role" value="user" class="outline contrast" style="margin:0;padding:0.25rem 0.5rem;font-size:0.75rem">View as user</button>
+        </form>
+    </div>
+    {% endif %}
     <div id="modal-container"></div>
     <script>
     function openExternalSearchModal(prefillQuery) {

--- a/src/resonance/templates/login.html
+++ b/src/resonance/templates/login.html
@@ -6,8 +6,8 @@
 <article>
     <h1>resonance</h1>
     <p>Personal media discovery and playlist generation platform.</p>
-    <a href="/api/v1/auth/spotify" role="button"><i data-lucide="music" class="icon-inline" style="color: var(--color-spotify)"></i> Connect with Spotify</a>
-    <a href="/api/v1/auth/listenbrainz" role="button" class="outline"><i data-lucide="headphones" class="icon-inline" style="color: var(--color-listenbrainz)"></i> Connect with ListenBrainz</a>
-    <a href="/api/v1/auth/lastfm" role="button" class="outline"><i data-lucide="radio" class="icon-inline" style="color: var(--color-lastfm)"></i> Connect with Last.fm</a>
+    {% for connector in authn_connectors %}
+    <a href="/api/v1/auth/{{ connector.service_type.value }}" role="button"{% if not loop.first %} class="outline"{% endif %}><i data-lucide="{{ connector.icon }}" class="icon-inline"{% if connector.color %} style="color: {{ connector.color }}"{% endif %}></i> Connect with {{ connector.display_name }}</a>
+    {% endfor %}
 </article>
 {% endblock %}

--- a/src/resonance/types.py
+++ b/src/resonance/types.py
@@ -15,6 +15,7 @@ class ServiceType(enum.StrEnum):
     SOUNDCLOUD = "soundcloud"
     ICAL = "ical"
     CONCERT_ARCHIVES = "concert_archives"
+    GITHUB = "github"
     MANUAL = "manual"
     TEST = "test"
 

--- a/src/resonance/ui/common.py
+++ b/src/resonance/ui/common.py
@@ -141,9 +141,9 @@ def _effective_role(session: Any) -> str:
     """Return the effective role, accounting for view-as."""
     actual: str = session.get("user_role", "user")
     view_as: str | None = session.get("view_as")
-    if not view_as:
+    if not view_as or view_as not in _ROLE_HIERARCHY:
         return actual
-    if _ROLE_HIERARCHY.get(view_as, 0) < _ROLE_HIERARCHY.get(actual, 0):
+    if _ROLE_HIERARCHY[view_as] < _ROLE_HIERARCHY.get(actual, 0):
         return view_as
     return actual
 

--- a/src/resonance/ui/common.py
+++ b/src/resonance/ui/common.py
@@ -11,6 +11,9 @@ from typing import TYPE_CHECKING, Any
 import fastapi
 import fastapi.templating
 
+import resonance.connectors.registry as registry_module
+import resonance.types as types_module
+
 if TYPE_CHECKING:
     import datetime
     from collections.abc import Sequence
@@ -47,69 +50,50 @@ def _localtime(
 templates.env.filters["localtime"] = _localtime
 
 # ---------------------------------------------------------------------------
-# Service display-name filter
+# Service display metadata filters (backed by connector registry)
 # ---------------------------------------------------------------------------
 
-SERVICE_DISPLAY_NAMES: dict[str, str] = {
-    "spotify": "Spotify",
-    "lastfm": "Last.fm",
-    "listenbrainz": "ListenBrainz",
-    "songkick": "Songkick",
-    "bandsintown": "Bandsintown",
-    "bandcamp": "Bandcamp",
-    "soundcloud": "SoundCloud",
-    "ical": "iCal",
-    "concert_archives": "Concert Archives",
-    "manual": "Manual",
-    "test": "Test",
-}
+_registry: registry_module.ConnectorRegistry | None = None
+
+
+def set_connector_registry(registry: registry_module.ConnectorRegistry) -> None:
+    """Set the connector registry for template filter lookups."""
+    global _registry
+    _registry = registry
 
 
 def _service_name(value: str) -> str:
     """Return the human-friendly display name for a service type value."""
-    return SERVICE_DISPLAY_NAMES.get(value, value.replace("_", " ").title())
-
-
-templates.env.filters["service_name"] = _service_name
-
-# ---------------------------------------------------------------------------
-# Service icon filter (Lucide icon names)
-# ---------------------------------------------------------------------------
-
-SERVICE_ICONS: dict[str, str] = {
-    "spotify": "music",
-    "lastfm": "radio",
-    "listenbrainz": "headphones",
-    "songkick": "ticket",
-    "bandsintown": "map-pin",
-    "bandcamp": "disc",
-    "soundcloud": "cloud",
-    "ical": "calendar",
-    "concert_archives": "archive",
-    "manual": "pen-tool",
-    "test": "flask-conical",
-}
+    if _registry is not None:
+        try:
+            return _registry.display_name(types_module.ServiceType(value))
+        except ValueError:
+            pass
+    return value.replace("_", " ").title()
 
 
 def _service_icon(value: str) -> str:
     """Return the Lucide icon name for a service type value."""
-    return SERVICE_ICONS.get(value, "link")
-
-
-templates.env.filters["service_icon"] = _service_icon
-
-SERVICE_COLORS: dict[str, str] = {
-    "spotify": "var(--color-spotify)",
-    "lastfm": "var(--color-lastfm)",
-    "listenbrainz": "var(--color-listenbrainz)",
-}
+    if _registry is not None:
+        try:
+            return _registry.icon(types_module.ServiceType(value))
+        except ValueError:
+            pass
+    return "link"
 
 
 def _service_color(value: str) -> str:
     """Return the CSS color value for a service, or empty string if none."""
-    return SERVICE_COLORS.get(value, "")
+    if _registry is not None:
+        try:
+            return _registry.color(types_module.ServiceType(value))
+        except ValueError:
+            pass
+    return ""
 
 
+templates.env.filters["service_name"] = _service_name
+templates.env.filters["service_icon"] = _service_icon
 templates.env.filters["service_color"] = _service_color
 
 
@@ -134,6 +118,9 @@ async def require_user(request: fastapi.Request) -> uuid.UUID:
 async def require_admin(request: fastapi.Request) -> uuid.UUID:
     """Return admin/owner user_id, or redirect/forbid.
 
+    Checks effective role (view-as aware): if view_as is set in the
+    session, uses that instead of the actual role.
+
     Use as a FastAPI dependency::
 
         user_id: Annotated[uuid.UUID, Depends(require_admin)]
@@ -141,10 +128,24 @@ async def require_admin(request: fastapi.Request) -> uuid.UUID:
     user_id = request.state.session.get("user_id")
     if not user_id:
         raise fastapi.HTTPException(status_code=307, headers={"Location": "/login"})
-    user_role = request.state.session.get("user_role", "user")
-    if user_role not in ("admin", "owner"):
+    effective = _effective_role(request.state.session)
+    if effective not in ("admin", "owner"):
         raise fastapi.HTTPException(status_code=403, detail="Admin access required")
     return uuid.UUID(user_id)
+
+
+_ROLE_HIERARCHY = {"user": 0, "admin": 1, "owner": 2}
+
+
+def _effective_role(session: Any) -> str:
+    """Return the effective role, accounting for view-as."""
+    actual: str = session.get("user_role", "user")
+    view_as: str | None = session.get("view_as")
+    if not view_as:
+        return actual
+    if _ROLE_HIERARCHY.get(view_as, 0) < _ROLE_HIERARCHY.get(actual, 0):
+        return view_as
+    return actual
 
 
 # ---------------------------------------------------------------------------
@@ -155,11 +156,14 @@ async def require_admin(request: fastapi.Request) -> uuid.UUID:
 def base_context(request: fastapi.Request) -> dict[str, Any]:
     """Build common template context with auth and timezone info."""
     session = request.state.session
+    actual_role = session.get("user_role", "user")
     return {
         "request": request,
         "user_id": session.get("user_id"),
         "user_tz": session.get("user_tz"),
-        "user_role": session.get("user_role", "user"),
+        "user_role": _effective_role(session),
+        "actual_role": actual_role,
+        "viewing_as": session.get("view_as"),
     }
 
 

--- a/src/resonance/ui/dashboard.py
+++ b/src/resonance/ui/dashboard.py
@@ -87,6 +87,8 @@ async def set_view_as(
         )
 
     referer = request.headers.get("referer", "/")
+    if not referer.startswith("/"):
+        referer = "/"
     return fastapi.responses.RedirectResponse(url=referer, status_code=303)
 
 

--- a/src/resonance/ui/dashboard.py
+++ b/src/resonance/ui/dashboard.py
@@ -10,6 +10,8 @@ import fastapi.responses
 import sqlalchemy as sa
 import sqlalchemy.ext.asyncio as sa_async
 
+import resonance.connectors.base as base_module
+import resonance.connectors.registry as registry_module
 import resonance.dependencies as deps_module
 import resonance.models.music as music_models
 import resonance.models.task as task_models
@@ -19,8 +21,13 @@ import resonance.ui.common as common
 
 router = fastapi.APIRouter(tags=["ui"])
 
-# Services that support OAuth login (auto-redirect targets).
-_AUTH_SERVICES = frozenset({"spotify", "listenbrainz", "lastfm"})
+
+def _get_authn_connectors(
+    request: fastapi.Request,
+) -> list[base_module.BaseConnector]:
+    """Return all connectors with AUTHN capability, ordered for the login page."""
+    registry: registry_module.ConnectorRegistry = request.app.state.connector_registry
+    return registry.get_by_capability(base_module.ConnectorCapability.AUTHN)
 
 
 @router.get("/login", response_class=fastapi.responses.HTMLResponse)
@@ -35,19 +42,52 @@ async def login(
     ``prompt`` is not ``"select"``), redirect to that service's OAuth
     flow so expired sessions re-authenticate automatically.
     """
-    # Already logged in — skip login page entirely.
     if request.state.session.get("user_id"):
         return fastapi.responses.RedirectResponse(url="/", status_code=307)
 
-    # Auto-login unless the user explicitly asked to pick a service.
+    authn_connectors = _get_authn_connectors(request)
+    authn_services = {c.service_type.value for c in authn_connectors}
+
     if prompt != "select":
         last_service = request.cookies.get("last_auth_service")
-        if last_service and last_service in _AUTH_SERVICES:
+        if last_service and last_service in authn_services:
             return fastapi.responses.RedirectResponse(
                 url=f"/api/v1/auth/{last_service}", status_code=307
             )
 
-    return common.templates.TemplateResponse(request, "login.html")
+    return common.templates.TemplateResponse(
+        request,
+        "login.html",
+        {"request": request, "authn_connectors": authn_connectors},
+    )
+
+
+@router.post("/view-as", response_class=fastapi.responses.HTMLResponse)
+async def set_view_as(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    role: str = "",
+) -> fastapi.responses.Response:
+    """Set or clear view-as role impersonation (admin/owner only)."""
+    session = request.state.session
+    actual_role = session.get("user_role", "user")
+
+    if actual_role not in ("admin", "owner"):
+        raise fastapi.HTTPException(status_code=403)
+
+    if not role or role == "reset":
+        session.pop("view_as", None)
+    elif common._ROLE_HIERARCHY.get(role, 0) < common._ROLE_HIERARCHY.get(
+        actual_role, 0
+    ):
+        session["view_as"] = role
+    else:
+        raise fastapi.HTTPException(
+            status_code=400, detail="Can only view as a lower role"
+        )
+
+    referer = request.headers.get("referer", "/")
+    return fastapi.responses.RedirectResponse(url=referer, status_code=303)
 
 
 @router.get("/", response_model=None)

--- a/tests/test_api_artist_search.py
+++ b/tests/test_api_artist_search.py
@@ -187,7 +187,7 @@ def _make_lb_connector_mock() -> AsyncMock:
     """Create a mock ListenBrainz connector with search and lookup methods."""
     mock = AsyncMock(spec=base_module.BaseConnector)
     mock.service_type = types_module.ServiceType.LISTENBRAINZ
-    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHENTICATION})
+    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHN})
     mock.parse_url = AsyncMock(return_value=None)
     mock.search_artists = AsyncMock(return_value=[])
     mock.get_artist_by_mbid = AsyncMock(return_value=None)
@@ -198,7 +198,7 @@ def _make_spotify_connector_mock() -> AsyncMock:
     """Create a mock Spotify connector with search methods."""
     mock = AsyncMock(spec=base_module.BaseConnector)
     mock.service_type = types_module.ServiceType.SPOTIFY
-    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHENTICATION})
+    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHN})
     mock.parse_url = AsyncMock(return_value=None)
     mock.search_artists = AsyncMock(return_value=[])
     return mock

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -73,7 +73,7 @@ def _make_mock_spotify_connector() -> MagicMock:
     """Create a mock Spotify connector with auth capability."""
     connector = MagicMock(spec=spotify_module.SpotifyConnector)
     connector.service_type = types_module.ServiceType.SPOTIFY
-    connector.capabilities = frozenset({base_module.ConnectorCapability.AUTHENTICATION})
+    connector.capabilities = frozenset({base_module.ConnectorCapability.AUTHN})
     connector.has_capability = MagicMock(
         side_effect=lambda cap: cap in connector.capabilities
     )
@@ -201,7 +201,7 @@ class TestAuthInitiate:
         assert response.status_code == 404
 
     async def test_service_without_auth_capability_returns_400(self) -> None:
-        """A connector without AUTHENTICATION capability should return 400."""
+        """A connector without AUTHN capability should return 400."""
         connector = MagicMock(spec=base_module.BaseConnector)
         connector.service_type = types_module.ServiceType.LASTFM
         connector.capabilities = frozenset(

--- a/tests/test_artist_enrichment.py
+++ b/tests/test_artist_enrichment.py
@@ -184,7 +184,7 @@ def _make_lb_connector_mock() -> AsyncMock:
     """Create a mock ListenBrainz connector with get_artist_by_mbid."""
     mock = AsyncMock(spec=base_module.BaseConnector)
     mock.service_type = types_module.ServiceType.LISTENBRAINZ
-    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHENTICATION})
+    mock.capabilities = frozenset({base_module.ConnectorCapability.AUTHN})
     mock.parse_url = AsyncMock(return_value=None)
     mock.search_artists = AsyncMock(return_value=[])
     mock.get_artist_by_mbid = AsyncMock(return_value=None)

--- a/tests/test_connector_display.py
+++ b/tests/test_connector_display.py
@@ -1,0 +1,116 @@
+"""Tests for connector display metadata and dynamic login page."""
+
+from __future__ import annotations
+
+import resonance.connectors.concert_archives as concert_archives_module
+import resonance.connectors.ical as ical_module
+import resonance.connectors.registry as registry_module
+import resonance.connectors.songkick as songkick_module
+import resonance.connectors.test as test_module
+import resonance.types as types_module
+import resonance.ui.common as common
+
+
+class TestConnectorDisplayMetadata:
+    def test_spotify_display_name(self) -> None:
+        from resonance.connectors import spotify as spotify_module
+
+        assert spotify_module.SpotifyConnector.display_name == "Spotify"
+
+    def test_lastfm_display_name(self) -> None:
+        from resonance.connectors import lastfm as lastfm_module
+
+        assert lastfm_module.LastFmConnector.display_name == "Last.fm"
+
+    def test_listenbrainz_display_name(self) -> None:
+        from resonance.connectors import listenbrainz as lb_module
+
+        assert lb_module.ListenBrainzConnector.display_name == "ListenBrainz"
+
+    def test_songkick_display_name(self) -> None:
+        assert songkick_module.SongkickConnector.display_name == "Songkick"
+
+    def test_ical_display_name(self) -> None:
+        assert ical_module.ICalConnector.display_name == "iCal"
+
+    def test_concert_archives_display_name(self) -> None:
+        c = concert_archives_module.ConcertArchivesConnector
+        assert c.display_name == "Concert Archives"
+
+    def test_test_connector_display_name(self) -> None:
+        assert test_module.TestConnector.display_name == "Test"
+
+    def test_spotify_icon(self) -> None:
+        from resonance.connectors import spotify as spotify_module
+
+        assert spotify_module.SpotifyConnector.icon == "music"
+
+    def test_spotify_color(self) -> None:
+        from resonance.connectors import spotify as spotify_module
+
+        assert spotify_module.SpotifyConnector.color == "var(--color-spotify)"
+
+    def test_songkick_color_empty(self) -> None:
+        assert songkick_module.SongkickConnector.color == ""
+
+
+class TestRegistryDisplayMethods:
+    def _make_registry(self) -> registry_module.ConnectorRegistry:
+        registry = registry_module.ConnectorRegistry()
+        registry.register(songkick_module.SongkickConnector())
+        registry.register(ical_module.ICalConnector())
+        registry.register(test_module.TestConnector())
+        return registry
+
+    def test_display_name_from_registry(self) -> None:
+        registry = self._make_registry()
+        assert registry.display_name(types_module.ServiceType.SONGKICK) == "Songkick"
+
+    def test_icon_from_registry(self) -> None:
+        registry = self._make_registry()
+        assert registry.icon(types_module.ServiceType.SONGKICK) == "ticket"
+
+    def test_color_from_registry(self) -> None:
+        registry = self._make_registry()
+        assert registry.color(types_module.ServiceType.SONGKICK) == ""
+
+    def test_unregistered_service_fallback_name(self) -> None:
+        registry = self._make_registry()
+        name = registry.display_name(types_module.ServiceType.BANDCAMP)
+        assert name == "Bandcamp"
+
+    def test_unregistered_service_fallback_icon(self) -> None:
+        registry = self._make_registry()
+        assert registry.icon(types_module.ServiceType.BANDCAMP) == "link"
+
+
+class TestTemplateFiltersWithRegistry:
+    def test_service_name_filter_uses_registry(self) -> None:
+        registry = registry_module.ConnectorRegistry()
+        registry.register(songkick_module.SongkickConnector())
+        common.set_connector_registry(registry)
+
+        assert common._service_name("songkick") == "Songkick"
+
+    def test_service_name_filter_fallback(self) -> None:
+        common.set_connector_registry(registry_module.ConnectorRegistry())
+        assert common._service_name("bandcamp") == "Bandcamp"
+
+    def test_service_icon_filter_uses_registry(self) -> None:
+        registry = registry_module.ConnectorRegistry()
+        registry.register(songkick_module.SongkickConnector())
+        common.set_connector_registry(registry)
+
+        assert common._service_icon("songkick") == "ticket"
+
+    def test_service_color_filter_uses_registry(self) -> None:
+        from resonance.connectors import spotify as spotify_module
+
+        settings = __import__("resonance.config", fromlist=["Settings"]).Settings(
+            spotify_client_id="x", spotify_client_secret="x"
+        )
+        registry = registry_module.ConnectorRegistry()
+        registry.register(spotify_module.SpotifyConnector(settings=settings))
+        common.set_connector_registry(registry)
+
+        assert common._service_color("spotify") == "var(--color-spotify)"

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -46,7 +46,7 @@ class TestConnectorCapability:
         assert base_module.ConnectorCapability.LISTENING_HISTORY == "listening_history"
 
     def test_authentication_value(self) -> None:
-        assert base_module.ConnectorCapability.AUTHENTICATION == "authentication"
+        assert base_module.ConnectorCapability.AUTHN == "authn"
 
     def test_all_capabilities_are_strings(self) -> None:
         for cap in base_module.ConnectorCapability:

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -1,0 +1,218 @@
+"""Tests for the GitHub/Dex OIDC connector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import resonance.config as config_module
+import resonance.connectors.base as base_module
+import resonance.connectors.github as github_module
+import resonance.types as types_module
+
+
+def _make_settings() -> config_module.Settings:
+    return config_module.Settings(
+        dex_client_id="test-dex-client",
+        dex_client_secret="test-dex-secret",
+        dex_issuer_url="https://auth.megadoomer.io",
+        base_url="https://resonance.megadoomer.io",
+    )
+
+
+def _make_connector() -> github_module.GitHubConnector:
+    return github_module.GitHubConnector(settings=_make_settings())
+
+
+class TestGitHubConnectorMetadata:
+    def test_service_type(self) -> None:
+        c = _make_connector()
+        assert c.service_type == types_module.ServiceType.GITHUB
+
+    def test_display_name(self) -> None:
+        c = _make_connector()
+        assert c.display_name == "GitHub"
+
+    def test_capabilities(self) -> None:
+        c = _make_connector()
+        assert c.has_capability(base_module.ConnectorCapability.AUTHN)
+        assert c.has_capability(base_module.ConnectorCapability.AUTHZ)
+        assert not c.has_capability(base_module.ConnectorCapability.LISTENING_HISTORY)
+
+    def test_connection_config_is_oauth_no_sync(self) -> None:
+        config = github_module.GitHubConnector.connection_config()
+        assert config.auth_type == "oauth"
+        assert config.sync_function is None
+        assert config.sync_style is None
+
+
+class TestGetAuthUrl:
+    def test_builds_dex_authorize_url(self) -> None:
+        c = _make_connector()
+        url = c.get_auth_url(state="test-state-123")
+        assert url.startswith("https://auth.megadoomer.io/auth?")
+        assert "client_id=test-dex-client" in url
+        assert "state=test-state-123" in url
+        assert "scope=openid+profile+email+groups" in url
+        assert "response_type=code" in url
+
+    def test_redirect_uri_in_auth_url(self) -> None:
+        c = _make_connector()
+        url = c.get_auth_url(state="s")
+        assert "redirect_uri=" in url
+        assert "resonance.megadoomer.io" in url
+
+
+class TestExchangeCode:
+    @pytest.mark.anyio
+    async def test_exchange_posts_to_dex_token_endpoint(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "dex-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+
+        with patch.object(c, "_request", return_value=mock_response) as req:
+            result = await c.exchange_code("auth-code-123")
+            req.assert_called_once()
+            call_args = req.call_args
+            assert call_args[0][0] == "POST"
+            assert "/token" in call_args[0][1]
+
+        assert result.access_token == "dex-access-token"
+        assert result.expires_in == 3600
+
+
+class TestGetCurrentUser:
+    @pytest.mark.anyio
+    async def test_returns_sub_and_name(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "sub": "dex-user-abc",
+            "name": "Mike D",
+            "preferred_username": "miked",
+            "email": "mike@example.com",
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            result = await c.get_current_user("access-token")
+
+        assert result["id"] == "dex-user-abc"
+        assert result["display_name"] == "Mike D"
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_preferred_username(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "sub": "dex-user-abc",
+            "preferred_username": "miked",
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            result = await c.get_current_user("access-token")
+
+        assert result["display_name"] == "miked"
+
+
+class TestGetRole:
+    @pytest.mark.anyio
+    async def test_admins_team_returns_admin(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "groups": ["megadoomer-io:admins", "megadoomer-io:other-team"],
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.ADMIN
+
+    @pytest.mark.anyio
+    async def test_resonance_admins_team_returns_admin(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "groups": ["megadoomer-io:resonance-admins"],
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.ADMIN
+
+    @pytest.mark.anyio
+    async def test_no_admin_team_returns_user(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "groups": ["megadoomer-io:some-other-team"],
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.USER
+
+    @pytest.mark.anyio
+    async def test_empty_groups_returns_user(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"groups": []}
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.USER
+
+    @pytest.mark.anyio
+    async def test_missing_groups_returns_user(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.USER
+
+    @pytest.mark.anyio
+    async def test_non_list_groups_returns_user(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"groups": "not-a-list"}
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.USER
+
+    @pytest.mark.anyio
+    async def test_request_failure_returns_none(self) -> None:
+        c = _make_connector()
+        with patch.object(c, "_request", side_effect=httpx.ConnectError("down")):
+            role = await c.get_role("access-token")
+
+        assert role is None
+
+    @pytest.mark.anyio
+    async def test_both_admin_teams_still_returns_admin(self) -> None:
+        c = _make_connector()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "groups": [
+                "megadoomer-io:admins",
+                "megadoomer-io:resonance-admins",
+            ],
+        }
+
+        with patch.object(c, "_request", return_value=mock_response):
+            role = await c.get_role("access-token")
+
+        assert role == types_module.UserRole.ADMIN

--- a/tests/test_lastfm_connector.py
+++ b/tests/test_lastfm_connector.py
@@ -45,7 +45,7 @@ class TestLastFmConnectorProperties:
         connector = _make_connector()
         expected = frozenset(
             {
-                base_module.ConnectorCapability.AUTHENTICATION,
+                base_module.ConnectorCapability.AUTHN,
                 base_module.ConnectorCapability.LISTENING_HISTORY,
                 base_module.ConnectorCapability.TRACK_RATINGS,
             }

--- a/tests/test_listenbrainz_connector.py
+++ b/tests/test_listenbrainz_connector.py
@@ -32,7 +32,7 @@ class TestListenBrainzConnectorProperties:
         connector = listenbrainz_module.ListenBrainzConnector(settings=_make_settings())
         expected = frozenset(
             {
-                base_module.ConnectorCapability.AUTHENTICATION,
+                base_module.ConnectorCapability.AUTHN,
                 base_module.ConnectorCapability.LISTENING_HISTORY,
                 base_module.ConnectorCapability.TRACK_DISCOVERY,
             }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,7 +39,7 @@ class TestServiceType:
         assert types_module.ServiceType.TEST == "test"
 
     def test_service_type_count(self) -> None:
-        assert len(types_module.ServiceType) == 11
+        assert len(types_module.ServiceType) == 12
 
 
 class TestArtistRelationType:

--- a/tests/test_spotify_connector.py
+++ b/tests/test_spotify_connector.py
@@ -32,7 +32,7 @@ class TestSpotifyConnectorProperties:
         connector = spotify_module.SpotifyConnector(settings=_make_settings())
         expected = frozenset(
             {
-                base_module.ConnectorCapability.AUTHENTICATION,
+                base_module.ConnectorCapability.AUTHN,
                 base_module.ConnectorCapability.LISTENING_HISTORY,
                 base_module.ConnectorCapability.FOLLOWS,
                 base_module.ConnectorCapability.TRACK_RATINGS,

--- a/tests/test_test_connector.py
+++ b/tests/test_test_connector.py
@@ -35,6 +35,4 @@ class TestTestConnector:
 
     def test_has_capability_authentication_false(self) -> None:
         connector = test_module.TestConnector()
-        assert not connector.has_capability(
-            base_module.ConnectorCapability.AUTHENTICATION
-        )
+        assert not connector.has_capability(base_module.ConnectorCapability.AUTHN)

--- a/tests/test_view_as.py
+++ b/tests/test_view_as.py
@@ -1,0 +1,108 @@
+"""Tests for view-as role impersonation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import fastapi
+import pytest
+
+import resonance.ui.common as common
+
+
+class FakeSession(dict[str, Any]):
+    """Dict-like session with pop support."""
+
+    pass
+
+
+_TEST_USER_ID = "12345678-1234-5678-1234-567812345678"
+
+
+def _make_request(
+    user_role: str = "admin",
+    view_as: str | None = None,
+    user_id: str = _TEST_USER_ID,
+) -> fastapi.Request:
+    """Create a fake request with session data."""
+    request = MagicMock(spec=fastapi.Request)
+    session = FakeSession(user_id=user_id, user_role=user_role)
+    if view_as:
+        session["view_as"] = view_as
+    request.state.session = session
+    return request
+
+
+class TestEffectiveRole:
+    def test_no_view_as_returns_actual(self) -> None:
+        session = FakeSession(user_role="admin")
+        assert common._effective_role(session) == "admin"
+
+    def test_view_as_lower_role(self) -> None:
+        session = FakeSession(user_role="admin", view_as="user")
+        assert common._effective_role(session) == "user"
+
+    def test_view_as_same_role_ignored(self) -> None:
+        session = FakeSession(user_role="admin", view_as="admin")
+        assert common._effective_role(session) == "admin"
+
+    def test_view_as_higher_role_ignored(self) -> None:
+        session = FakeSession(user_role="user", view_as="admin")
+        assert common._effective_role(session) == "user"
+
+    def test_owner_view_as_admin(self) -> None:
+        session = FakeSession(user_role="owner", view_as="admin")
+        assert common._effective_role(session) == "admin"
+
+    def test_owner_view_as_user(self) -> None:
+        session = FakeSession(user_role="owner", view_as="user")
+        assert common._effective_role(session) == "user"
+
+    def test_empty_view_as_returns_actual(self) -> None:
+        session = FakeSession(user_role="admin", view_as="")
+        assert common._effective_role(session) == "admin"
+
+
+class TestRequireAdminViewAs:
+    @pytest.mark.anyio
+    async def test_admin_without_view_as_passes(self) -> None:
+        request = _make_request(user_role="admin")
+        result = await common.require_admin(request)
+        assert str(result) == _TEST_USER_ID
+
+    @pytest.mark.anyio
+    async def test_admin_viewing_as_user_is_forbidden(self) -> None:
+        request = _make_request(user_role="admin", view_as="user")
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await common.require_admin(request)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_owner_viewing_as_admin_passes(self) -> None:
+        request = _make_request(user_role="owner", view_as="admin")
+        result = await common.require_admin(request)
+        assert str(result) == _TEST_USER_ID
+
+    @pytest.mark.anyio
+    async def test_owner_viewing_as_user_is_forbidden(self) -> None:
+        request = _make_request(user_role="owner", view_as="user")
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await common.require_admin(request)
+        assert exc_info.value.status_code == 403
+
+
+class TestBaseContextViewAs:
+    def test_includes_effective_and_actual_role(self) -> None:
+        request = _make_request(user_role="admin", view_as="user")
+        ctx = common.base_context(request)
+        assert ctx["user_role"] == "user"
+        assert ctx["actual_role"] == "admin"
+        assert ctx["viewing_as"] == "user"
+
+    def test_no_view_as_roles_match(self) -> None:
+        request = _make_request(user_role="admin")
+        ctx = common.base_context(request)
+        assert ctx["user_role"] == "admin"
+        assert ctx["actual_role"] == "admin"
+        assert ctx["viewing_as"] is None


### PR DESCRIPTION
## Summary

Integrates GitHub authentication via Dex OIDC as a new identity connector, establishing the auth contract for the megadoomer-io ecosystem. Users can log in with GitHub, roles are assigned automatically from team membership, and admins get a view-as pill for role impersonation.

<details>
<summary>How to Review</summary>

This PR is organized into 3 commits:

1. **Core feature** (236d9fd) — All source changes: connector framework AUTHN/AUTHZ split, GitHubConnector, auth callback role mapping + session invalidation, display metadata refactor, dynamic login page, view-as, sync guard, Dex config. Review the connector at `src/resonance/connectors/github.py` first, then trace through `api/v1/auth.py` for the callback changes.

2. **Migration** (e135600) — Alembic migration adding GITHUB to ServiceType CHECK constraints across all tables. Standard pattern matching previous ServiceType additions.

3. **Tests + docs** (7273855) — 49 new tests across 3 files (GitHubConnector, view-as, display metadata), existing test updates for the AUTHN rename, and TODOS.md with deferred work items.

**Suggested approach:** Start with `connectors/github.py` to understand the new connector, then `api/v1/auth.py` for the AUTHZ role mapping flow, then `ui/common.py` + `ui/dashboard.py` for view-as and dynamic login.
</details>

<details>
<summary>Test Plan</summary>

- [x] All 1221 tests pass (1172 existing + 49 new)
- [x] mypy strict mode passes (86 source files)
- [x] ruff lint + format clean
- [x] Pre-commit hooks pass on all commits
- [ ] Manual: Dex client registration in megadoomer-config (in progress separately)
- [ ] Post-implementation reviews: security, design, devex, QA (planned)
</details>

<details>
<summary>Impact</summary>

**New capabilities:**
- GitHub login via Dex OIDC (when `DEX_CLIENT_ID` is configured)
- Automatic role assignment from GitHub team membership
- View-as role impersonation for admins/owners
- Dynamic login page built from AUTHN-capable connectors

**Breaking changes:**
- `ConnectorCapability.AUTHENTICATION` renamed to `ConnectorCapability.AUTHN`
- `ConnectionConfig.sync_function` and `sync_style` are now `str | None` (previously `str`)
- Display metadata dicts removed from `common.py` (now on connector classes)

**Migration required:**
- Alembic migration adds GITHUB to ServiceType CHECK constraints
- Runs automatically via init container on deploy

**Config required:**
- `DEX_CLIENT_ID`, `DEX_CLIENT_SECRET`, `DEX_ISSUER_URL` env vars
- Dex static client registration in megadoomer-config
- GitHub connector only registers when `DEX_CLIENT_ID` is set
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)