### PR TITLE
feat: add ListenBrainz as a second similar-artists provider (#105)

### DIFF
--- a/src/resonance/connectors/listenbrainz.py
+++ b/src/resonance/connectors/listenbrainz.py
@@ -19,6 +19,15 @@ MUSICBRAINZ_AUTH_URL = "https://musicbrainz.org/oauth2/authorize"
 MUSICBRAINZ_TOKEN_URL = "https://musicbrainz.org/oauth2/token"
 MUSICBRAINZ_USERINFO_URL = "https://musicbrainz.org/oauth2/userinfo"
 LISTENBRAINZ_API_BASE = "https://api.listenbrainz.org/1"
+LISTENBRAINZ_LABS_BASE = "https://labs.api.listenbrainz.org"
+
+# The labs similar-artists endpoint bakes its result limit into the algorithm
+# name (limit_100). There is no separate limit query param, so the caller's
+# limit is applied client-side after fetching.
+LISTENBRAINZ_SIMILAR_ALGORITHM = (
+    "session_based_days_7500_session_300_contribution_5_"
+    "threshold_10_limit_100_filter_True_skip_30"
+)
 
 
 class ListenBrainzListenItem(pydantic.BaseModel):
@@ -40,6 +49,7 @@ class ListenBrainzConnector(base_module.BaseConnector):
             base_module.ConnectorCapability.AUTHN,
             base_module.ConnectorCapability.LISTENING_HISTORY,
             base_module.ConnectorCapability.TRACK_DISCOVERY,
+            base_module.ConnectorCapability.SIMILAR_ARTISTS,
         }
     )
 
@@ -303,6 +313,83 @@ class ListenBrainzConnector(base_module.BaseConnector):
                 return track_id
 
         return None
+
+    async def get_similar_artists(
+        self,
+        artist_name: str,
+        *,
+        mbid: str | None = None,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Fetch artists similar to the given artist via the ListenBrainz labs.
+
+        Uses the MBID-keyed similar-artists labs endpoint, whose similarity
+        signal is derived from listening data. This is a complement to a
+        name-based provider (e.g. Last.fm): an ``mbid`` is required, so artists
+        without a MusicBrainz ID yield no neighbors here.
+
+        Args:
+            artist_name: The artist name (used only for logging; matching is by
+                MBID).
+            mbid: MusicBrainz artist ID. Required — when absent, returns an
+                empty list.
+            limit: Maximum number of similar artists to return.
+
+        Returns:
+            A list of ``{"name", "mbid", "match"}`` dicts ordered by similarity
+            (descending). ``match`` is the raw labs score normalized to 0-1
+            against the top result, matching the shape used by other
+            similar-artist providers. Returns an empty list when ``mbid`` is
+            missing or the endpoint has no data for the artist.
+        """
+        if not mbid:
+            logger.debug("listenbrainz_similar_skipped_no_mbid", artist=artist_name)
+            return []
+
+        try:
+            response = await self._request(
+                "GET",
+                f"{LISTENBRAINZ_LABS_BASE}/similar-artists/json",
+                params={
+                    "artist_mbids": mbid,
+                    "algorithm": LISTENBRAINZ_SIMILAR_ALGORITHM,
+                },
+            )
+        except httpx.HTTPStatusError:
+            logger.warning("listenbrainz_similar_failed", artist=artist_name, mbid=mbid)
+            return []
+
+        raw: list[dict[str, Any]] = response.json()
+        # Scores are unbounded co-occurrence counts; normalize against the top
+        # result so ``match`` lands in 0-1, comparable across providers.
+        scores = [s for item in raw if (s := item.get("score")) is not None and s > 0]
+        max_score = float(max(scores)) if scores else 0.0
+
+        results: list[dict[str, Any]] = []
+        for item in raw[:limit]:
+            name = item.get("name")
+            if not name:
+                continue
+            raw_score = item.get("score")
+            match = (
+                float(raw_score) / max_score
+                if max_score > 0 and raw_score is not None
+                else 0.0
+            )
+            results.append(
+                {
+                    "name": name,
+                    "mbid": item.get("artist_mbid") or None,
+                    "match": match,
+                }
+            )
+        logger.info(
+            "listenbrainz_similar_resolved",
+            artist=artist_name,
+            mbid=mbid,
+            result_count=len(results),
+        )
+        return results
 
     @staticmethod
     def _parse_mb_artist(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -863,7 +863,7 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
 
 async def _resolve_similar_library_artists(
     session: sa_async.AsyncSession,
-    connector: Any,
+    connectors: collections.abc.Sequence[Any],
     target_artists: collections.abc.Sequence[music_models.Artist],
     exclude_ids: set[uuid.UUID],
     *,
@@ -871,15 +871,21 @@ async def _resolve_similar_library_artists(
 ) -> set[uuid.UUID]:
     """Resolve library artists similar to the targets (issue #103, Mode 1).
 
-    For each target artist, ask the connector for similar artists, then match
-    those names against artists already in the library. Returns the matching
-    local artist IDs, excluding ``exclude_ids`` (the target set). Similar
-    artists not already in the library are ignored — importing their tracks is
-    out of scope (that is track discovery, a separate feature).
+    For each target artist, ask every similar-artist provider for neighbors and
+    union their names, then match those names against artists already in the
+    library. Returns the matching local artist IDs, excluding ``exclude_ids``
+    (the target set). Similar artists not already in the library are ignored —
+    importing their tracks is out of scope (that is track discovery, a separate
+    feature).
+
+    Multiple providers are complementary: a name-based provider (Last.fm) covers
+    artists by name, while an MBID-keyed provider (ListenBrainz) only resolves
+    artists carrying a MusicBrainz ID. Unioning the results widens recall
+    without needing to rank across providers, since Mode 1 only uses names.
 
     Args:
         session: Async DB session.
-        connector: A connector exposing ``get_similar_artists``.
+        connectors: Connectors exposing ``get_similar_artists``.
         target_artists: The event's target (lineup) artists.
         exclude_ids: Artist IDs to exclude from the result (the target set).
         per_artist_limit: Max similar artists to request per target artist.
@@ -895,13 +901,14 @@ async def _resolve_similar_library_artists(
         if isinstance(mb, dict):
             raw_id = mb.get("id")
             mbid = str(raw_id) if raw_id else None
-        neighbors = await connector.get_similar_artists(
-            artist.name, mbid=mbid, limit=per_artist_limit
-        )
-        for neighbor in neighbors:
-            name = neighbor.get("name")
-            if name:
-                similar_names.add(name.lower())
+        for connector in connectors:
+            neighbors = await connector.get_similar_artists(
+                artist.name, mbid=mbid, limit=per_artist_limit
+            )
+            for neighbor in neighbors:
+                name = neighbor.get("name")
+                if name:
+                    similar_names.add(name.lower())
 
     if not similar_names:
         return set()
@@ -1020,7 +1027,7 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                     )
                     adjacent_ids = await _resolve_similar_library_artists(
                         session,
-                        similar_connectors[0],
+                        similar_connectors,
                         list(target_artists_result.scalars().all()),
                         artist_ids,
                     )
@@ -1028,6 +1035,7 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                     log.info(
                         "similar_artists_resolved",
                         adjacent_count=len(adjacent_ids),
+                        provider_count=len(similar_connectors),
                     )
 
             # Query all tracks by these artists (target + any adjacent)

--- a/tests/test_listenbrainz_connector.py
+++ b/tests/test_listenbrainz_connector.py
@@ -35,6 +35,7 @@ class TestListenBrainzConnectorProperties:
                 base_module.ConnectorCapability.AUTHN,
                 base_module.ConnectorCapability.LISTENING_HISTORY,
                 base_module.ConnectorCapability.TRACK_DISCOVERY,
+                base_module.ConnectorCapability.SIMILAR_ARTISTS,
             }
         )
         assert connector.capabilities == expected
@@ -400,3 +401,78 @@ class TestDiscoverTracks:
         assert result[0].popularity_score == 100
         assert result[1].popularity_score == 95
         assert result[2].popularity_score == 90
+
+
+class TestGetSimilarArtists:
+    """Tests for get_similar_artists via the ListenBrainz labs endpoint."""
+
+    def _connector_with_handler(
+        self, handler: object
+    ) -> listenbrainz_module.ListenBrainzConnector:
+        transport = httpx.MockTransport(handler)  # type: ignore[arg-type]
+        connector = listenbrainz_module.ListenBrainzConnector(settings=_make_settings())
+        connector._http_client = httpx.AsyncClient(transport=transport)
+        connector._budget = ratelimit_module.RateLimitBudget(default_interval=0.0)
+        return connector
+
+    @pytest.mark.anyio()
+    async def test_parses_and_normalizes_scores(self) -> None:
+        labs_response = [
+            {"artist_mbid": "mbid-nirvana", "name": "Nirvana", "score": 10000},
+            {"artist_mbid": "mbid-muse", "name": "Muse", "score": 5000},
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "labs.api.listenbrainz.org/similar-artists/json" in str(request.url)
+            assert "artist_mbids=mbid-radiohead" in str(request.url)
+            return httpx.Response(200, json=labs_response)
+
+        connector = self._connector_with_handler(handler)
+
+        result = await connector.get_similar_artists("Radiohead", mbid="mbid-radiohead")
+
+        assert result == [
+            {"name": "Nirvana", "mbid": "mbid-nirvana", "match": 1.0},
+            {"name": "Muse", "mbid": "mbid-muse", "match": 0.5},
+        ]
+
+    @pytest.mark.anyio()
+    async def test_requires_mbid(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            raise AssertionError("endpoint should not be called without an mbid")
+
+        connector = self._connector_with_handler(handler)
+
+        result = await connector.get_similar_artists("Radiohead")
+
+        assert result == []
+
+    @pytest.mark.anyio()
+    async def test_truncates_to_limit(self) -> None:
+        labs_response = [
+            {"artist_mbid": f"mbid-{i}", "name": f"Artist {i}", "score": 100 - i}
+            for i in range(10)
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=labs_response)
+
+        connector = self._connector_with_handler(handler)
+
+        result = await connector.get_similar_artists(
+            "Radiohead", mbid="mbid-radiohead", limit=3
+        )
+
+        assert len(result) == 3
+        assert [r["name"] for r in result] == ["Artist 0", "Artist 1", "Artist 2"]
+
+    @pytest.mark.anyio()
+    async def test_returns_empty_on_http_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        connector = self._connector_with_handler(handler)
+
+        result = await connector.get_similar_artists("Radiohead", mbid="mbid-radiohead")
+
+        assert result == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2896,7 +2896,7 @@ class TestResolveSimilarLibraryArtists:
         session.execute.return_value = result
 
         matched = await worker_module._resolve_similar_library_artists(
-            session, connector, [target], {target_id}
+            session, [connector], [target], {target_id}
         )
 
         assert matched == {elder_id}
@@ -2915,7 +2915,7 @@ class TestResolveSimilarLibraryArtists:
         session = AsyncMock()
 
         matched = await worker_module._resolve_similar_library_artists(
-            session, connector, [target], set()
+            session, [connector], [target], set()
         )
 
         assert matched == set()
@@ -2923,3 +2923,42 @@ class TestResolveSimilarLibraryArtists:
         connector.get_similar_artists.assert_awaited_once_with(
             "Obscure Band", mbid=None, limit=30
         )
+
+    @pytest.mark.anyio()
+    async def test_unions_neighbors_across_providers(self) -> None:
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = {"musicbrainz": {"id": "mbid-kb"}}
+
+        # Two providers each contribute a distinct neighbor; both should be
+        # queried and their results unioned.
+        lastfm = AsyncMock()
+        lastfm.get_similar_artists.return_value = [
+            {"name": "Elder", "mbid": None, "match": 0.9},
+        ]
+        listenbrainz = AsyncMock()
+        listenbrainz.get_similar_artists.return_value = [
+            {"name": "Pallbearer", "mbid": "mbid-pb", "match": 0.8},
+        ]
+
+        elder_id = uuid.uuid4()
+        pallbearer_id = uuid.uuid4()
+        result = MagicMock()
+        result.all.return_value = [(elder_id,), (pallbearer_id,)]
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        matched = await worker_module._resolve_similar_library_artists(
+            session, [lastfm, listenbrainz], [target], set()
+        )
+
+        assert matched == {elder_id, pallbearer_id}
+        # Both providers are consulted...
+        lastfm.get_similar_artists.assert_awaited_once_with(
+            "King Buffalo", mbid="mbid-kb", limit=30
+        )
+        listenbrainz.get_similar_artists.assert_awaited_once_with(
+            "King Buffalo", mbid="mbid-kb", limit=30
+        )
+        # ...and their neighbors are unioned into a single library query.
+        session.execute.assert_awaited_once()


### PR DESCRIPTION
## Summary

Adds ListenBrainz as a second `SIMILAR_ARTISTS` provider (#105). Last.fm (name-based) and ListenBrainz (MBID-keyed, listening-data-derived) now run together and their results are unioned.

- `ListenBrainzConnector.get_similar_artists()` hits the MBID-keyed similar-artists labs endpoint and declares `ConnectorCapability.SIMILAR_ARTISTS`.
- Scores are normalized to 0-1 against the top result so `match` matches the Last.fm shape.
- ListenBrainz has **no name fallback** — without an MBID it returns `[]`, so it complements Last.fm rather than replacing it.
- The worker now consults **every** `SIMILAR_ARTISTS` provider and unions neighbors into a single library query (was: only `[0]`). Mode 1 matches by name, so a union widens recall without cross-provider ranking.

`Fixes #105`

<details>
<summary>How to Review</summary>

Single commit. Review order:

1. `src/resonance/connectors/listenbrainz.py` — new `get_similar_artists` (labs endpoint, MBID-required, score normalization) + capability flag.
2. `src/resonance/worker.py` — `_resolve_similar_library_artists` now takes a sequence of connectors and unions neighbor names; caller passes the full provider list.
3. Tests — `TestGetSimilarArtists` (parse/normalize, MBID-required, limit truncation, HTTP error → `[]`); worker `test_unions_neighbors_across_providers` plus the two existing tests updated to pass a list.
</details>

<details>
<summary>Test Plan</summary>

- [x] `uv run pytest` — 1276 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/` — no issues
- [x] Verified the labs endpoint shape live against a known MBID (Radiohead)
- [ ] Live verification after deploy: generate with `similar_artist_ratio > 0` for an event whose lineup artists carry MusicBrainz IDs; confirm ListenBrainz neighbors widen the adjacent set
</details>

<details>
<summary>Impact</summary>

- No schema changes, no new config.
- Behavior change only when `similar_artist_ratio > 0`: adjacent-artist recall widens because two providers contribute instead of one.
- The merge is name-union only (Mode 1). Cross-provider score ranking is deferred until match scores are actually consumed downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>