### PR TITLE
fix: create Spotify playlists as private (real fix for export 403)

### DIFF
--- a/src/resonance/connectors/spotify.py
+++ b/src/resonance/connectors/spotify.py
@@ -295,10 +295,12 @@ class SpotifyConnector(base_module.BaseConnector):
         name: str,
         description: str = "",
     ) -> str:
-        """Create a playlist on the user's Spotify account.
+        """Create a private playlist on the user's Spotify account.
 
-        Spotify dev mode ignores ``public=False``, so playlists are always
-        public.  We send ``public=True`` to match the actual behavior.
+        Sends ``public=False`` because the OAuth grant requests
+        ``playlist-modify-private`` (not ``playlist-modify-public``). Creating
+        a public playlist requires the public scope, so ``public=True`` returns
+        403 "Insufficient client scope".
         """
         response = await self._request(
             "POST",
@@ -308,7 +310,7 @@ class SpotifyConnector(base_module.BaseConnector):
             json={
                 "name": name,
                 "description": description,
-                "public": True,
+                "public": False,
             },
         )
         data: dict[str, str] = response.json()

--- a/tests/test_spotify_export.py
+++ b/tests/test_spotify_export.py
@@ -47,7 +47,8 @@ class TestCreatePlaylist:
             body = json.loads(request.content)
             assert body["name"] == "My Playlist"
             assert body["description"] == "A test playlist"
-            assert body["public"] is True
+            # Private: the grant has playlist-modify-private, not -public.
+            assert body["public"] is False
             return httpx.Response(
                 201, json={"id": "playlist-abc123", "name": "My Playlist"}
             )


### PR DESCRIPTION
## Summary

This is the **actual** root cause of the playlist export 403 (PR #106 added 403-retry resilience but did not fix this — retrying a scope error just fails slower).

`create_playlist` sent `public: True`. Creating a **public** playlist requires the `playlist-modify-public` scope, but the OAuth grant only requests `playlist-modify-private`. Spotify returns **403 "Insufficient client scope"** on every export.

Confirmed live against the affected token:

```
POST /me/playlists  public=True  -> 403 {"error":{"status":403,"message":"Insufficient client scope"}}
POST /me/playlists  public=False -> 201
```

Fix: send `public: False`, matching the granted scope. Playlists are created private; no re-auth needed.

<details>
<summary>How this was missed before</summary>

The initial diagnosis called it "transient" because the first manual replay accidentally used `public: False` (got 201). Replaying the connector's exact request (`public: True`) reproduces the 403 deterministically. The prior code comment ("dev mode ignores public=False, so playlists are always public") is no longer accurate — `public: False` now creates a private playlist (verified 201).
</details>

<details>
<summary>Test Plan</summary>

- [x] Live confirmation: `public:True` → 403, `public:False` → 201 (same token)
- [x] Updated `test_posts_to_me_playlists` to assert `public is False`
- [x] `uv run pytest tests/test_spotify*.py` — 42 passed
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check` / `format --check` — clean
- [x] pre-commit hooks passed

</details>

<details>
<summary>Relationship to #106</summary>

#106 (merged) adds bounded retry for genuinely transient 403s — still useful, but it does not address this scope error (which fails on every retry). This PR fixes the export. Consider whether to keep #106's retry; it's harmless for true transients but adds ~14s of delay before a genuine permission 403 surfaces.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)