### PR TITLE
fix: concert_prep discovery + blend-quota scoring (#110, #111, #57)

### DIFF
--- a/src/resonance/generators/concert_prep.py
+++ b/src/resonance/generators/concert_prep.py
@@ -69,9 +69,53 @@ def _score_candidate(
     return scoring_module.composite_score(
         familiarity_val=fam_val,
         popularity_val=pop_val,
-        is_target_artist=candidate.is_target_artist,
         params=params,
     )
+
+
+def _round_half_up(value: float) -> int:
+    """Round to the nearest integer, halves rounding up (not banker's rounding).
+
+    Used for slot-count math so a 3.5 quota becomes 4, predictably.
+    """
+    return int(value + 0.5)
+
+
+def _select_with_quota(
+    target_pool: list[tuple[CandidateTrack, float]],
+    adjacent_pool: list[tuple[CandidateTrack, float]],
+    similar_artist_ratio: int,
+    max_tracks: int,
+) -> list[tuple[CandidateTrack, float]]:
+    """Fill ``max_tracks`` slots, drawing ~ratio% from the adjacent pool.
+
+    Both pools must already be sorted by score descending. The adjacent quota is
+    ``round_half_up(max_tracks * ratio / 100)``; the rest go to the target pool.
+
+    When a pool cannot fill its quota, the shortfall is backfilled from the other
+    pool -- but only if the other pool was allocated at least one slot. This keeps
+    the extremes literal: at ratio=0 no adjacent track is ever added, and at
+    ratio=100 no target track is ever added (matching the design intent that 0 is
+    target-only and 100 is adjacent-only).
+    """
+    ratio = max(0, min(100, similar_artist_ratio))
+    adj_quota = _round_half_up(max_tracks * ratio / 100)
+    tgt_quota = max_tracks - adj_quota
+
+    tgt_take = target_pool[:tgt_quota]
+    adj_take = adjacent_pool[:adj_quota]
+
+    tgt_short = tgt_quota - len(tgt_take)
+    adj_short = adj_quota - len(adj_take)
+
+    # Backfill a pool's shortfall from the other pool's remainder, but only when
+    # the other pool was allocated slots (so 0/100 stay pure).
+    if tgt_short > 0 and adj_quota > 0:
+        adj_take += adjacent_pool[adj_quota : adj_quota + tgt_short]
+    if adj_short > 0 and tgt_quota > 0:
+        tgt_take += target_pool[tgt_quota : tgt_quota + adj_short]
+
+    return (tgt_take + adj_take)[:max_tracks]
 
 
 def _apply_freshness_filter(
@@ -145,10 +189,20 @@ def score_and_select(
         scored, previous_track_ids, freshness_target, max_tracks
     )
 
-    # 4. Take the top max_tracks
-    scored = scored[:max_tracks]
+    # 4. Partition into target / adjacent pools (each stays score-desc) and
+    #    select per the similar_artist_ratio blend quota.
+    target_pool = [pair for pair in scored if pair[0].is_target_artist]
+    adjacent_pool = [pair for pair in scored if not pair[0].is_target_artist]
+    selected = _select_with_quota(
+        target_pool,
+        adjacent_pool,
+        params.get("similar_artist_ratio", 0),
+        max_tracks,
+    )
 
-    # 5. Assign positions (1-indexed) and build ScoredTrack list
+    # 5. Re-sort the merged selection by score for final ordering, then assign
+    #    1-indexed positions and build the ScoredTrack list.
+    selected.sort(key=lambda pair: pair[1], reverse=True)
     tracks = [
         ScoredTrack(
             track_id=candidate.track_id,
@@ -158,7 +212,7 @@ def score_and_select(
             score=score,
             source=candidate.source,
         )
-        for i, (candidate, score) in enumerate(scored)
+        for i, (candidate, score) in enumerate(selected)
     ]
 
     # 6. Compute source summary

--- a/src/resonance/generators/scoring.py
+++ b/src/resonance/generators/scoring.py
@@ -24,23 +24,6 @@ def popularity_signal(*, popularity_score: int) -> float:
     return max(0.0, min(1.0, popularity_score / 100.0))
 
 
-def artist_relevance_signal(*, is_target_artist: bool) -> float:
-    """1.0 for target artists, 0.0 for adjacent artists."""
-    return 1.0 if is_target_artist else 0.0
-
-
-def adjacent_multiplier(*, is_target_artist: bool, similar_artist_ratio: int) -> float:
-    """Score multiplier from artist relevance, scaled by similar_artist_ratio.
-
-    Target artists always score at full weight (1.0). Adjacent artists are
-    scaled by similar_artist_ratio (a 0-100 unipolar parameter): 0 excludes
-    them entirely, 100 applies no penalty, 50 halves their score.
-    """
-    relevance = artist_relevance_signal(is_target_artist=is_target_artist)
-    ratio = max(0.0, min(1.0, similar_artist_ratio / 100.0))
-    return relevance + (1.0 - relevance) * ratio
-
-
 def bipolar_weight(param_value: int) -> float:
     """Convert a 0-100 bipolar parameter to a -1.0 to 1.0 weight.
 
@@ -53,12 +36,14 @@ def composite_score(
     *,
     familiarity_val: float,
     popularity_val: float,
-    is_target_artist: bool,
     params: dict[str, int],
 ) -> float:
-    """Compute composite score for a candidate track.
+    """Compute composite score for a candidate track from familiarity and hit_depth.
 
-    Returns a value clamped to [0.0, 1.0].
+    Returns a value clamped to [0.0, 1.0]. Artist relevance (target vs adjacent)
+    is intentionally NOT part of this score: similar_artist_ratio is applied as a
+    blend quota at selection time (see concert_prep.score_and_select), keeping
+    familiarity (within-pool rank) and similar_artist_ratio (the mix) orthogonal.
     """
     base = 0.5
 
@@ -68,9 +53,5 @@ def composite_score(
     score = base
     score += fam_weight * (familiarity_val - 0.5)
     score += hit_weight * (popularity_val - 0.5)
-    score *= adjacent_multiplier(
-        is_target_artist=is_target_artist,
-        similar_artist_ratio=params.get("similar_artist_ratio", 0),
-    )
 
     return max(0.0, min(1.0, score))

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -625,8 +625,36 @@ async def backfill_mbids(ctx: dict[str, Any], task_id: str) -> None:
 # Playlist generation pipeline
 # ---------------------------------------------------------------------------
 
-# Minimum number of library tracks per artist before skipping discovery.
+# Minimum number of distinct library tracks per artist before skipping discovery.
 _MIN_LIBRARY_TRACKS = 5
+
+# A profile with familiarity below this (0-100 bipolar; <50 leans toward
+# discovery) triggers an external catalog fetch for ALL target artists, not just
+# under-covered ones, so a well-known artist can still surface unheard tracks.
+_DISCOVERY_FAMILIARITY_THRESHOLD = 50
+
+
+def _artists_needing_discovery(
+    artist_ids: collections.abc.Iterable[uuid.UUID],
+    track_coverage: collections.abc.Mapping[uuid.UUID, int],
+    discovery_wanted: bool,
+) -> list[uuid.UUID]:
+    """Pick which artists need an external catalog fetch (TRACK_DISCOVERY).
+
+    An artist needs discovery when its distinct-track coverage is below
+    ``_MIN_LIBRARY_TRACKS`` OR the profile is leaning toward discovery
+    (``discovery_wanted``). The discovery-intent branch is what lets a
+    well-covered target artist surface unheard catalog tracks for a
+    high-discovery playlist (issue #110); without it, the candidate pool for such
+    an artist is 100% scrobble-derived and has nothing unheard to offer.
+
+    Pure logic (no DB) so the gating decision is unit-testable.
+    """
+    return [
+        aid
+        for aid in artist_ids
+        if track_coverage.get(aid, 0) < _MIN_LIBRARY_TRACKS or discovery_wanted
+    ]
 
 
 async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
@@ -731,11 +759,13 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
             )
             artists_by_id = {a.id: a for a in artists_result.scalars().all()}
 
-            # Check library coverage for all artists in a single query
-            listen_counts_result = await session.execute(
+            # Library coverage = distinct tracks per artist that the user has
+            # actually listened to (not total scrobbles). A handful of songs
+            # played many times should NOT read as broad coverage.
+            track_coverage_result = await session.execute(
                 sa.select(
                     music_models.Track.artist_id,
-                    sa.func.count(music_models.ListeningEvent.id).label("cnt"),
+                    sa.func.count(sa.distinct(music_models.Track.id)).label("cnt"),
                 )
                 .join(
                     music_models.ListeningEvent,
@@ -747,14 +777,19 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 )
                 .group_by(music_models.Track.artist_id)
             )
-            listen_counts: dict[uuid.UUID, int] = {
-                row[0]: row[1] for row in listen_counts_result.all()
+            track_coverage: dict[uuid.UUID, int] = {
+                row[0]: row[1] for row in track_coverage_result.all()
             }
-            artists_needing_discovery = [
-                aid
-                for aid in artist_ids
-                if listen_counts.get(aid, 0) < _MIN_LIBRARY_TRACKS
-            ]
+
+            # A discovery-leaning profile fetches catalog tracks for every target
+            # artist, so well-known artists also surface unheard tracks (#110).
+            gen_params = params_module.apply_defaults(dict(profile.parameter_values))
+            discovery_wanted = (
+                gen_params.get("familiarity", 50) < _DISCOVERY_FAMILIARITY_THRESHOLD
+            )
+            artists_needing_discovery = _artists_needing_discovery(
+                artist_ids, track_coverage, discovery_wanted
+            )
 
             # Create child tasks
             arq_redis = wctx["redis"]

--- a/tests/test_concert_prep_generator.py
+++ b/tests/test_concert_prep_generator.py
@@ -352,3 +352,141 @@ class TestSelectionResult:
         )
         scores = [t.score for t in result.tracks]
         assert scores == sorted(scores, reverse=True)
+
+
+def _candidate(*, is_target: bool) -> concert_prep_module.CandidateTrack:
+    """Build a candidate track with a unique id for blend-quota tests."""
+    return concert_prep_module.CandidateTrack(
+        track_id=uuid.uuid4(),
+        title="Song",
+        artist_name="Target" if is_target else "Adjacent",
+        artist_id=uuid.uuid4(),
+        is_target_artist=is_target,
+        listen_count=10,
+        in_library=True,
+        popularity_score=0,
+        source=types_module.TrackSource.LIBRARY,
+    )
+
+
+class TestBlendQuota:
+    """similar_artist_ratio sets the fraction of slots from the adjacent pool.
+
+    Familiarity/hit_depth rank within a pool; the ratio picks the mix. The two
+    are orthogonal (issue #111/#57).
+    """
+
+    def test_ratio_zero_excludes_adjacent(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(10)]
+        adjacent = [_candidate(is_target=False) for _ in range(10)]
+        target_ids = {t.track_id for t in target}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 0},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 10
+        assert all(t.track_id in target_ids for t in result.tracks)
+
+    def test_ratio_hundred_excludes_target(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(10)]
+        adjacent = [_candidate(is_target=False) for _ in range(10)]
+        adjacent_ids = {t.track_id for t in adjacent}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 100},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 10
+        assert all(t.track_id in adjacent_ids for t in result.tracks)
+
+    def test_ratio_thirty_splits_pools(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(20)]
+        adjacent = [_candidate(is_target=False) for _ in range(20)]
+        adjacent_ids = {t.track_id for t in adjacent}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 30},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 10
+        adj_count = sum(1 for t in result.tracks if t.track_id in adjacent_ids)
+        # round_half_up(10 * 30 / 100) = 3 adjacent, 7 target
+        assert adj_count == 3
+
+    def test_ratio_rounds_half_up(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(20)]
+        adjacent = [_candidate(is_target=False) for _ in range(20)]
+        adjacent_ids = {t.track_id for t in adjacent}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 35},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        adj_count = sum(1 for t in result.tracks if t.track_id in adjacent_ids)
+        # round_half_up(10 * 35 / 100) = round_half_up(3.5) = 4 adjacent
+        assert adj_count == 4
+
+    def test_adjacent_underflow_backfills_from_target(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(20)]
+        adjacent = [_candidate(is_target=False) for _ in range(2)]
+        adjacent_ids = {t.track_id for t in adjacent}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 50},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        # quota is 5 adjacent, but only 2 exist => 2 adjacent + 8 target = 10
+        assert len(result.tracks) == 10
+        adj_count = sum(1 for t in result.tracks if t.track_id in adjacent_ids)
+        assert adj_count == 2
+
+    def test_target_underflow_backfills_from_adjacent(self) -> None:
+        target = [_candidate(is_target=True) for _ in range(2)]
+        adjacent = [_candidate(is_target=False) for _ in range(20)]
+        target_ids = {t.track_id for t in target}
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 50},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        # quota is 5 target, but only 2 exist => 2 target + 8 adjacent = 10
+        assert len(result.tracks) == 10
+        tgt_count = sum(1 for t in result.tracks if t.track_id in target_ids)
+        assert tgt_count == 2
+
+    def test_ratio_zero_no_target_yields_empty(self) -> None:
+        # ratio=0 is target-only; with no target tracks, no adjacent backfill.
+        adjacent = [_candidate(is_target=False) for _ in range(10)]
+        result = concert_prep_module.score_and_select(
+            candidates=adjacent,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 0},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 0
+
+    def test_ratio_hundred_no_adjacent_yields_empty(self) -> None:
+        # ratio=100 is adjacent-only; with no adjacent tracks, no target backfill.
+        target = [_candidate(is_target=True) for _ in range(10)]
+        result = concert_prep_module.score_and_select(
+            candidates=target,
+            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 100},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -29,14 +29,6 @@ class TestPopularitySignal:
         assert 0.4 <= score <= 0.6
 
 
-class TestArtistRelevanceSignal:
-    def test_target_artist(self) -> None:
-        assert scoring_module.artist_relevance_signal(is_target_artist=True) == 1.0
-
-    def test_adjacent_artist(self) -> None:
-        assert scoring_module.artist_relevance_signal(is_target_artist=False) == 0.0
-
-
 class TestBipolarWeight:
     def test_neutral_returns_zero(self) -> None:
         assert scoring_module.bipolar_weight(50) == 0.0
@@ -52,89 +44,65 @@ class TestBipolarWeight:
 
 
 class TestCompositeScore:
-    def test_neutral_params_score_from_relevance(self) -> None:
+    """composite_score reflects familiarity + hit_depth only.
+
+    Artist relevance (target vs adjacent) is NOT a score factor; it is applied
+    as a blend quota at selection time (see concert_prep.score_and_select).
+    """
+
+    def test_neutral_params_midpoint(self) -> None:
         score = scoring_module.composite_score(
             familiarity_val=0.5,
             popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 0},
+            params={"familiarity": 50, "hit_depth": 50},
         )
-        assert 0.0 <= score <= 1.0
+        assert score == 0.5
 
     def test_high_familiarity_boosts_known_tracks(self) -> None:
         known = scoring_module.composite_score(
             familiarity_val=0.9,
             popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 90, "hit_depth": 50, "similar_artist_ratio": 0},
+            params={"familiarity": 90, "hit_depth": 50},
         )
         unknown = scoring_module.composite_score(
             familiarity_val=0.1,
             popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 90, "hit_depth": 50, "similar_artist_ratio": 0},
+            params={"familiarity": 90, "hit_depth": 50},
         )
         assert known > unknown
 
-    def test_similar_artist_ratio_zero_excludes_adjacent(self) -> None:
+    def test_discovery_profile_boosts_unheard(self) -> None:
+        # familiarity=0 (all discovery) => an unheard track outranks a heard one.
+        unheard = scoring_module.composite_score(
+            familiarity_val=0.0,
+            popularity_val=0.5,
+            params={"familiarity": 0, "hit_depth": 50},
+        )
+        heard = scoring_module.composite_score(
+            familiarity_val=1.0,
+            popularity_val=0.5,
+            params={"familiarity": 0, "hit_depth": 50},
+        )
+        assert unheard > heard
+
+    def test_missing_params_default_to_neutral(self) -> None:
         score = scoring_module.composite_score(
             familiarity_val=0.5,
             popularity_val=0.5,
-            is_target_artist=False,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 0},
+            params={},
         )
-        assert score == 0.0
+        assert score == 0.5
 
-    def test_similar_artist_ratio_does_not_affect_target_artist(self) -> None:
-        low = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 0},
-        )
+    def test_clamped_to_unit_range(self) -> None:
         high = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 100},
+            familiarity_val=1.0,
+            popularity_val=1.0,
+            params={"familiarity": 100, "hit_depth": 100},
         )
-        assert low == high
-
-    def test_similar_artist_ratio_full_removes_adjacent_penalty(self) -> None:
-        target = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 100},
+        low = scoring_module.composite_score(
+            familiarity_val=0.0,
+            popularity_val=0.0,
+            params={"familiarity": 100, "hit_depth": 100},
         )
-        adjacent = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=False,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 100},
-        )
-        assert adjacent == target
-
-    def test_similar_artist_ratio_partial_scales_adjacent(self) -> None:
-        target = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=True,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 50},
-        )
-        adjacent = scoring_module.composite_score(
-            familiarity_val=0.7,
-            popularity_val=0.5,
-            is_target_artist=False,
-            params={"familiarity": 50, "hit_depth": 50, "similar_artist_ratio": 50},
-        )
-        assert adjacent == target * 0.5
-
-    def test_similar_artist_ratio_defaults_to_zero(self) -> None:
-        score = scoring_module.composite_score(
-            familiarity_val=0.5,
-            popularity_val=0.5,
-            is_target_artist=False,
-            params={"familiarity": 50, "hit_depth": 50},
-        )
-        assert score == 0.0
+        assert high == 1.0
+        assert low == 0.0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2963,3 +2963,51 @@ class TestResolveSimilarLibraryArtists:
         )
         # ...and their neighbors are unioned into a single library query.
         session.execute.assert_awaited_once()
+
+
+class TestArtistsNeedingDiscovery:
+    """Gating for which target artists get an external catalog fetch (#110)."""
+
+    def test_under_covered_artist_always_included(self) -> None:
+        aid = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [aid], {aid: 2}, discovery_wanted=False
+        )
+        assert result == [aid]
+
+    def test_well_covered_artist_excluded_when_not_discovery(self) -> None:
+        aid = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [aid], {aid: 50}, discovery_wanted=False
+        )
+        assert result == []
+
+    def test_well_covered_artist_included_when_discovery_wanted(self) -> None:
+        aid = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [aid], {aid: 50}, discovery_wanted=True
+        )
+        assert result == [aid]
+
+    def test_missing_coverage_treated_as_zero(self) -> None:
+        aid = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [aid], {}, discovery_wanted=False
+        )
+        assert result == [aid]
+
+    def test_boundary_at_min_library_tracks(self) -> None:
+        # coverage == _MIN_LIBRARY_TRACKS is "covered" (gate is strictly less-than)
+        aid = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [aid], {aid: worker_module._MIN_LIBRARY_TRACKS}, discovery_wanted=False
+        )
+        assert result == []
+
+    def test_discovery_wanted_includes_all(self) -> None:
+        covered = uuid.uuid4()
+        under = uuid.uuid4()
+        result = worker_module._artists_needing_discovery(
+            [covered, under], {covered: 50, under: 1}, discovery_wanted=True
+        )
+        assert set(result) == {covered, under}


### PR DESCRIPTION
## Summary

Two confirmed bugs kept concert_prep from delivering a high-discovery playlist for artists you've listened to:

1. **Adjacency was a score multiplier, not a blend quota** (#111, #57). `composite_score` scaled a track's whole score by `similar_artist_ratio/100`, so the ratio and familiarity fought — a perfect unheard discovery track from an adjacent artist got scaled down and lost to a heard target track.
2. **Discovery was gated on low library coverage** (#110). A well-known target artist (≥5 library tracks) never got an external catalog fetch, so its candidate pool was 100% scrobble-derived and a discovery profile had no unheard tracks to surface.

After this, the two knobs are orthogonal: familiarity/hit_depth rank tracks *within* a pool, and `similar_artist_ratio` sets *the mix*; and a discovery-leaning profile pulls unheard catalog tracks for every target artist.

<details>
<summary>How to Review</summary>

Two logical commits, review in order:

1. **`9eebdd5` — blend quota (#111/#57):** `scoring.py` drops the adjacency multiplier from `composite_score` (and the now-dead `adjacent_multiplier` / `artist_relevance_signal` helpers). `concert_prep.py` `score_and_select` partitions candidates into target/adjacent pools and fills `round_half_up(max_tracks * ratio/100)` slots from the adjacent pool, the rest from target, each ranked by score. `_select_with_quota` backfills a pool's shortfall from the other pool — **except at the extremes** (ratio=0 stays target-only, ratio=100 stays adjacent-only).
2. **`a453d4e` — discovery gating (#110):** `worker.py` `generate_playlist` reads profile params and gates discovery on `coverage < _MIN_LIBRARY_TRACKS OR familiarity < 50`. Coverage now counts **distinct listened tracks** (`count(distinct Track.id)`), not total scrobbles. The predicate is extracted as the pure helper `_artists_needing_discovery` for unit testing.

Key edge-case decisions (all confirmed): ratio=100 is literal (0 target tracks); discovery threshold is `familiarity < 50`; distinct-track coverage count is included here.
</details>

<details>
<summary>Test Plan</summary>

- [x] `make check` (ruff + mypy strict + pytest) — green, 1342 passed
- [x] Bug 1: rewrote `test_scoring.py` composite tests for the new pure-familiarity behavior; added `TestBlendQuota` in `test_concert_prep_generator.py` (ratio 0/30/100, round-half-up, underflow backfill both directions, extreme-purity empties). Verified red-before / green-after.
- [x] Bug 2: added `TestArtistsNeedingDiscovery` in `test_worker.py` (under-covered always included; well-covered excluded unless discovery wanted; boundary at `_MIN_LIBRARY_TRACKS`; missing coverage → zero).
</details>

<details>
<summary>Impact</summary>

- A high-discovery concert_prep profile now surfaces unheard tracks for well-known lineup artists.
- `similar_artist_ratio` now behaves as documented ("30 = ~30% adjacent").
- More external catalog fetches on discovery profiles (one per target artist), but bounded to 20 tracks/artist and dispatched sequentially (MusicBrainz rate-limit safe); existing `RateLimitExceededError` deferral handles throttling.
- **Latent issue, not fixed here:** `popularity_score` is hardcoded `0` when building candidates (`worker.py`), so `hit_depth` / "Big Hits" currently does nothing. Worth a follow-up.
- **Out of scope:** adjacent-artist *catalog* discovery (for "mostly related + mostly discovery" playlists) — adjacent artists still contribute only existing library tracks. Separate, larger piece.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)