### PR TITLE
fix: retry transient Spotify 403s on playlist export

### DIFF
--- a/src/resonance/connectors/base.py
+++ b/src/resonance/connectors/base.py
@@ -190,6 +190,7 @@ class BaseConnector(abc.ABC):
     _MAX_TRANSIENT_RETRIES = 5
     _TRANSIENT_BACKOFF_BASE = 2.0  # seconds — doubles each retry
     _MAX_RATE_LIMIT_WAIT = 120.0  # seconds — fail instead of sleeping longer
+    _MAX_FORBIDDEN_RETRIES = 3  # Spotify dev mode returns transient 403s
 
     async def _request(
         self,
@@ -198,20 +199,27 @@ class BaseConnector(abc.ABC):
         *,
         high_priority: bool = False,
         max_retries: int | None = None,
+        retry_forbidden: bool = False,
         **kwargs: Any,
     ) -> httpx.Response:
         """Make an HTTP request with rate limit pacing and automatic retry.
 
-        Handles two retry scenarios:
+        Handles three retry scenarios:
         - **429 rate limits**: Respects Retry-After headers, retries
           indefinitely until the request succeeds.
         - **Transient errors** (timeouts, disconnects, connection errors):
           Retries with exponential backoff up to _MAX_TRANSIENT_RETRIES.
+        - **Transient 403s** (opt-in via ``retry_forbidden``): Spotify dev mode
+          intermittently returns 403 on writes that succeed on retry. Retries
+          with backoff up to _MAX_FORBIDDEN_RETRIES; a genuine permission error
+          still fails once retries are exhausted.
 
         Args:
             method: HTTP method (GET, POST, etc.).
             url: Request URL.
             high_priority: If True, skip pacing when budget is available.
+            max_retries: Override the transient-retry cap for this request.
+            retry_forbidden: If True, retry transient 403 responses with backoff.
             **kwargs: Additional arguments passed to httpx request.
 
         Returns:
@@ -227,6 +235,7 @@ class BaseConnector(abc.ABC):
             max_retries if max_retries is not None else self._MAX_TRANSIENT_RETRIES
         )
         transient_attempt = 0
+        forbidden_attempt = 0  # never reset mid-loop; bounds total 403 retries
 
         while True:
             interval = self._budget.paced_interval(high_priority=high_priority)
@@ -313,6 +322,28 @@ class BaseConnector(abc.ABC):
                     status_code=response.status_code,
                     attempt=transient_attempt,
                     max_attempts=effective_max_retries,
+                    backoff_seconds=round(backoff, 1),
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            if response.status_code == 403 and retry_forbidden:
+                forbidden_attempt += 1
+                if forbidden_attempt > self._MAX_FORBIDDEN_RETRIES:
+                    logger.error(
+                        "forbidden_retries_exhausted",
+                        method=method,
+                        url=url,
+                        attempts=forbidden_attempt,
+                    )
+                    response.raise_for_status()
+                backoff = self._TRANSIENT_BACKOFF_BASE**forbidden_attempt
+                logger.warning(
+                    "forbidden_retry",
+                    method=method,
+                    url=url,
+                    attempt=forbidden_attempt,
+                    max_attempts=self._MAX_FORBIDDEN_RETRIES,
                     backoff_seconds=round(backoff, 1),
                 )
                 await asyncio.sleep(backoff)

--- a/src/resonance/connectors/spotify.py
+++ b/src/resonance/connectors/spotify.py
@@ -304,6 +304,7 @@ class SpotifyConnector(base_module.BaseConnector):
             "POST",
             f"{SPOTIFY_API_BASE}/me/playlists",
             headers={"Authorization": f"Bearer {access_token}"},
+            retry_forbidden=True,
             json={
                 "name": name,
                 "description": description,
@@ -328,6 +329,7 @@ class SpotifyConnector(base_module.BaseConnector):
                 "POST",
                 f"{SPOTIFY_API_BASE}/playlists/{playlist_id}/items",
                 headers=headers,
+                retry_forbidden=True,
                 json={"uris": batch},
             )
         logger.info("spotify_tracks_added", playlist_id=playlist_id, count=len(uris))
@@ -343,6 +345,7 @@ class SpotifyConnector(base_module.BaseConnector):
             "PUT",
             f"{SPOTIFY_API_BASE}/playlists/{playlist_id}/items",
             headers={"Authorization": f"Bearer {access_token}"},
+            retry_forbidden=True,
             json={"uris": uris},
         )
         logger.info("spotify_tracks_replaced", playlist_id=playlist_id, count=len(uris))

--- a/tests/test_spotify_connector.py
+++ b/tests/test_spotify_connector.py
@@ -1,6 +1,7 @@
 """Tests for the Spotify connector."""
 
 import urllib.parse
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -601,3 +602,66 @@ class TestSavedTrackPage:
         assert page.items == []
         assert page.total == 0
         assert page.next_url is None
+
+
+class TestForbiddenRetry:
+    """Tests for transient 403 retry on Spotify write operations."""
+
+    @staticmethod
+    def _connector(handler: httpx.MockTransport) -> spotify_module.SpotifyConnector:
+        connector = spotify_module.SpotifyConnector(settings=_make_settings())
+        connector._budget = ratelimit_module.RateLimitBudget(default_interval=0.0)
+        connector._http_client = httpx.AsyncClient(transport=handler)
+        return connector
+
+    @pytest.mark.anyio()
+    async def test_create_playlist_retries_transient_403(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(403, json={"error": {"status": 403}})
+            return httpx.Response(201, json={"id": "pl-123"})
+
+        connector = self._connector(httpx.MockTransport(handler))
+        with patch("resonance.connectors.base.asyncio.sleep", new=AsyncMock()):
+            playlist_id = await connector.create_playlist("tok", "My Playlist", "")
+
+        assert playlist_id == "pl-123"
+        assert calls["n"] == 2  # one 403, then success
+
+    @pytest.mark.anyio()
+    async def test_create_playlist_exhausts_403_then_raises(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(403, json={"error": {"status": 403}})
+
+        connector = self._connector(httpx.MockTransport(handler))
+        with (
+            patch("resonance.connectors.base.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await connector.create_playlist("tok", "My Playlist", "")
+
+        # initial attempt + _MAX_FORBIDDEN_RETRIES retries
+        assert calls["n"] == base_module.BaseConnector._MAX_FORBIDDEN_RETRIES + 1
+
+    @pytest.mark.anyio()
+    async def test_non_write_403_fails_fast(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(403, json={"error": {"status": 403}})
+
+        connector = self._connector(httpx.MockTransport(handler))
+        with (
+            patch("resonance.connectors.base.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await connector.get_current_user("tok")
+
+        assert calls["n"] == 1  # no retry without retry_forbidden


### PR DESCRIPTION
## Summary

Playlist export was failing with a 403 on `POST /me/playlists`. Diagnosed against the live service: the worker refreshed the token successfully, matched 15 tracks, then got a 403 on playlist creation. Replaying the **exact same token** seconds later created a playlist (201) — so it's a **transient** Spotify dev-mode 403, not a permissions, scope, or token problem (the connection has `playlist-modify-private` and was created after that scope landed).

The request layer (`connectors/base.py`) retried 5xx and 429 but sent every 403 straight to `raise_for_status`, so a single transient blip killed the whole export.

This adds an opt-in bounded 403 retry and turns it on for Spotify writes.

<details>
<summary>How to Review</summary>

Two commits:

1. **`aed9caa` — request layer.** `_request` gains a `retry_forbidden` flag (default `False`). When set, a 403 retries with exponential backoff up to `_MAX_FORBIDDEN_RETRIES` (3). The `forbidden_attempt` counter is never reset mid-loop, so a genuine permission 403 still fails after exhausting retries. Default-off keeps every other connector failing fast on real 403s.
2. **`f966591` — Spotify writes.** `create_playlist`, `add_tracks_to_playlist`, and `replace_playlist_tracks` pass `retry_forbidden=True`. Tests cover: transient 403 → retry → success; persistent 403 → fail after N; and a non-write 403 (`get_current_user`) failing fast with no retry.

</details>

<details>
<summary>Test Plan</summary>

- [x] `uv run pytest` — 1271 passed (3 new)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check` / `format --check` — clean
- [x] pre-commit hooks passed
- [x] Diagnosed against live service (token replay reproduced 201 where worker saw 403)

</details>

<details>
<summary>Impact</summary>

- Playlist export survives transient dev-mode 403s instead of failing on the first one.
- Backoff is 2/4/8s over 3 retries (~14s worst case) on a background task — acceptable.
- A real permission 403 still fails (after retries), and logs `forbidden_retries_exhausted` for diagnosis.
- No behavior change for non-Spotify connectors or Spotify reads (opt-in).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)