### PR TITLE
feat: adjacent-artist candidate generation (makes similar_artist_ratio functional)

### DIFF
--- a/src/resonance/connectors/base.py
+++ b/src/resonance/connectors/base.py
@@ -56,6 +56,7 @@ class ConnectorCapability(enum.StrEnum):
     TRACK_RATINGS = "track_ratings"
     NEW_RELEASES = "new_releases"
     TRACK_DISCOVERY = "track_discovery"
+    SIMILAR_ARTISTS = "similar_artists"
 
 
 class TokenResponse(pydantic.BaseModel):

--- a/src/resonance/connectors/lastfm.py
+++ b/src/resonance/connectors/lastfm.py
@@ -39,6 +39,7 @@ class LastFmConnector(base_module.BaseConnector):
             base_module.ConnectorCapability.AUTHN,
             base_module.ConnectorCapability.LISTENING_HISTORY,
             base_module.ConnectorCapability.TRACK_RATINGS,
+            base_module.ConnectorCapability.SIMILAR_ARTISTS,
         }
     )
 
@@ -291,3 +292,57 @@ class LastFmConnector(base_module.BaseConnector):
             "limit": limit,
         }
         return await self._api_call("user.getLovedTracks", params=params)
+
+    async def get_similar_artists(
+        self,
+        artist_name: str,
+        *,
+        mbid: str | None = None,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Fetch artists similar to the given artist via ``artist.getSimilar``.
+
+        Uses API-key auth (no user session required). Prefers an ``mbid``
+        lookup when provided, otherwise searches by name with autocorrect.
+
+        Args:
+            artist_name: The artist name to find neighbors for.
+            mbid: Optional MusicBrainz ID for an exact lookup.
+            limit: Maximum number of similar artists to return.
+
+        Returns:
+            A list of ``{"name", "mbid", "match"}`` dicts ordered by match
+            score (descending, as returned by Last.fm). Returns an empty
+            list if the artist is unknown to Last.fm.
+        """
+        params: dict[str, Any] = {"limit": limit, "autocorrect": 1}
+        if mbid:
+            params["mbid"] = mbid
+        else:
+            params["artist"] = artist_name
+
+        try:
+            data = await self._api_call("artist.getSimilar", params=params)
+        except LastFmApiError:
+            # Unknown artist (error 6) or similar — no neighbors to return.
+            return []
+
+        raw = data.get("similarartists", {}).get("artist", [])
+        results: list[dict[str, Any]] = []
+        for item in raw:
+            name = item.get("name")
+            if not name:
+                continue
+            match_raw = item.get("match")
+            try:
+                match = float(match_raw) if match_raw is not None else 0.0
+            except TypeError, ValueError:
+                match = 0.0
+            results.append(
+                {
+                    "name": name,
+                    "mbid": item.get("mbid") or None,
+                    "match": match,
+                }
+            )
+        return results

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -861,6 +861,59 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
             await _check_parent_completion(session, task, arq_redis, log)
 
 
+async def _resolve_similar_library_artists(
+    session: sa_async.AsyncSession,
+    connector: Any,
+    target_artists: collections.abc.Sequence[music_models.Artist],
+    exclude_ids: set[uuid.UUID],
+    *,
+    per_artist_limit: int = 30,
+) -> set[uuid.UUID]:
+    """Resolve library artists similar to the targets (issue #103, Mode 1).
+
+    For each target artist, ask the connector for similar artists, then match
+    those names against artists already in the library. Returns the matching
+    local artist IDs, excluding ``exclude_ids`` (the target set). Similar
+    artists not already in the library are ignored — importing their tracks is
+    out of scope (that is track discovery, a separate feature).
+
+    Args:
+        session: Async DB session.
+        connector: A connector exposing ``get_similar_artists``.
+        target_artists: The event's target (lineup) artists.
+        exclude_ids: Artist IDs to exclude from the result (the target set).
+        per_artist_limit: Max similar artists to request per target artist.
+
+    Returns:
+        Set of local artist IDs that are similar to the target artists.
+    """
+    similar_names: set[str] = set()
+    for artist in target_artists:
+        mbid: str | None = None
+        links = artist.service_links or {}
+        mb = links.get("musicbrainz")
+        if isinstance(mb, dict):
+            raw_id = mb.get("id")
+            mbid = str(raw_id) if raw_id else None
+        neighbors = await connector.get_similar_artists(
+            artist.name, mbid=mbid, limit=per_artist_limit
+        )
+        for neighbor in neighbors:
+            name = neighbor.get("name")
+            if name:
+                similar_names.add(name.lower())
+
+    if not similar_names:
+        return set()
+
+    result = await session.execute(
+        sa.select(music_models.Artist.id).where(
+            sa.func.lower(music_models.Artist.name).in_(similar_names)
+        )
+    )
+    return {row[0] for row in result.all()} - exclude_ids
+
+
 async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
     """Score tracks and build the final playlist.
 
@@ -946,10 +999,41 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 if cand.matched_artist_id is not None:
                     artist_ids.add(cand.matched_artist_id)
 
-            # Query all tracks by these artists
+            # Apply parameter defaults early — adjacent-artist expansion below
+            # is gated on similar_artist_ratio.
+            params = params_module.apply_defaults(dict(profile.parameter_values))
+
+            # Expand the candidate pool with adjacent (similar) artists that are
+            # already in the library when similar_artist_ratio > 0 (issue #103).
+            # Their tracks enter as is_target_artist=False candidates, which the
+            # scoring engine scales by similar_artist_ratio.
+            query_artist_ids: set[uuid.UUID] = set(artist_ids)
+            if params.get("similar_artist_ratio", 0) > 0:
+                similar_connectors = wctx["connector_registry"].get_by_capability(
+                    base_module.ConnectorCapability.SIMILAR_ARTISTS
+                )
+                if similar_connectors:
+                    target_artists_result = await session.execute(
+                        sa.select(music_models.Artist).where(
+                            music_models.Artist.id.in_(artist_ids)
+                        )
+                    )
+                    adjacent_ids = await _resolve_similar_library_artists(
+                        session,
+                        similar_connectors[0],
+                        list(target_artists_result.scalars().all()),
+                        artist_ids,
+                    )
+                    query_artist_ids |= adjacent_ids
+                    log.info(
+                        "similar_artists_resolved",
+                        adjacent_count=len(adjacent_ids),
+                    )
+
+            # Query all tracks by these artists (target + any adjacent)
             tracks_result = await session.execute(
                 sa.select(music_models.Track)
-                .where(music_models.Track.artist_id.in_(artist_ids))
+                .where(music_models.Track.artist_id.in_(query_artist_ids))
                 .options(sa_orm.joinedload(music_models.Track.artist))
             )
             all_tracks = tracks_result.scalars().all()
@@ -1029,9 +1113,6 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                         ),
                     )
                 )
-
-            # Apply parameter defaults
-            params = params_module.apply_defaults(dict(profile.parameter_values))
 
             # max_tracks and freshness_target are generation-time options
             # stored on the parent PLAYLIST_GENERATION task, not the profile

--- a/tests/test_lastfm_connector.py
+++ b/tests/test_lastfm_connector.py
@@ -48,6 +48,7 @@ class TestLastFmConnectorProperties:
                 base_module.ConnectorCapability.AUTHN,
                 base_module.ConnectorCapability.LISTENING_HISTORY,
                 base_module.ConnectorCapability.TRACK_RATINGS,
+                base_module.ConnectorCapability.SIMILAR_ARTISTS,
             }
         )
         assert connector.capabilities == expected
@@ -294,3 +295,83 @@ class TestApiCallErrorHandling:
 
         with pytest.raises(lastfm_module.LastFmApiError, match="Invalid API key"):
             await connector._api_call("user.getInfo")
+
+
+class TestGetSimilarArtists:
+    """Tests for get_similar_artists (artist.getSimilar)."""
+
+    @pytest.mark.anyio()
+    async def test_parses_results(self) -> None:
+        api_response = {
+            "similarartists": {
+                "artist": [
+                    {"name": "Elder", "mbid": "mbid-elder", "match": "1.0"},
+                    {"name": "Pallbearer", "mbid": "mbid-pb", "match": "0.42"},
+                ],
+                "@attr": {"artist": "King Buffalo"},
+            }
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params["method"] == "artist.getSimilar"
+            assert request.url.params["artist"] == "King Buffalo"
+            return httpx.Response(200, json=api_response)
+
+        connector = _make_connector(httpx.MockTransport(handler))
+        results = await connector.get_similar_artists("King Buffalo")
+
+        assert results == [
+            {"name": "Elder", "mbid": "mbid-elder", "match": 1.0},
+            {"name": "Pallbearer", "mbid": "mbid-pb", "match": 0.42},
+        ]
+
+    @pytest.mark.anyio()
+    async def test_prefers_mbid_lookup(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params["mbid"] == "mbid-kb"
+            assert "artist" not in request.url.params
+            return httpx.Response(200, json={"similarartists": {"artist": []}})
+
+        connector = _make_connector(httpx.MockTransport(handler))
+        results = await connector.get_similar_artists("King Buffalo", mbid="mbid-kb")
+
+        assert results == []
+
+    @pytest.mark.anyio()
+    async def test_unknown_artist_returns_empty(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "error": 6,
+                    "message": "The artist you supplied could not be found",
+                },
+            )
+
+        connector = _make_connector(httpx.MockTransport(handler))
+        results = await connector.get_similar_artists("Nonexistent Band Xyz")
+
+        assert results == []
+
+    @pytest.mark.anyio()
+    async def test_handles_missing_or_invalid_match(self) -> None:
+        api_response = {
+            "similarartists": {
+                "artist": [
+                    {"name": "NoMatch"},
+                    {"name": "BadMatch", "match": "not-a-number"},
+                    {"mbid": "no-name-skip", "match": "0.9"},
+                ]
+            }
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=api_response)
+
+        connector = _make_connector(httpx.MockTransport(handler))
+        results = await connector.get_similar_artists("Whoever")
+
+        assert results == [
+            {"name": "NoMatch", "mbid": None, "match": 0.0},
+            {"name": "BadMatch", "mbid": None, "match": 0.0},
+        ]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2869,3 +2869,57 @@ class TestExportPlaylist:
             types_module.TaskType.PLAYLIST_EXPORT
         ]
         assert job_name == "export_playlist"
+
+
+class TestResolveSimilarLibraryArtists:
+    """Tests for _resolve_similar_library_artists (issue #103, Mode 1)."""
+
+    @pytest.mark.anyio()
+    async def test_matches_library_artists_excluding_targets(self) -> None:
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = {"musicbrainz": {"id": "mbid-kb"}}
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = [
+            {"name": "Elder", "mbid": None, "match": 0.9},
+            {"name": "Pallbearer", "mbid": None, "match": 0.5},
+        ]
+
+        elder_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+        # The library query returns a similar artist and a target artist;
+        # the target must be filtered out via exclude_ids.
+        result = MagicMock()
+        result.all.return_value = [(elder_id,), (target_id,)]
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        matched = await worker_module._resolve_similar_library_artists(
+            session, connector, [target], {target_id}
+        )
+
+        assert matched == {elder_id}
+        connector.get_similar_artists.assert_awaited_once_with(
+            "King Buffalo", mbid="mbid-kb", limit=30
+        )
+
+    @pytest.mark.anyio()
+    async def test_no_similar_names_skips_query(self) -> None:
+        target = MagicMock()
+        target.name = "Obscure Band"
+        target.service_links = None
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = []
+        session = AsyncMock()
+
+        matched = await worker_module._resolve_similar_library_artists(
+            session, connector, [target], set()
+        )
+
+        assert matched == set()
+        session.execute.assert_not_called()
+        connector.get_similar_artists.assert_awaited_once_with(
+            "Obscure Band", mbid=None, limit=30
+        )


### PR DESCRIPTION
## Summary

`similar_artist_ratio` was wired into scoring (#102) but had no effect: the concert_prep candidate pool was filtered to exactly the lineup artists, so `is_target_artist` was always `True` and the ratio had nothing to scale (a live 0-vs-100 A/B produced identical playlists).

This makes the parameter functional. When `similar_artist_ratio > 0`, the candidate pool is expanded with artists *similar to the lineup that are already in the library*. Their tracks enter as `is_target_artist=False` candidates, which the scoring engine scales by the ratio: `0` excludes them, `100` includes at full weight.

Similar artists are sourced from Last.fm `artist.getSimilar`. Closes #103.

<details>
<summary>How to Review</summary>

Two commits:

1. **`c562ca5` — SIMILAR_ARTISTS capability + Last.fm getSimilar.** New `ConnectorCapability.SIMILAR_ARTISTS`; `LastFmConnector.get_similar_artists()` (API-key auth, prefers MBID, returns `name/mbid/match`, empty list for unknown artists). Review `connectors/base.py`, `connectors/lastfm.py`, and the connector tests.
2. **`51a4200` — worker wiring.** `_resolve_similar_library_artists()` resolves lineup-similar artists to local rows; `score_and_build_playlist` expands the tracks query when ratio > 0 and keeps `is_target_artist` against the target set. Review `worker.py` and the two helper tests.

</details>

<details>
<summary>Test Plan</summary>

- [x] `uv run pytest` — 1268 passed (6 new: 4 connector, 2 worker helper)
- [x] `uv run mypy src/` — clean (86 files)
- [x] `uv run ruff check` / `format --check` — clean
- [x] pre-commit hooks passed
- [ ] Live 0-vs-100 A/B after deploy (will run post-merge)

</details>

<details>
<summary>Impact & scope</summary>

- **Behavior:** `similar_artist_ratio` now affects output when > 0. Default is `0`, so default generation is unchanged. Only fires when a profile sets the param (no generator UI surfaces it yet).
- **Mode 1 (library-only):** only similar artists already in your library contribute tracks. Importing tracks for similar artists you don't own (track discovery / "Mode 2") is deliberately out of scope.
- **Cost:** one Last.fm `getSimilar` call per lineup artist, only when ratio > 0.

Follow-ups (not in this PR):
- UI control for `similar_artist_ratio` (add to a generator type's `featured_parameters` + slider) — was always gated on this.
- Mode 2: discover/import tracks for non-library similar artists.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)