### PR TITLE
feat: MusicBrainz MBID backfill (Phase A, #71)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -33,3 +33,31 @@ Deferred work items with full context. Each entry explains what, why, and where 
 **Where to start:** Add a `_TASK_TYPE_CAPABILITIES` mapping from TaskType to required ConnectorCapability. Add capability checks in `_check_parent_completion()` and `_reenqueue_orphaned_tasks()`. Add runtime validation in `startup()` to verify registered strategies match declared capabilities.
 
 **Source:** /plan-eng-review D12+D17, 2026-05-28. Outside voice caught the call-site audit gap; user requested forward-looking refactor.
+
+## Phase B — local MusicBrainz DB as discovery engine (#71 follow-on)
+
+**Status:** Deferred 2026-06-18. Revisit after Phase A (hosted-mapper MBID backfill) ships and its coverage report is in hand.
+
+**What:** Stand up a local MusicBrainz mirror — the DB-only variant (`docker-compose.alt.db-only-mirror.yml` in metabrainz/musicbrainz-docker, no web/search/API containers). Use it as (1) a discovery engine for deep cuts, unheard tracks by known artists, and never-before-seen related artists, and (2) an alternate, rate-limit-free matching source if the hosted mapper's coverage disappoints.
+
+**Why:** The hosted MetaBrainz mapper (Phase A) can backfill MBIDs but cannot power discovery (querying recordings/relationships at will), and may have a low match ceiling on a concert-discovery library skewed to live/bootleg/long-tail recordings. A local mirror removes both limits. Deployed nowhere — laptop-only, one-time-ish tool.
+
+**Depends on / blocked by:** Phase A coverage report (the match-rate gate, T3-A) telling us whether the hosted ceiling actually justifies the mirror. The Phase A matcher is built source-agnostic (adapter pattern) so the local DB slots in as a third adapter.
+
+**Where to start:** When ready to download, see https://musicbrainz.org/doc/MusicBrainz_Database/Download (and the db-only-mirror compose file). Needs Docker (colima on macOS). Expect a multi-GB download + import taking hours. Then add a local-DB adapter behind the Phase A backfill core, and a query layer for discovery.
+
+**Source:** /plan-eng-review 2026-06-18, #71. Hosted-mapper-first sequencing (D1); local DB deferred per coverage gate.
+
+## Surface MBID collisions as merge candidates (#71 follow-on)
+
+**Status:** Deferred 2026-06-18. Revisit once Phase A produces collision logs worth acting on.
+
+**What:** Turn logged MBID collisions (two library rows resolving to the same MusicBrainz id, recorded by the Phase A backfill per T5-A) into an actionable merge-candidate queue.
+
+**Why:** `dedup.py` finds name-based duplicates, but an identical MBID is a stronger, higher-precision dedup signal that Phase A currently only logs and skips. Acting on it would catch duplicates name-matching misses.
+
+**Depends on / blocked by:** Phase A backfill emitting collision logs (counted in the coverage report).
+
+**Where to start:** Add a merge-candidate store (a small candidates table, or reuse `EventArtistCandidate`-style storage) that the backfill writes collisions into, surfaced through the existing `api/v1/matching.py` pairwise merge preview/confirm. No auto-merge.
+
+**Source:** /plan-eng-review 2026-06-18, #71, Tension 4 (T5-A). Outside voice flagged that the merge endpoints are pairwise/UI-only with no ingest path.

--- a/alembic/versions/e6f7g8h9i0j1_add_mb_backfill_columns.py
+++ b/alembic/versions/e6f7g8h9i0j1_add_mb_backfill_columns.py
@@ -1,0 +1,58 @@
+"""add MusicBrainz MBID-backfill bookkeeping columns to artists and tracks
+
+Adds mb_attempted_at (resume key; NULL = not yet attempted) and mb_match_status
+(matched / no_match / below_similarity) to both tables for #71. The MBID itself
+continues to live in service_links["musicbrainz"]["id"]; these columns only track
+the outcome of a backfill attempt.
+
+mb_match_status mirrors the MatchStatus StrEnum stored as native_enum=False
+(VARCHAR + CHECK). SQLAlchemy persists the enum .name (UPPERCASE), so the CHECK
+uses 'MATCHED' / 'NO_MATCH' / 'BELOW_SIMILARITY'.
+
+Revision ID: e6f7g8h9i0j1
+Revises: d5e6f7g8h9i0
+Create Date: 2026-06-18
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e6f7g8h9i0j1"
+down_revision: str | None = "d5e6f7g8h9i0"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+# Longest value "BELOW_SIMILARITY" is 16 chars.
+_MATCH_STATUS_LEN = 16
+_MATCH_STATUS_VALUES = "'MATCHED', 'NO_MATCH', 'BELOW_SIMILARITY'"
+
+
+def upgrade() -> None:
+    for table in ("artists", "tracks"):
+        op.add_column(
+            table,
+            sa.Column("mb_attempted_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column("mb_match_status", sa.String(_MATCH_STATUS_LEN), nullable=True),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_mb_match_status",
+            table,
+            f"mb_match_status IN ({_MATCH_STATUS_VALUES})",
+        )
+
+
+def downgrade() -> None:
+    for table in ("artists", "tracks"):
+        op.drop_constraint(
+            f"ck_{table}_mb_match_status",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "mb_match_status")
+        op.drop_column(table, "mb_attempted_at")

--- a/src/resonance/api/v1/admin.py
+++ b/src/resonance/api/v1/admin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Annotated
+from typing import Annotated, Any
 
 import fastapi
 import sqlalchemy as sa
@@ -136,6 +136,41 @@ async def get_db_stats(
         "events_by_service": {row[0]: row[1] for row in events_by_svc.all()},
         "duplicate_artist_groups": dup_artists_result.scalar() or 0,
         "duplicate_track_groups": dup_tracks_result.scalar() or 0,
+    }
+
+
+async def _mb_status_counts(
+    db: sa_async.AsyncSession, status_col: Any
+) -> dict[str, int]:
+    """Count rows grouped by an mb_match_status column (None -> 'unattempted')."""
+    rows = (
+        await db.execute(sa.select(status_col, sa.func.count()).group_by(status_col))
+    ).all()
+    return {
+        (status.value if status is not None else "unattempted"): count
+        for status, count in rows
+    }
+
+
+async def get_backfill_coverage(db: sa_async.AsyncSession) -> dict[str, object]:
+    """MBID-backfill coverage by entity type and outcome (#71, the T3-A gate).
+
+    For tracks and artists, counts rows by ``mb_match_status``. The None bucket
+    (not yet attempted, or left for retry after a transient error) is reported as
+    ``"unattempted"``. This is the decision input for whether hosted-mapper
+    coverage is good enough or the local MB DB (Phase B) is worth standing up.
+    """
+    return {
+        "track": {
+            "by_status": await _mb_status_counts(
+                db, music_models.Track.mb_match_status
+            ),
+        },
+        "artist": {
+            "by_status": await _mb_status_counts(
+                db, music_models.Artist.mb_match_status
+            ),
+        },
     }
 
 
@@ -326,6 +361,55 @@ async def admin_dedup_endpoint(
             ),
         )
     return await enqueue_dedup(request, db, f"dedup_{operation}")
+
+
+@router.post(
+    "/backfill-mbids",
+    summary="Enqueue MusicBrainz MBID backfill",
+)
+async def admin_backfill_mbids_endpoint(
+    request: fastapi.Request,
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    retry: bool = False,
+    entity_types: Annotated[list[str] | None, fastapi.Query()] = None,
+) -> dict[str, str]:
+    """Enqueue an MBID_BACKFILL task (#71).
+
+    Query params: ``retry`` re-attempts prior no_match/below_similarity rows;
+    ``entity_types`` (repeatable) limits to "track" and/or "artist" (default both).
+    """
+    params: dict[str, object] = {}
+    if entity_types:
+        params["entity_types"] = entity_types
+    if retry:
+        params["retry"] = True
+    task = task_models.Task(
+        task_type=types_module.TaskType.MBID_BACKFILL,
+        status=types_module.SyncStatus.PENDING,
+        params=params,
+        description="MBID Backfill",
+    )
+    db.add(task)
+    await db.commit()
+    task_id = str(task.id)
+
+    arq_redis = request.app.state.arq_redis
+    await arq_redis.enqueue_job(
+        "backfill_mbids",
+        task_id,
+        _job_id=f"mbid-backfill:{task_id}",
+    )
+    return {"task_id": task_id, "status": "started"}
+
+
+@router.get(
+    "/backfill-mbids",
+    summary="MusicBrainz MBID backfill coverage",
+)
+async def admin_backfill_coverage_endpoint(
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, object]:
+    return await get_backfill_coverage(db)
 
 
 # ---------------------------------------------------------------------------

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -78,6 +78,7 @@ Commands:
   feed-add ical <url> [--label] Add generic iCal connection
   feed-sync <conn_id|all>      Sync a calendar connection (or all)
   dedup <type> [--no-wait]     Run deduplication
+  backfill-mbids [opts]        Backfill MusicBrainz MBIDs (#71)
   task <task_id>               Check task status
   track <query>                Search tracks by title
   profile <subcommand>         Manage generator profiles
@@ -962,6 +963,54 @@ def _cmd_watermark() -> None:
     asyncio.run(_watermark(service, reset=reset))
 
 
+_BACKFILL_USAGE = """\
+Usage: resonance-api backfill-mbids [opts]
+
+Options:
+  --status       Show coverage (counts by match status), do not enqueue
+  --retry        Re-attempt prior no-match / below-similarity rows
+  --tracks       Only backfill track recording MBIDs
+  --artists      Only backfill artist MBIDs
+  --no-wait      Enqueue and return immediately (don't poll)
+
+With no --tracks/--artists flag, both passes run (tracks first, to harvest
+artist MBIDs). Default polls the task to completion and prints per-type counts.
+"""
+
+
+def _cmd_backfill_mbids() -> None:
+    args = sys.argv[2:]
+    if "--help" in args or "-h" in args:
+        print(_BACKFILL_USAGE)
+        return
+    if "--status" in args:
+        resp = _api_request("GET", "/api/v1/admin/backfill-mbids")
+        print(json.dumps(resp.json(), indent=2))
+        return
+
+    query: list[str] = []
+    if "--retry" in args:
+        query.append("retry=true")
+    want_tracks = "--tracks" in args
+    want_artists = "--artists" in args
+    if want_tracks and not want_artists:
+        query.append("entity_types=track")
+    elif want_artists and not want_tracks:
+        query.append("entity_types=artist")
+
+    path = "/api/v1/admin/backfill-mbids"
+    if query:
+        path += "?" + "&".join(query)
+    resp = _api_request("POST", path)
+    task_id = resp.json().get("task_id", "")
+
+    if "--no-wait" in args:
+        print(f"backfill-mbids: task {task_id}")
+        return
+    result = _poll_task(task_id, "Backfilling MBIDs")
+    print(json.dumps(result, indent=2))
+
+
 _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "healthz": ("Health + deployed revision", _cmd_healthz),
     "status": ("Recent sync job overview", _cmd_status),
@@ -971,6 +1020,7 @@ _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "feed-add": ("Add calendar connection", _cmd_feed_add),
     "feed-sync": ("Sync a calendar connection", _cmd_feed_sync),
     "dedup": ("Run deduplication", _cmd_dedup),
+    "backfill-mbids": ("Backfill MusicBrainz MBIDs", _cmd_backfill_mbids),
     "task": ("Check task status", _cmd_task),
     "track": ("Search tracks by title", _cmd_track),
     "profile": ("Manage generator profiles", _cmd_profile),

--- a/src/resonance/config.py
+++ b/src/resonance/config.py
@@ -43,6 +43,12 @@ class Settings(pydantic_settings.BaseSettings):
     musicbrainz_client_secret: str = ""
     musicbrainz_redirect_path: str = "/api/v1/auth/listenbrainz/callback"
 
+    # ListenBrainz user token + MBID backfill (#71)
+    # lb_user_token authenticates the /1/metadata/lookup mapper endpoint.
+    lb_user_token: str = ""
+    mbid_mapper_batch_size: int = 50
+    mbid_match_min_similarity: float = 0.85
+
     # Last.fm API
     lastfm_api_key: str = ""
     lastfm_shared_secret: str = ""

--- a/src/resonance/models/music.py
+++ b/src/resonance/models/music.py
@@ -43,6 +43,17 @@ class Artist(base_module.TimestampMixin, base_module.Base):
     end_year: orm.Mapped[int | None] = orm.mapped_column(
         sa.Integer, nullable=True, default=None
     )
+    # MusicBrainz MBID-backfill bookkeeping (#71). mb_attempted_at IS NULL means
+    # "not yet attempted" and is the resume key for the backfill task; the MBID
+    # itself lives in service_links["musicbrainz"]["id"], not here.
+    mb_attempted_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        sa.DateTime(timezone=True), nullable=True, default=None
+    )
+    mb_match_status: orm.Mapped[types_module.MatchStatus | None] = orm.mapped_column(
+        sa.Enum(types_module.MatchStatus, native_enum=False),
+        nullable=True,
+        default=None,
+    )
 
     tracks: orm.Mapped[list[Track]] = orm.relationship(
         back_populates="artist", cascade="all, delete-orphan"
@@ -66,6 +77,16 @@ class Track(base_module.TimestampMixin, base_module.Base):
     )
     service_links: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(
         sa.JSON, nullable=True, default=None
+    )
+    # MusicBrainz MBID-backfill bookkeeping (#71). See Artist for semantics; the
+    # recording MBID lives in service_links["musicbrainz"]["id"].
+    mb_attempted_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        sa.DateTime(timezone=True), nullable=True, default=None
+    )
+    mb_match_status: orm.Mapped[types_module.MatchStatus | None] = orm.mapped_column(
+        sa.Enum(types_module.MatchStatus, native_enum=False),
+        nullable=True,
+        default=None,
     )
 
     artist: orm.Mapped[Artist] = orm.relationship(back_populates="tracks")

--- a/src/resonance/normalize.py
+++ b/src/resonance/normalize.py
@@ -8,6 +8,7 @@ are preserved elsewhere — this module is for comparison only.
 
 from __future__ import annotations
 
+import difflib
 import re
 import unicodedata
 
@@ -63,6 +64,27 @@ def normalize_name(value: str) -> str:
 def names_match(a: str, b: str) -> bool:
     """Check whether two names refer to the same entity after normalization."""
     return normalize_name(a) == normalize_name(b)
+
+
+def name_similarity(a: str, b: str) -> float:
+    """Return a 0..1 similarity ratio between two names after normalization.
+
+    Runs ``difflib.SequenceMatcher`` over ``normalize_name``-d strings, so it is
+    tolerant of case, accents, smart quotes, and whitespace (like
+    ``names_match``) while also scoring partial differences such as punctuation
+    or a missing "The" prefix. A ratio of 1.0 means the normalized names are
+    identical (``names_match`` would return True). Used as the MBID-backfill
+    similarity gate (#71), where the mapper returns no confidence score of its
+    own.
+
+    Args:
+        a: First name.
+        b: Second name.
+
+    Returns:
+        Similarity ratio in the range 0.0 (no overlap) to 1.0 (identical).
+    """
+    return difflib.SequenceMatcher(None, normalize_name(a), normalize_name(b)).ratio()
 
 
 # ---------------------------------------------------------------------------

--- a/src/resonance/services/mbid_mapper.py
+++ b/src/resonance/services/mbid_mapper.py
@@ -1,0 +1,220 @@
+"""Client for the ListenBrainz metadata lookup (MusicBrainz MBID mapper).
+
+Resolves ``(artist_name, recording_name)`` pairs to MusicBrainz recording and
+artist MBIDs via the ListenBrainz ``/1/metadata/lookup`` batch endpoint (#71).
+
+Design notes:
+
+- This is deliberately separate from ``connectors.listenbrainz`` (the OAuth
+  user-connection connector). The mapper is an anonymous bulk-lookup tool, not a
+  per-user connection — see /plan-eng-review issue 7 (7A).
+- The endpoint requires a ListenBrainz user token (anti-scraper) and returns
+  **no confidence score**, so callers gate matches with ``normalize.name_similarity``
+  rather than trusting the mapper blindly (T1-A).
+- The batch POST returns a JSON array aligned to the input order; a miss is an
+  entry whose ``recording_mbid`` is null. Alignment is therefore positional.
+- It reuses ``RateLimitBudget`` for pacing/backoff but keeps a small, focused
+  request loop (no OAuth, no high-priority lane, no Spotify 403 path). The full
+  ``BaseConnector._request`` is richer but lives in the connector ABC; extracting
+  it into a shared mixin is a possible future DRY refactor.
+
+Transient failures (timeouts, 429, 5xx) raise ``MapperUnavailableError`` so the
+backfill core can leave the entity unattempted (retried later) instead of
+recording a false ``no_match``. Hard failures (e.g. 401 bad token, 400 bad
+request) propagate as ``httpx.HTTPStatusError``.
+
+       queries (in order)              response array (aligned)
+   ┌──────────────────────────┐    ┌──────────────────────────────┐
+   │ 0: Rick Astley / NGGYU   │ →  │ 0: {recording_mbid: "8f34…"} │ → RecordingMatch
+   │ 1: Zzqq / Fake Track     │ →  │ 1: {recording_mbid: null}    │ → None (no match)
+   └──────────────────────────┘    └──────────────────────────────┘
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+import pydantic
+import structlog
+
+import resonance.config as config_module
+import resonance.connectors.ratelimit as ratelimit_module
+
+logger = structlog.get_logger()
+
+_DEFAULT_BASE_URL = "https://api.listenbrainz.org/1"
+_LOOKUP_PATH = "/metadata/lookup/"
+
+
+class RecordingQuery(pydantic.BaseModel):
+    """A single (artist, recording) lookup request."""
+
+    artist_name: str
+    recording_name: str
+    release_name: str | None = None
+
+    def to_payload(self) -> dict[str, str]:
+        """Render the query as the endpoint's per-recording payload dict."""
+        payload = {
+            "artist_name": self.artist_name,
+            "recording_name": self.recording_name,
+        }
+        if self.release_name:
+            payload["release_name"] = self.release_name
+        return payload
+
+
+class RecordingMatch(pydantic.BaseModel):
+    """A resolved MusicBrainz match for a recording query.
+
+    ``artist_credit_name`` / ``recording_name`` are the mapper's view of the
+    matched entity and are what callers feed to the similarity gate.
+    """
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    recording_mbid: str
+    artist_mbids: list[str] = pydantic.Field(default_factory=list)
+    artist_credit_name: str | None = None
+    recording_name: str | None = None
+    release_mbid: str | None = None
+    release_name: str | None = None
+
+
+class MapperUnavailableError(Exception):
+    """Raised when the mapper cannot produce a usable answer for a batch.
+
+    Covers transient conditions (timeouts, connection errors, 429, 5xx) and
+    malformed/misaligned responses. The backfill core treats this as "not
+    attempted" (leaves ``mb_attempted_at`` NULL) so the entities are retried,
+    rather than recording a false ``no_match``.
+    """
+
+
+class MbidMapperClient:
+    """Batch client for the ListenBrainz MusicBrainz mapper endpoint."""
+
+    _TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+        httpx.ReadTimeout,
+        httpx.ConnectError,
+        httpx.RemoteProtocolError,
+    )
+    _MAX_RETRIES = 5
+    _BACKOFF_BASE = 2.0  # seconds — doubles each retry
+
+    def __init__(
+        self,
+        settings: config_module.Settings,
+        *,
+        base_url: str | None = None,
+    ) -> None:
+        self._token = settings.lb_user_token
+        self._base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self._batch_size = max(1, settings.mbid_mapper_batch_size)
+        self._budget = ratelimit_module.RateLimitBudget(default_interval=0.0)
+        self._http_client: httpx.AsyncClient | None = None
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Lazily create and return the HTTP client.
+
+        Tests inject a transport by assigning ``_http_client`` directly, matching
+        the connector test convention.
+        """
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=60.0)
+        return self._http_client
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def lookup_recordings(
+        self, queries: list[RecordingQuery]
+    ) -> list[RecordingMatch | None]:
+        """Resolve queries to matches, aligned by index (None = no match).
+
+        Splits the input into chunks of ``mbid_mapper_batch_size`` and POSTs each
+        chunk to the batch endpoint.
+
+        Args:
+            queries: Lookup queries.
+
+        Returns:
+            A list the same length as ``queries``; element ``i`` is the match for
+            ``queries[i]`` or None if the mapper found no match.
+
+        Raises:
+            MapperUnavailableError: On transient failure for any chunk.
+            httpx.HTTPStatusError: On hard HTTP errors (e.g. 401, 400).
+        """
+        if not queries:
+            return []
+        results: list[RecordingMatch | None] = []
+        for start in range(0, len(queries), self._batch_size):
+            chunk = queries[start : start + self._batch_size]
+            results.extend(await self._lookup_chunk(chunk))
+        return results
+
+    async def _lookup_chunk(
+        self, chunk: list[RecordingQuery]
+    ) -> list[RecordingMatch | None]:
+        url = f"{self._base_url}{_LOOKUP_PATH}"
+        body = {"recordings": [q.to_payload() for q in chunk]}
+        headers = {
+            "Authorization": f"Token {self._token}",
+            "Content-Type": "application/json",
+        }
+        attempt = 0
+        while True:
+            interval = self._budget.paced_interval()
+            if interval > 0:
+                await asyncio.sleep(interval)
+
+            try:
+                response = await self.http_client.post(url, json=body, headers=headers)
+            except self._TRANSIENT_ERRORS as exc:
+                attempt += 1
+                if attempt > self._MAX_RETRIES:
+                    raise MapperUnavailableError(
+                        f"transient error after {attempt} attempts: {exc}"
+                    ) from exc
+                await asyncio.sleep(self._BACKOFF_BASE**attempt)
+                continue
+
+            self._budget.update_from_headers(dict(response.headers))
+            self._budget.record_request()
+
+            if response.status_code == 429 or response.status_code >= 500:
+                attempt += 1
+                if attempt > self._MAX_RETRIES:
+                    raise MapperUnavailableError(
+                        f"mapper {response.status_code} after {attempt} attempts"
+                    )
+                await asyncio.sleep(self._BACKOFF_BASE**attempt)
+                continue
+
+            # Hard errors (401 bad token, 400 bad request) propagate — not transient.
+            response.raise_for_status()
+            return self._parse_results(response.json(), len(chunk))
+
+    @staticmethod
+    def _parse_results(payload: Any, expected_len: int) -> list[RecordingMatch | None]:
+        """Parse the batch response array into index-aligned matches.
+
+        A length mismatch is treated as transient (raises
+        MapperUnavailableError) rather than risking misaligned writes.
+        """
+        if not isinstance(payload, list) or len(payload) != expected_len:
+            raise MapperUnavailableError(
+                f"unexpected mapper response shape (expected list of {expected_len})"
+            )
+        out: list[RecordingMatch | None] = []
+        for entry in payload:
+            if isinstance(entry, dict) and entry.get("recording_mbid"):
+                out.append(RecordingMatch.model_validate(entry))
+            else:
+                out.append(None)
+        return out

--- a/src/resonance/sync/backfill.py
+++ b/src/resonance/sync/backfill.py
@@ -1,0 +1,341 @@
+"""MusicBrainz MBID backfill core (#71).
+
+Resolves missing MusicBrainz IDs onto library Tracks and Artists and writes them
+into ``service_links["musicbrainz"]["id"]``. Phase A (hosted-mapper-first):
+
+- **Tracks** are resolved via the hosted ListenBrainz mapper
+  (``MbidMapperClient``), keyed on ``(artist_name, recording_name)``.
+- **Artists** are resolved by *harvesting* ``artist_mbids`` from gated track
+  matches first (free), then falling back to MusicBrainz ``/ws/2`` artist search
+  (the existing connector's ``search_artists``) for any still missing (T1-A).
+
+Shared mechanics live in ``_apply`` (the engine); the two passes differ only in
+how they *resolve* an entity to a candidate MBID + name (6A).
+
+Decisions encoded here (from /plan-eng-review):
+
+- **Resume (2A):** each pass loops over rows ``WHERE mb_attempted_at IS NULL`` in
+  batches, marking each row attempted and committing per batch. A worker restart
+  resumes from the unattempted remainder.
+- **Similarity gate (T1-A / 4A):** a match is only written when
+  ``normalize.name_similarity(library_name, matched_name) >= threshold``. The
+  mapper returns no score of its own, so this is the guard against wrong matches
+  (bias: no MBID over wrong MBID). Below the threshold → ``below_similarity``.
+- **Write safety (3A):** writes merge into ``service_links`` (sibling keys
+  preserved) and never overwrite a *different* existing MBID (``conflict``).
+- **Collisions (T5-A):** if two rows in one run resolve to the same MBID, the
+  first writes it and later rows are logged + skipped (``collision`` count). They
+  are genuine duplicates for ``dedup`` to merge later; not auto-merged here.
+- **Transient errors (CRITICAL):** a mapper/search outage leaves
+  ``mb_attempted_at`` NULL (NOT ``no_match``) so the row is retried next run.
+
+      TRACK PASS                              ARTIST PASS
+   ┌───────────────────────┐              ┌────────────────────────────┐
+   │ tracks WHERE attempted │              │ artists WHERE attempted      │
+   │   IS NULL (batched)    │   harvest    │   IS NULL (batched)          │
+   │ mapper.lookup_recordings│  artist_mbid │ 1. harvested[artist_id]?     │
+   │  → gate on artist name │ ───────────► │    → trust (already gated)   │
+   │  → write recording mbid│              │ 2. else search_artists +gate │
+   └───────────────────────┘              └────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import sqlalchemy as sa
+import sqlalchemy.orm as orm
+import structlog
+
+import resonance.config as config_module
+import resonance.connectors.listenbrainz as listenbrainz_module
+import resonance.models.music as music_module
+import resonance.normalize as normalize_module
+import resonance.services.artist_utils as artist_utils
+import resonance.services.mbid_mapper as mapper_module
+import resonance.types as types_module
+
+if TYPE_CHECKING:
+    import uuid
+
+logger = structlog.get_logger()
+
+
+@dataclasses.dataclass
+class BackfillCounts:
+    """Per-entity-type outcome tally for one backfill pass."""
+
+    matched: int = 0
+    no_match: int = 0
+    below_similarity: int = 0
+    conflict: int = 0
+    collision: int = 0
+    transient: int = 0
+
+    @property
+    def attempted(self) -> int:
+        """Rows whose outcome was recorded (everything except transient)."""
+        return (
+            self.matched
+            + self.no_match
+            + self.below_similarity
+            + self.conflict
+            + self.collision
+        )
+
+
+@dataclasses.dataclass
+class Resolution:
+    """A candidate resolution for one entity.
+
+    ``mbid`` None means the resolver found no match. ``transient`` True means the
+    resolver could not reach its backend for this entity (leave it unattempted).
+    ``artist_mbid`` is the harvested artist MBID from a track match (tracks only).
+    """
+
+    mbid: str | None = None
+    matched_name: str | None = None
+    artist_mbid: str | None = None
+    transient: bool = False
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _merge_mbid(service_links: dict[str, Any] | None, mbid: str) -> dict[str, Any]:
+    """Return a copy of ``service_links`` with ``musicbrainz.id`` set to ``mbid``.
+
+    Sibling keys (spotify, listenbrainz, ...) and any other musicbrainz sub-keys
+    are preserved (3A).
+    """
+    links: dict[str, Any] = dict(service_links or {})
+    existing_mb = links.get("musicbrainz")
+    mb: dict[str, Any] = dict(existing_mb) if isinstance(existing_mb, dict) else {}
+    mb["id"] = mbid
+    links["musicbrainz"] = mb
+    return links
+
+
+def _apply(
+    entity: Any,
+    library_name: str,
+    res: Resolution,
+    settings: config_module.Settings,
+    seen: dict[str, uuid.UUID],
+    counts: BackfillCounts,
+) -> None:
+    """Apply a resolution to one entity: gate, write (merge-safe), record status.
+
+    Mutates ``entity`` (``service_links``, ``mb_attempted_at``, ``mb_match_status``)
+    and ``counts``/``seen`` in place. Does not touch the DB session.
+    """
+    if res.transient:
+        counts.transient += 1
+        return  # leave mb_attempted_at NULL -> retried next run (CRITICAL)
+
+    entity.mb_attempted_at = _now()
+
+    if res.mbid is None:
+        entity.mb_match_status = types_module.MatchStatus.NO_MATCH
+        counts.no_match += 1
+        return
+
+    similarity = normalize_module.name_similarity(library_name, res.matched_name or "")
+    if similarity < settings.mbid_match_min_similarity:
+        entity.mb_match_status = types_module.MatchStatus.BELOW_SIMILARITY
+        counts.below_similarity += 1
+        logger.info(
+            "mbid_backfill_below_similarity",
+            entity_id=str(entity.id),
+            library_name=library_name,
+            matched_name=res.matched_name,
+            similarity=round(similarity, 3),
+        )
+        return
+
+    existing = artist_utils.get_mbid(entity.service_links)
+    if existing and existing != res.mbid:
+        # Never overwrite a different existing MBID (3A).
+        entity.mb_match_status = types_module.MatchStatus.MATCHED
+        counts.conflict += 1
+        logger.warning(
+            "mbid_backfill_conflict",
+            entity_id=str(entity.id),
+            existing_mbid=existing,
+            proposed_mbid=res.mbid,
+        )
+        return
+
+    claimer = seen.get(res.mbid)
+    if claimer is not None and claimer != entity.id:
+        # Another row this run already claimed this MBID — a duplicate (T5-A).
+        entity.mb_match_status = types_module.MatchStatus.MATCHED
+        counts.collision += 1
+        logger.info(
+            "mbid_backfill_collision",
+            mbid=res.mbid,
+            first_entity_id=str(claimer),
+            duplicate_entity_id=str(entity.id),
+        )
+        return  # skip the write; dedup merges these later
+
+    entity.service_links = _merge_mbid(entity.service_links, res.mbid)
+    entity.mb_match_status = types_module.MatchStatus.MATCHED
+    seen[res.mbid] = entity.id
+    counts.matched += 1
+
+
+# Transient errors from the MB /ws/2 search (after the connector exhausts its own
+# retries) — treat as "not attempted" for the artist rather than a false no_match.
+_SEARCH_TRANSIENT_ERRORS = (httpx.HTTPError,)
+
+
+async def backfill_tracks(
+    session: Any,
+    settings: config_module.Settings,
+    mapper: mapper_module.MbidMapperClient,
+    *,
+    harvested: dict[uuid.UUID, str],
+) -> BackfillCounts:
+    """Resolve recording MBIDs for tracks via the hosted mapper.
+
+    Gates each match on the artist name (the worst failure is a wrong-artist
+    recording). On a gated match, harvests the artist MBID into ``harvested`` for
+    the artist pass.
+    """
+    counts = BackfillCounts()
+    seen: dict[str, uuid.UUID] = {}
+    while True:
+        stmt = (
+            sa.select(music_module.Track)
+            .where(music_module.Track.mb_attempted_at.is_(None))
+            .options(orm.selectinload(music_module.Track.artist))
+            .limit(settings.mbid_mapper_batch_size)
+        )
+        tracks = list((await session.execute(stmt)).scalars().all())
+        if not tracks:
+            break
+
+        queries = [
+            mapper_module.RecordingQuery(
+                artist_name=t.artist.name, recording_name=t.title
+            )
+            for t in tracks
+        ]
+        try:
+            matches = await mapper.lookup_recordings(queries)
+        except mapper_module.MapperUnavailableError:
+            logger.warning("mbid_backfill_tracks_mapper_unavailable", batch=len(tracks))
+            counts.transient += len(tracks)
+            break  # leave the rest unattempted; retried next run
+
+        for track, match in zip(tracks, matches, strict=True):
+            res = Resolution(
+                mbid=match.recording_mbid if match else None,
+                matched_name=match.artist_credit_name if match else None,
+                artist_mbid=(
+                    match.artist_mbids[0] if match and match.artist_mbids else None
+                ),
+            )
+            _apply(track, track.artist.name, res, settings, seen, counts)
+            if (
+                track.mb_match_status == types_module.MatchStatus.MATCHED
+                and res.artist_mbid
+            ):
+                # Harvested from an artist-name-gated track match -> trustworthy.
+                harvested.setdefault(track.artist_id, res.artist_mbid)
+
+        await session.commit()
+
+    logger.info("mbid_backfill_tracks_done", **dataclasses.asdict(counts))
+    return counts
+
+
+async def backfill_artists(
+    session: Any,
+    settings: config_module.Settings,
+    connector: listenbrainz_module.ListenBrainzConnector,
+    *,
+    harvested: dict[uuid.UUID, str],
+) -> BackfillCounts:
+    """Resolve artist MBIDs: harvested-from-tracks first, then MB /ws/2 search."""
+    counts = BackfillCounts()
+    seen: dict[str, uuid.UUID] = {}
+    while True:
+        stmt = (
+            sa.select(music_module.Artist)
+            .where(music_module.Artist.mb_attempted_at.is_(None))
+            .limit(settings.mbid_mapper_batch_size)
+        )
+        artists = list((await session.execute(stmt)).scalars().all())
+        if not artists:
+            break
+
+        for artist in artists:
+            harvested_mbid = harvested.get(artist.id)
+            if harvested_mbid:
+                # Already gated during the track pass — trust it (gate passes at 1.0).
+                res = Resolution(mbid=harvested_mbid, matched_name=artist.name)
+                _apply(artist, artist.name, res, settings, seen, counts)
+                continue
+
+            try:
+                results = await connector.search_artists(artist.name, limit=1)
+            except _SEARCH_TRANSIENT_ERRORS as exc:
+                logger.warning(
+                    "mbid_backfill_artist_search_unavailable",
+                    artist_id=str(artist.id),
+                    error=type(exc).__name__,
+                )
+                _apply(
+                    artist,
+                    artist.name,
+                    Resolution(transient=True),
+                    settings,
+                    seen,
+                    counts,
+                )
+                continue
+
+            top = results[0] if results else None
+            res = Resolution(
+                mbid=top.get("mbid") if top else None,
+                matched_name=top.get("name") if top else None,
+            )
+            _apply(artist, artist.name, res, settings, seen, counts)
+
+        await session.commit()
+
+    logger.info("mbid_backfill_artists_done", **dataclasses.asdict(counts))
+    return counts
+
+
+async def run_mbid_backfill(
+    session: Any,
+    settings: config_module.Settings,
+    *,
+    mapper: mapper_module.MbidMapperClient,
+    connector: listenbrainz_module.ListenBrainzConnector,
+    do_tracks: bool = True,
+    do_artists: bool = True,
+) -> dict[str, BackfillCounts]:
+    """Run the track and artist backfill passes (tracks first, to harvest).
+
+    Returns per-entity-type counts: ``{"track": ..., "artist": ...}`` (only the
+    passes that ran are present).
+    """
+    harvested: dict[uuid.UUID, str] = {}
+    out: dict[str, BackfillCounts] = {}
+    if do_tracks:
+        out["track"] = await backfill_tracks(
+            session, settings, mapper, harvested=harvested
+        )
+    if do_artists:
+        out["artist"] = await backfill_artists(
+            session, settings, connector, harvested=harvested
+        )
+    return out

--- a/src/resonance/types.py
+++ b/src/resonance/types.py
@@ -63,6 +63,7 @@ class TaskType(enum.StrEnum):
     CONCERT_ARCHIVES_IMPORT = "concert_archives_import"
     CONCERT_ARCHIVES_CHUNK = "concert_archives_chunk"
     PLAYLIST_EXPORT = "playlist_export"
+    MBID_BACKFILL = "mbid_backfill"
 
 
 class SyncStatus(enum.StrEnum):
@@ -124,3 +125,22 @@ class TrackSource(enum.StrEnum):
     LIBRARY = "library"
     DISCOVERY = "discovery"
     MANUAL = "manual"
+
+
+class MatchStatus(enum.StrEnum):
+    """Outcome of a MusicBrainz MBID backfill attempt for an artist or track.
+
+    Stored in Artist/Track.mb_match_status. A NULL column (no member) means the
+    entity has not been attempted yet (resume key). MATCHED means an MBID was
+    written; NO_MATCH means the mapper returned nothing; BELOW_SIMILARITY means a
+    candidate was returned but rejected by the name-similarity gate. Transient
+    errors leave mb_attempted_at / mb_match_status NULL so they are retried.
+
+    Note: SQLAlchemy stores the enum .name (UPPERCASE) in the column, so DB-level
+    CHECK constraints and raw SQL must use 'MATCHED' / 'NO_MATCH' /
+    'BELOW_SIMILARITY', not the lowercase values.
+    """
+
+    MATCHED = "matched"
+    NO_MATCH = "no_match"
+    BELOW_SIMILARITY = "below_similarity"

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import datetime
 import traceback
 import typing
@@ -47,6 +48,8 @@ import resonance.models.task as task_module
 import resonance.models.taste as taste_models
 import resonance.models.user as user_models
 import resonance.services.artist_utils as artist_utils
+import resonance.services.mbid_mapper as mbid_mapper_module
+import resonance.sync.backfill as backfill_module
 import resonance.sync.base as sync_base
 import resonance.sync.lastfm as lastfm_sync
 import resonance.sync.lifecycle as lifecycle_module
@@ -96,6 +99,10 @@ _TASK_DISPATCH: dict[
     ),
     types_module.TaskType.PLAYLIST_EXPORT: (
         "export_playlist",
+        lambda t: (str(t.id),),
+    ),
+    types_module.TaskType.MBID_BACKFILL: (
+        "backfill_mbids",
         lambda t: (str(t.id),),
     ),
 }
@@ -498,6 +505,119 @@ async def run_bulk_job(ctx: dict[str, Any], task_id: str) -> None:
             if task is not None:
                 await lifecycle_module.fail_task(session, task, traceback.format_exc())
                 await session.commit()
+
+
+async def backfill_mbids(ctx: dict[str, Any], task_id: str) -> None:
+    """Execute an MBID_BACKFILL task (#71): resolve missing MusicBrainz IDs.
+
+    Reads ``params``:
+      - ``entity_types``: subset of ["track", "artist"] (default both).
+      - ``retry``: if true, first clear prior NO_MATCH/BELOW_SIMILARITY markers so
+        those rows are re-attempted (transient rows are already unattempted).
+
+    Runs tracks-first (to harvest artist_mbids) then artists via
+    ``backfill.run_mbid_backfill``, recording per-entity-type counts in the task
+    result. Long-running but resumable (``mb_attempted_at``), so a worker restart
+    re-enters and continues from the unattempted remainder.
+
+    Args:
+        ctx: arq worker context dict.
+        task_id: UUID string of the MBID_BACKFILL Task.
+    """
+    wctx = typing.cast("WorkerContext", ctx)
+    settings = wctx["settings"]
+    session_factory = wctx["session_factory"]
+    log = logger.bind(task_id=task_id)
+
+    connector = wctx["connector_registry"].get_base_connector(
+        types_module.ServiceType.LISTENBRAINZ
+    )
+    mapper = mbid_mapper_module.MbidMapperClient(settings)
+
+    async with session_factory() as session:
+        task: task_module.Task | None = None
+        try:
+            task = await _load_task(session, task_id)
+            if task is None:
+                log.error("mbid_backfill_task_not_found")
+                return
+
+            if await lifecycle_module.is_cancelled(session, task):
+                await lifecycle_module.fail_task(
+                    session, task, "Parent task was cancelled"
+                )
+                await session.commit()
+                return
+
+            if not isinstance(connector, listenbrainz_module.ListenBrainzConnector):
+                await lifecycle_module.fail_task(
+                    session,
+                    task,
+                    "ListenBrainz connector unavailable for MBID backfill",
+                )
+                await session.commit()
+                log.error("mbid_backfill_no_connector")
+                return
+
+            task.status = types_module.SyncStatus.RUNNING
+            task.started_at = datetime.datetime.now(datetime.UTC)
+            await session.commit()
+
+            params = task.params or {}
+            raw_types = params.get("entity_types")
+            entity_types = (
+                raw_types if isinstance(raw_types, list) else ["track", "artist"]
+            )
+            do_tracks = "track" in entity_types
+            do_artists = "artist" in entity_types
+            retry = bool(params.get("retry", False))
+
+            if retry:
+                # Re-attempt prior misses (transient rows are already unattempted).
+                # Unrolled per model so the column types stay concrete for mypy.
+                reattempt = [
+                    types_module.MatchStatus.NO_MATCH,
+                    types_module.MatchStatus.BELOW_SIMILARITY,
+                ]
+                await session.execute(
+                    sa.update(music_models.Track)
+                    .where(music_models.Track.mb_match_status.in_(reattempt))
+                    .values(mb_attempted_at=None, mb_match_status=None)
+                )
+                await session.execute(
+                    sa.update(music_models.Artist)
+                    .where(music_models.Artist.mb_match_status.in_(reattempt))
+                    .values(mb_attempted_at=None, mb_match_status=None)
+                )
+                await session.commit()
+
+            log.info(
+                "mbid_backfill_started",
+                do_tracks=do_tracks,
+                do_artists=do_artists,
+                retry=retry,
+            )
+            counts = await backfill_module.run_mbid_backfill(
+                session,
+                settings,
+                mapper=mapper,
+                connector=connector,
+                do_tracks=do_tracks,
+                do_artists=do_artists,
+            )
+            result: dict[str, object] = {
+                etype: dataclasses.asdict(c) for etype, c in counts.items()
+            }
+            await lifecycle_module.complete_task(session, task, result)
+            await session.commit()
+            log.info("mbid_backfill_done", result=result)
+        except Exception:
+            log.exception("mbid_backfill_failed")
+            if task is not None:
+                await lifecycle_module.fail_task(session, task, traceback.format_exc())
+                await session.commit()
+        finally:
+            await mapper.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -2094,6 +2214,7 @@ class WorkerSettings:
             heartbeat_module.with_heartbeat(score_and_build_playlist), timeout=600
         ),
         arq.func(heartbeat_module.with_heartbeat(export_playlist), timeout=600),
+        arq.func(heartbeat_module.with_heartbeat(backfill_mbids), timeout=3600),
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -565,3 +565,64 @@ class TestAdminDedup:
         assert "task_id" in data
         assert data["status"] == "started"
         assert len(db_session._added) == 1
+
+
+class TestAdminBackfillMbids:
+    """Tests for the MBID backfill admin endpoints (#71)."""
+
+    async def test_enqueues_with_retry_param(self) -> None:
+        db_session = FakeAsyncSession()
+        application = _make_bearer_app(db_session=db_session)
+        fake_arq = MagicMock()
+        fake_arq.enqueue_job = AsyncMock()
+        application.state.arq_redis = fake_arq
+
+        transport = httpx.ASGITransport(app=application)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.post(
+                "/api/v1/admin/backfill-mbids?retry=true",
+                headers={"Authorization": "Bearer test-admin-token"},
+            )
+        assert response.status_code == 200
+        assert response.json()["status"] == "started"
+        assert len(db_session._added) == 1
+        task = db_session._added[0]
+        assert task.task_type == types_module.TaskType.MBID_BACKFILL
+        assert task.params.get("retry") is True
+        fake_arq.enqueue_job.assert_awaited_once()
+
+    async def test_entity_types_param(self) -> None:
+        db_session = FakeAsyncSession()
+        application = _make_bearer_app(db_session=db_session)
+        application.state.arq_redis = MagicMock(enqueue_job=AsyncMock())
+
+        transport = httpx.ASGITransport(app=application)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.post(
+                "/api/v1/admin/backfill-mbids?entity_types=track",
+                headers={"Authorization": "Bearer test-admin-token"},
+            )
+        assert response.status_code == 200
+        assert db_session._added[0].params.get("entity_types") == ["track"]
+
+    async def test_coverage_report(self) -> None:
+        db_session = FakeAsyncSession()
+        db_session.set_execute_results(
+            [
+                FakeResult([(types_module.MatchStatus.MATCHED, 5), (None, 10)]),
+                FakeResult([(types_module.MatchStatus.NO_MATCH, 2)]),
+            ]
+        )
+        application = _make_bearer_app(db_session=db_session)
+
+        transport = httpx.ASGITransport(app=application)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.get(
+                "/api/v1/admin/backfill-mbids",
+                headers={"Authorization": "Bearer test-admin-token"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["track"]["by_status"]["matched"] == 5
+        assert data["track"]["by_status"]["unattempted"] == 10
+        assert data["artist"]["by_status"]["no_match"] == 2

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,330 @@
+"""Tests for the MBID backfill core (#71)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import resonance.config as config_module
+import resonance.services.mbid_mapper as mapper_module
+import resonance.sync.backfill as backfill_module
+import resonance.types as types_module
+
+
+def _settings() -> config_module.Settings:
+    return config_module.Settings(
+        mbid_match_min_similarity=0.85, mbid_mapper_batch_size=50
+    )
+
+
+def _entity(**overrides: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "service_links": None,
+        "mb_attempted_at": None,
+        "mb_match_status": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class FakeResult:
+    """Mimics session.execute(...).scalars().all()."""
+
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def scalars(self) -> FakeResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return self._items
+
+
+def _session(batches: list[list[Any]]) -> AsyncMock:
+    """An AsyncMock session whose execute yields each batch then is consumed."""
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[FakeResult(b) for b in batches])
+    session.commit = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _apply — the shared engine (pure, no session)
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def _run(
+        self,
+        entity: SimpleNamespace,
+        res: backfill_module.Resolution,
+        *,
+        library_name: str = "Portishead",
+        seen: dict[str, uuid.UUID] | None = None,
+    ) -> backfill_module.BackfillCounts:
+        counts = backfill_module.BackfillCounts()
+        backfill_module._apply(
+            entity,
+            library_name,
+            res,
+            _settings(),
+            seen if seen is not None else {},
+            counts,
+        )
+        return counts
+
+    def test_matched_writes_mbid_and_preserves_siblings(self) -> None:
+        entity = _entity(service_links={"spotify": {"id": "abc"}})
+        counts = self._run(
+            entity,
+            backfill_module.Resolution(mbid="MB-1", matched_name="Portishead"),
+        )
+        assert entity.service_links["musicbrainz"]["id"] == "MB-1"
+        assert entity.service_links["spotify"] == {"id": "abc"}  # preserved
+        assert entity.mb_match_status == types_module.MatchStatus.MATCHED
+        assert entity.mb_attempted_at is not None
+        assert counts.matched == 1
+
+    def test_no_match_records_status_no_write(self) -> None:
+        entity = _entity()
+        counts = self._run(entity, backfill_module.Resolution(mbid=None))
+        assert entity.service_links is None
+        assert entity.mb_match_status == types_module.MatchStatus.NO_MATCH
+        assert entity.mb_attempted_at is not None
+        assert counts.no_match == 1
+
+    def test_below_similarity_no_write(self) -> None:
+        entity = _entity()
+        counts = self._run(
+            entity,
+            backfill_module.Resolution(
+                mbid="MB-1", matched_name="Completely Different"
+            ),
+        )
+        assert entity.service_links is None
+        assert entity.mb_match_status == types_module.MatchStatus.BELOW_SIMILARITY
+        assert counts.below_similarity == 1
+
+    def test_transient_leaves_unattempted(self) -> None:
+        entity = _entity()
+        counts = self._run(entity, backfill_module.Resolution(transient=True))
+        assert entity.mb_attempted_at is None  # CRITICAL: retried next run
+        assert entity.mb_match_status is None
+        assert counts.transient == 1
+
+    def test_conflict_keeps_existing_mbid(self) -> None:
+        entity = _entity(service_links={"musicbrainz": {"id": "OLD"}})
+        counts = self._run(
+            entity,
+            backfill_module.Resolution(mbid="NEW", matched_name="Portishead"),
+        )
+        assert entity.service_links["musicbrainz"]["id"] == "OLD"  # not overwritten
+        assert counts.conflict == 1
+        assert entity.mb_match_status == types_module.MatchStatus.MATCHED
+
+    def test_existing_same_mbid_is_idempotent_match(self) -> None:
+        entity = _entity(service_links={"musicbrainz": {"id": "MB-1"}})
+        counts = self._run(
+            entity, backfill_module.Resolution(mbid="MB-1", matched_name="Portishead")
+        )
+        assert counts.matched == 1
+        assert counts.conflict == 0
+
+    def test_collision_skips_second_write(self) -> None:
+        first_id = uuid.uuid4()
+        seen: dict[str, uuid.UUID] = {"MB-1": first_id}
+        entity = _entity()  # different id
+        counts = self._run(
+            entity,
+            backfill_module.Resolution(mbid="MB-1", matched_name="Portishead"),
+            seen=seen,
+        )
+        assert entity.service_links is None  # write skipped (T5-A)
+        assert counts.collision == 1
+        assert entity.mb_attempted_at is not None
+
+    def test_first_claim_records_in_seen(self) -> None:
+        seen: dict[str, uuid.UUID] = {}
+        entity = _entity()
+        self._run(
+            entity,
+            backfill_module.Resolution(mbid="MB-1", matched_name="Portishead"),
+            seen=seen,
+        )
+        assert seen["MB-1"] == entity.id
+
+
+# ---------------------------------------------------------------------------
+# backfill_tracks
+# ---------------------------------------------------------------------------
+
+
+def _track(
+    title: str, artist_name: str, artist_id: uuid.UUID | None = None
+) -> SimpleNamespace:
+    return _entity(
+        title=title,
+        artist_id=artist_id or uuid.uuid4(),
+        artist=SimpleNamespace(name=artist_name),
+    )
+
+
+def _match(
+    recording_mbid: str, artist_credit_name: str, artist_mbids: list[str]
+) -> mapper_module.RecordingMatch:
+    return mapper_module.RecordingMatch(
+        recording_mbid=recording_mbid,
+        artist_credit_name=artist_credit_name,
+        artist_mbids=artist_mbids,
+    )
+
+
+class TestBackfillTracks:
+    @pytest.mark.anyio()
+    async def test_match_writes_and_harvests_artist_mbid(self) -> None:
+        artist_id = uuid.uuid4()
+        track = _track("Glory Box", "Portishead", artist_id)
+        session = _session([[track], []])
+        mapper = AsyncMock()
+        mapper.lookup_recordings = AsyncMock(
+            return_value=[_match("REC-1", "Portishead", ["ART-1"])]
+        )
+        harvested: dict[uuid.UUID, str] = {}
+
+        counts = await backfill_module.backfill_tracks(
+            session, _settings(), mapper, harvested=harvested
+        )
+
+        assert track.service_links["musicbrainz"]["id"] == "REC-1"
+        assert harvested[artist_id] == "ART-1"  # harvested for the artist pass
+        assert counts.matched == 1
+        session.commit.assert_awaited()
+
+    @pytest.mark.anyio()
+    async def test_wrong_artist_match_is_below_similarity_no_harvest(self) -> None:
+        artist_id = uuid.uuid4()
+        track = _track("Glory Box", "Portishead", artist_id)
+        session = _session([[track], []])
+        mapper = AsyncMock()
+        mapper.lookup_recordings = AsyncMock(
+            return_value=[_match("REC-X", "Some Other Band", ["ART-X"])]
+        )
+        harvested: dict[uuid.UUID, str] = {}
+
+        counts = await backfill_module.backfill_tracks(
+            session, _settings(), mapper, harvested=harvested
+        )
+
+        assert track.mb_match_status == types_module.MatchStatus.BELOW_SIMILARITY
+        assert artist_id not in harvested  # nothing harvested from a rejected match
+        assert counts.below_similarity == 1
+
+    @pytest.mark.anyio()
+    async def test_mapper_unavailable_leaves_unattempted(self) -> None:
+        track = _track("Glory Box", "Portishead")
+        session = _session([[track], []])
+        mapper = AsyncMock()
+        mapper.lookup_recordings = AsyncMock(
+            side_effect=mapper_module.MapperUnavailableError("down")
+        )
+        counts = await backfill_module.backfill_tracks(
+            session, _settings(), mapper, harvested={}
+        )
+        assert track.mb_attempted_at is None  # CRITICAL
+        assert counts.transient == 1
+        session.commit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# backfill_artists
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillArtists:
+    @pytest.mark.anyio()
+    async def test_harvested_path_skips_search(self) -> None:
+        artist = _entity(name="Portishead")
+        session = _session([[artist], []])
+        connector = AsyncMock()
+        connector.search_artists = AsyncMock()
+        harvested = {artist.id: "ART-1"}
+
+        counts = await backfill_module.backfill_artists(
+            session, _settings(), connector, harvested=harvested
+        )
+
+        assert artist.service_links["musicbrainz"]["id"] == "ART-1"
+        connector.search_artists.assert_not_awaited()
+        assert counts.matched == 1
+
+    @pytest.mark.anyio()
+    async def test_search_fallback_matches(self) -> None:
+        artist = _entity(name="Portishead")
+        session = _session([[artist], []])
+        connector = AsyncMock()
+        connector.search_artists = AsyncMock(
+            return_value=[{"mbid": "ART-2", "name": "Portishead"}]
+        )
+        counts = await backfill_module.backfill_artists(
+            session, _settings(), connector, harvested={}
+        )
+        assert artist.service_links["musicbrainz"]["id"] == "ART-2"
+        assert counts.matched == 1
+
+    @pytest.mark.anyio()
+    async def test_search_no_results_is_no_match(self) -> None:
+        artist = _entity(name="Obscure Local Band")
+        session = _session([[artist], []])
+        connector = AsyncMock()
+        connector.search_artists = AsyncMock(return_value=[])
+        counts = await backfill_module.backfill_artists(
+            session, _settings(), connector, harvested={}
+        )
+        assert artist.mb_match_status == types_module.MatchStatus.NO_MATCH
+        assert counts.no_match == 1
+
+    @pytest.mark.anyio()
+    async def test_search_transient_leaves_unattempted(self) -> None:
+        import httpx
+
+        artist = _entity(name="Portishead")
+        session = _session([[artist], []])
+        connector = AsyncMock()
+        connector.search_artists = AsyncMock(side_effect=httpx.ConnectError("down"))
+        counts = await backfill_module.backfill_artists(
+            session, _settings(), connector, harvested={}
+        )
+        assert artist.mb_attempted_at is None  # CRITICAL
+        assert counts.transient == 1
+
+
+class TestRunMbidBackfill:
+    @pytest.mark.anyio()
+    async def test_tracks_then_artists_harvest_flows(self) -> None:
+        artist_id = uuid.uuid4()
+        track = _track("Glory Box", "Portishead", artist_id)
+        artist = _entity(id=artist_id, name="Portishead")
+        # execute order: tracks batch, tracks empty, artists batch, artists empty
+        session = _session([[track], [], [artist], []])
+        mapper = AsyncMock()
+        mapper.lookup_recordings = AsyncMock(
+            return_value=[_match("REC-1", "Portishead", ["ART-1"])]
+        )
+        connector = AsyncMock()
+        connector.search_artists = AsyncMock()
+
+        out = await backfill_module.run_mbid_backfill(
+            session, _settings(), mapper=mapper, connector=connector
+        )
+
+        assert track.service_links["musicbrainz"]["id"] == "REC-1"
+        # artist filled from harvest, no search call
+        assert artist.service_links["musicbrainz"]["id"] == "ART-1"
+        connector.search_artists.assert_not_awaited()
+        assert out["track"].matched == 1
+        assert out["artist"].matched == 1

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -362,3 +362,64 @@ class TestApiCommandRegistration:
 
     def test_api_in_usage_text(self) -> None:
         assert "api" in cli_module._USAGE
+
+
+class TestBackfillMbidsCommand:
+    """Tests for `resonance-api backfill-mbids` (#71)."""
+
+    def test_registered(self) -> None:
+        assert "backfill-mbids" in cli_module._COMMANDS
+
+    def test_status_does_get(
+        self, monkeypatch: pytest.MonkeyPatch, _mock_config: None
+    ) -> None:
+        monkeypatch.setattr(
+            sys, "argv", ["resonance-api", "backfill-mbids", "--status"]
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_req(method: str, path: str, **_: Any) -> httpx.Response:
+            captured["method"], captured["path"] = method, path
+            return _fake_response(json_body={"track": {"by_status": {"matched": 5}}})
+
+        monkeypatch.setattr(cli_module, "_api_request", fake_req)
+        cli_module._cmd_backfill_mbids()
+        assert captured["method"] == "GET"
+        assert captured["path"] == "/api/v1/admin/backfill-mbids"
+
+    def test_retry_no_wait_posts_with_query(
+        self, monkeypatch: pytest.MonkeyPatch, _mock_config: None
+    ) -> None:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["resonance-api", "backfill-mbids", "--retry", "--no-wait"],
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_req(method: str, path: str, **_: Any) -> httpx.Response:
+            captured["method"], captured["path"] = method, path
+            return _fake_response(json_body={"task_id": "T1", "status": "started"})
+
+        monkeypatch.setattr(cli_module, "_api_request", fake_req)
+        cli_module._cmd_backfill_mbids()
+        assert captured["method"] == "POST"
+        assert "retry=true" in captured["path"]
+
+    def test_tracks_only_sets_entity_types(
+        self, monkeypatch: pytest.MonkeyPatch, _mock_config: None
+    ) -> None:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["resonance-api", "backfill-mbids", "--tracks", "--no-wait"],
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_req(method: str, path: str, **_: Any) -> httpx.Response:
+            captured["path"] = path
+            return _fake_response(json_body={"task_id": "T1", "status": "started"})
+
+        monkeypatch.setattr(cli_module, "_api_request", fake_req)
+        cli_module._cmd_backfill_mbids()
+        assert "entity_types=track" in captured["path"]

--- a/tests/test_mbid_mapper.py
+++ b/tests/test_mbid_mapper.py
@@ -1,0 +1,210 @@
+"""Tests for the MusicBrainz MBID mapper client (#71)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+import resonance.config as config_module
+import resonance.services.mbid_mapper as mapper_module
+
+_MATCH = {
+    "recording_mbid": "8f3471b5-7e6a-48da-86a9-c1c07a0f47ae",
+    "artist_mbids": ["db92a151-1ac2-438b-bc43-b82e149ddd50"],
+    "artist_credit_name": "Rick Astley",
+    "recording_name": "Never Gonna Give You Up",
+    "release_mbid": "18550a84-4ede-451c-a91a-dd9b3af9f71d",
+    "release_name": "Red Hot",
+}
+_MISS = {
+    "recording_mbid": None,
+    "artist_credit_name": None,
+    "recording_name": None,
+}
+
+
+def _make_settings(batch_size: int = 50) -> config_module.Settings:
+    return config_module.Settings(
+        lb_user_token="test-token", mbid_mapper_batch_size=batch_size
+    )
+
+
+def _client_with_handler(
+    handler: Any, *, batch_size: int = 50
+) -> mapper_module.MbidMapperClient:
+    client = mapper_module.MbidMapperClient(_make_settings(batch_size))
+    client._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _q(
+    artist: str, recording: str, release: str | None = None
+) -> mapper_module.RecordingQuery:
+    return mapper_module.RecordingQuery(
+        artist_name=artist, recording_name=recording, release_name=release
+    )
+
+
+class TestLookupRecordings:
+    @pytest.mark.anyio()
+    async def test_empty_queries_returns_empty(self) -> None:
+        client = _client_with_handler(lambda req: httpx.Response(200, json=[]))
+        assert await client.lookup_recordings([]) == []
+
+    @pytest.mark.anyio()
+    async def test_match_and_miss_aligned_by_index(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[_MATCH, _MISS])
+
+        client = _client_with_handler(handler)
+        results = await client.lookup_recordings(
+            [_q("Rick Astley", "Never Gonna Give You Up"), _q("Zzqq", "Fake")]
+        )
+        assert results[0] is not None
+        assert results[0].recording_mbid == _MATCH["recording_mbid"]
+        assert results[0].artist_mbids == _MATCH["artist_mbids"]
+        assert results[0].artist_credit_name == "Rick Astley"
+        assert results[1] is None
+
+    @pytest.mark.anyio()
+    async def test_auth_header_and_payload(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["auth"] = request.headers.get("Authorization")
+            import json
+
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=[_MATCH])
+
+        client = _client_with_handler(handler)
+        await client.lookup_recordings(
+            [_q("Rick Astley", "Never Gonna Give You Up", release="Red Hot")]
+        )
+        assert captured["auth"] == "Token test-token"
+        assert captured["body"] == {
+            "recordings": [
+                {
+                    "artist_name": "Rick Astley",
+                    "recording_name": "Never Gonna Give You Up",
+                    "release_name": "Red Hot",
+                }
+            ]
+        }
+
+    @pytest.mark.anyio()
+    async def test_release_name_omitted_when_absent(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=[_MISS])
+
+        client = _client_with_handler(handler)
+        await client.lookup_recordings([_q("A", "B")])
+        assert "release_name" not in captured["body"]["recordings"][0]
+
+    @pytest.mark.anyio()
+    async def test_chunking_splits_requests_and_preserves_order(self) -> None:
+        calls: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content)
+            n = len(body["recordings"])
+            calls.append(n)
+            # Echo a distinct match per item so order can be verified.
+            resp = [
+                {**_MATCH, "recording_name": rec["recording_name"]}
+                for rec in body["recordings"]
+            ]
+            return httpx.Response(200, json=resp)
+
+        client = _client_with_handler(handler, batch_size=2)
+        queries = [_q("Artist", f"T{i}") for i in range(5)]
+        results = await client.lookup_recordings(queries)
+        assert calls == [2, 2, 1]  # 5 items in chunks of 2
+        assert [r.recording_name for r in results if r] == [f"T{i}" for i in range(5)]
+
+
+class TestRetryAndErrors:
+    @pytest.mark.anyio()
+    async def test_429_then_success(self) -> None:
+        state = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            state["n"] += 1
+            if state["n"] == 1:
+                return httpx.Response(429)
+            return httpx.Response(200, json=[_MATCH])
+
+        client = _client_with_handler(handler)
+        with patch.object(mapper_module.asyncio, "sleep", new_callable=AsyncMock):
+            results = await client.lookup_recordings([_q("Rick Astley", "NGGYU")])
+        assert state["n"] == 2
+        assert results[0] is not None
+
+    @pytest.mark.anyio()
+    async def test_429_exhausted_raises_unavailable(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429)
+
+        client = _client_with_handler(handler)
+        with (
+            patch.object(mapper_module.asyncio, "sleep", new_callable=AsyncMock),
+            pytest.raises(mapper_module.MapperUnavailableError),
+        ):
+            await client.lookup_recordings([_q("A", "B")])
+
+    @pytest.mark.anyio()
+    async def test_5xx_then_success(self) -> None:
+        state = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            state["n"] += 1
+            if state["n"] == 1:
+                return httpx.Response(503)
+            return httpx.Response(200, json=[_MATCH])
+
+        client = _client_with_handler(handler)
+        with patch.object(mapper_module.asyncio, "sleep", new_callable=AsyncMock):
+            results = await client.lookup_recordings([_q("A", "B")])
+        assert results[0] is not None
+
+    @pytest.mark.anyio()
+    async def test_transient_error_raises_unavailable_after_retries(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+        client = _client_with_handler(handler)
+        with (
+            patch.object(mapper_module.asyncio, "sleep", new_callable=AsyncMock),
+            pytest.raises(mapper_module.MapperUnavailableError),
+        ):
+            await client.lookup_recordings([_q("A", "B")])
+
+    @pytest.mark.anyio()
+    async def test_length_mismatch_raises_unavailable(self) -> None:
+        # Two queries, but the mapper returns only one entry -> misalignment.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[_MATCH])
+
+        client = _client_with_handler(handler)
+        with pytest.raises(mapper_module.MapperUnavailableError):
+            await client.lookup_recordings([_q("A", "B"), _q("C", "D")])
+
+    @pytest.mark.anyio()
+    async def test_401_propagates_as_http_error_not_unavailable(self) -> None:
+        # A bad/expired token is a hard failure, not a per-entity transient one.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "invalid token"})
+
+        client = _client_with_handler(handler)
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.lookup_recordings([_q("A", "B")])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,7 @@ class TestTaskType:
         assert types_module.TaskType.CALENDAR_SYNC == "calendar_sync"
 
     def test_task_type_count(self) -> None:
-        assert len(types_module.TaskType) == 11
+        assert len(types_module.TaskType) == 12
 
 
 class TestAttendanceStatus:
@@ -124,6 +124,26 @@ class TestCandidateStatus:
 
     def test_candidate_status_count(self) -> None:
         assert len(types_module.CandidateStatus) == 4
+
+
+class TestMatchStatus:
+    """Verify MatchStatus enum values (MBID backfill outcomes, #71)."""
+
+    def test_values(self) -> None:
+        assert types_module.MatchStatus.MATCHED == "matched"
+        assert types_module.MatchStatus.NO_MATCH == "no_match"
+        assert types_module.MatchStatus.BELOW_SIMILARITY == "below_similarity"
+
+    def test_match_status_count(self) -> None:
+        assert len(types_module.MatchStatus) == 3
+
+    def test_names_are_uppercase_for_db_storage(self) -> None:
+        # SQLAlchemy stores the .name; the migration CHECK depends on these.
+        assert {m.name for m in types_module.MatchStatus} == {
+            "MATCHED",
+            "NO_MATCH",
+            "BELOW_SIMILARITY",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -335,9 +355,20 @@ class TestArtistModel:
             "id",
             "name",
             "service_links",
+            "mb_attempted_at",
+            "mb_match_status",
             "created_at",
             "updated_at",
         }
+
+    def test_mb_match_status_is_enum(self) -> None:
+        col = _get_column(music_module.Artist.__table__, "mb_match_status")  # type: ignore[arg-type]
+        assert isinstance(col.type, sa.Enum)
+        assert col.nullable is True
+
+    def test_mb_attempted_at_nullable(self) -> None:
+        col = _get_column(music_module.Artist.__table__, "mb_attempted_at")  # type: ignore[arg-type]
+        assert col.nullable is True
 
     def test_tracks_relationship(self) -> None:
         mapper: orm.Mapper[music_module.Artist] = orm.class_mapper(music_module.Artist)
@@ -358,9 +389,16 @@ class TestTrackModel:
             "title",
             "artist_id",
             "service_links",
+            "mb_attempted_at",
+            "mb_match_status",
             "created_at",
             "updated_at",
         }
+
+    def test_mb_match_status_is_enum(self) -> None:
+        col = _get_column(music_module.Track.__table__, "mb_match_status")  # type: ignore[arg-type]
+        assert isinstance(col.type, sa.Enum)
+        assert col.nullable is True
 
     def test_artist_fk(self) -> None:
         col = _get_column(music_module.Track.__table__, "artist_id")  # type: ignore[arg-type]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -93,6 +93,32 @@ class TestNamesMatch:
         assert not normalize_module.names_match("", "Iron Maiden")
 
 
+class TestNameSimilarity:
+    def test_identical_normalized_is_one(self) -> None:
+        assert normalize_module.name_similarity("Iron Maiden", "iron maiden") == 1.0
+
+    def test_diacritics_and_quotes_are_one(self) -> None:
+        # Same normalization as names_match -> ratio 1.0.
+        assert normalize_module.name_similarity("Motörhead", "Motorhead") == 1.0
+        assert normalize_module.name_similarity("KK’s Priest", "KK's Priest") == 1.0
+
+    def test_punctuation_variant_scores_between_exact_and_different(self) -> None:
+        # "Jay-Z" vs "Jay Z" fails exact names_match but scores ~0.8 here —
+        # higher than a different artist, yet below the conservative 0.85
+        # default gate (so it would land as below_similarity). The coverage
+        # gate (T3-A) exists to reveal whether 0.85 is too strict.
+        assert not normalize_module.names_match("Jay-Z", "Jay Z")
+        ratio = normalize_module.name_similarity("Jay-Z", "Jay Z")
+        assert 0.75 <= ratio < 0.85
+
+    def test_different_names_score_low(self) -> None:
+        assert normalize_module.name_similarity("Iron Maiden", "Judas Priest") < 0.5
+
+    def test_range_is_zero_to_one(self) -> None:
+        assert normalize_module.name_similarity("", "") == 1.0
+        assert normalize_module.name_similarity("abc", "") == 0.0
+
+
 class TestNormalizeState:
     def test_abbreviation_expands(self) -> None:
         assert normalize_module.normalize_state("CA") == "california"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -94,6 +94,9 @@ class TestTaskTypeNewValues:
         assert types_module.TaskType.BULK_JOB == "bulk_job"
         assert types_module.TaskType.CALENDAR_SYNC == "calendar_sync"
 
-    def test_tasktype_has_eleven_members(self) -> None:
-        """TaskType should have 11 members."""
-        assert len(types_module.TaskType) == 11
+    def test_tasktype_member_count(self) -> None:
+        """TaskType members (bump when adding a task type)."""
+        assert len(types_module.TaskType) == 12
+
+    def test_mbid_backfill_value(self) -> None:
+        assert types_module.TaskType.MBID_BACKFILL == "mbid_backfill"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -44,7 +44,7 @@ class TestWorkerSettings:
 
     def test_functions_registered(self) -> None:
         funcs = worker_module.WorkerSettings.functions
-        assert len(funcs) == 10
+        assert len(funcs) == 11
         names = {f.name for f in funcs}
         assert names == {
             "plan_sync",
@@ -57,6 +57,7 @@ class TestWorkerSettings:
             "discover_tracks_for_artist",
             "score_and_build_playlist",
             "export_playlist",
+            "backfill_mbids",
         }
 
     def test_lifecycle_hooks(self) -> None:

--- a/tests/test_worker_backfill.py
+++ b/tests/test_worker_backfill.py
@@ -1,0 +1,147 @@
+"""Tests for the MBID backfill worker task (#71 T4)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import resonance.config as config_module
+import resonance.connectors.listenbrainz as listenbrainz_module
+import resonance.sync.backfill as backfill_module
+import resonance.types as types_module
+import resonance.worker as worker_module
+
+
+def _mock_session_factory(session: AsyncMock) -> MagicMock:
+    ctx_manager = AsyncMock()
+    ctx_manager.__aenter__.return_value = session
+    ctx_manager.__aexit__.return_value = False
+    factory = MagicMock()
+    factory.return_value = ctx_manager
+    return factory
+
+
+def _ctx(session: AsyncMock) -> dict[str, Any]:
+    registry = MagicMock()
+    registry.get_base_connector.return_value = MagicMock(
+        spec=listenbrainz_module.ListenBrainzConnector
+    )
+    return {
+        "session_factory": _mock_session_factory(session),
+        "connector_registry": registry,
+        "settings": config_module.Settings(),
+    }
+
+
+def _task(params: dict[str, Any] | None = None) -> MagicMock:
+    task = MagicMock()
+    task.id = uuid.uuid4()
+    task.params = params or {}
+    return task
+
+
+@pytest.mark.asyncio
+async def test_runs_both_passes_and_completes() -> None:
+    session = AsyncMock()
+    task = _task()
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_mbid_backfill",
+            AsyncMock(
+                return_value={
+                    "track": backfill_module.BackfillCounts(matched=2, no_match=1),
+                    "artist": backfill_module.BackfillCounts(matched=1),
+                }
+            ),
+        ) as run_mock,
+    ):
+        await worker_module.backfill_mbids(_ctx(session), str(task.id))
+
+    # both passes requested by default
+    _, kwargs = run_mock.call_args
+    assert kwargs["do_tracks"] is True
+    assert kwargs["do_artists"] is True
+    # result recorded by complete_task (sets status + result on the task)
+    assert task.status == types_module.SyncStatus.COMPLETED
+    assert task.result["track"]["matched"] == 2
+    assert task.result["artist"]["matched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_entity_types_param_limits_passes() -> None:
+    session = AsyncMock()
+    task = _task({"entity_types": ["track"]})
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_mbid_backfill",
+            AsyncMock(return_value={"track": backfill_module.BackfillCounts()}),
+        ) as run_mock,
+    ):
+        await worker_module.backfill_mbids(_ctx(session), str(task.id))
+
+    _, kwargs = run_mock.call_args
+    assert kwargs["do_tracks"] is True
+    assert kwargs["do_artists"] is False
+
+
+@pytest.mark.asyncio
+async def test_retry_clears_prior_markers() -> None:
+    session = AsyncMock()
+    task = _task({"retry": True})
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_mbid_backfill",
+            AsyncMock(return_value={"track": backfill_module.BackfillCounts()}),
+        ),
+    ):
+        await worker_module.backfill_mbids(_ctx(session), str(task.id))
+
+    # retry issues UPDATE statements (one per model) to clear markers
+    assert session.execute.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_missing_connector_fails_task() -> None:
+    session = AsyncMock()
+    task = _task()
+    ctx = _ctx(session)
+    ctx["connector_registry"].get_base_connector.return_value = None  # not registered
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module.backfill_module, "run_mbid_backfill", AsyncMock()
+        ) as run_mock,
+    ):
+        await worker_module.backfill_mbids(ctx, str(task.id))
+
+    run_mock.assert_not_awaited()
+    assert task.status == types_module.SyncStatus.FAILED


### PR DESCRIPTION
## Summary

Backfills `service_links["musicbrainz"]["id"]` onto library **Artists** and **Tracks** so ListenBrainz similar-artists and #79 track matching have MBIDs to work with. **Phase A is hosted-mapper-first** — resolve via MetaBrainz's hosted mapper (`/1/metadata/lookup`); the local MusicBrainz DB is deferred to a **Phase B** discovery engine (tracked in `TODOS.md`).

Relates to #71 (which was scoped as "investigate local MB database" — this implements the hosted-mapper outcome of that investigation; the local-DB path is Phase B).

<details>
<summary>How to Review</summary>

Single squashed commit; review by area:

1. **Data model** — `models/music.py` + `types.py` (`MatchStatus`) + the `e6f7g8h9i0j1` migration. Nullable `mb_attempted_at` (resume key) + `mb_match_status`. MBID still lives in `service_links`; these columns track *attempt outcome*.
2. **Mapper client** — `services/mbid_mapper.py`. Batch `/1/metadata/lookup`, token auth, `RateLimitBudget` backoff. Transient failures → `MapperUnavailableError` (so the backfill leaves rows unattempted, not a false `no_match`). Separate from the OAuth `listenbrainz` connector by design.
3. **Gate** — `normalize.name_similarity` (difflib over `normalize_name`); the mapper returns no confidence score, so writes are gated on name similarity (default 0.85, conservative).
4. **Backfill core** — `sync/backfill.py`. Shared `_apply` engine (gate → merge-safe write → conflict/collision → status). Tracks resolve via the mapper and harvest `artist_mbids`; artists use harvested MBIDs first, then MB `/ws/2` search fallback. Resumable, commit-per-batch.
5. **Worker** — `TaskType.MBID_BACKFILL` + `backfill_mbids` in `worker.py`, wired into dispatch + orphan recovery.
6. **API + CLI** — `POST`/`GET /api/v1/admin/backfill-mbids` and `resonance-api backfill-mbids`.

Reviewed via `/plan-eng-review` (8 issues + outside-voice pass). The outside voice caught that the mapper is recording-centric with no artist endpoint and no score — that reshaped the artist path (harvest-then-search) and replaced the "confidence threshold" with the similarity gate.
</details>

<details>
<summary>Test Plan</summary>

- [x] Full suite **1326 passing**; ruff + `mypy --strict` clean
- [x] Migration verified with a live `upgrade` → `downgrade` → `upgrade` round-trip against Postgres
- [x] Mapper client validated against the real endpoint (HTTP 200, returns `recording_mbid` + `artist_mbids`)
- [x] Unit tests: mapper client (batch/align/429/transient/401), backfill engine (every status branch incl. the critical transient≠no_match), worker task, admin endpoints, CLI
</details>

<details>
<summary>Impact / Not in scope</summary>

**Deploy dependency (not in this PR):** the deployed worker needs `LB_USER_TOKEN` as a k8s secret in `megadoomer-config`. Local is wired via dotfiles; prod isn't yet.

**Deferred (TODOS.md):** the local MB DB (Phase B discovery engine), and surfacing MBID collisions as merge candidates.

No behavior change until a backfill is triggered (`resonance-api backfill-mbids`).
</details>