### PR TITLE
feat: Track.popularity_score + wire hit_depth (foundation for #114)

### DIFF
--- a/alembic/versions/g8h9i0j1k2l3_add_track_popularity_score.py
+++ b/alembic/versions/g8h9i0j1k2l3_add_track_popularity_score.py
@@ -1,0 +1,36 @@
+"""add popularity_score column to tracks
+
+Track popularity (0-100) feeds the generator's hit_depth parameter via
+scoring.popularity_signal. Until now the column did not exist and
+score_and_build_playlist hardcoded 0, so hit_depth had no effect (#114).
+
+Nullable int, NULL = unknown popularity (treated as 0 at scoring time). Populated
+going forward by track discovery (ListenBrainz synthetic rank) and, in a later
+phase, by Spotify's authoritative 0-100 popularity.
+
+Revision ID: g8h9i0j1k2l3
+Revises: f7g8h9i0j1k2
+Create Date: 2026-06-19
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "g8h9i0j1k2l3"
+down_revision: str | None = "f7g8h9i0j1k2"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tracks",
+        sa.Column("popularity_score", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tracks", "popularity_score")

--- a/src/resonance/models/music.py
+++ b/src/resonance/models/music.py
@@ -88,6 +88,12 @@ class Track(base_module.TimestampMixin, base_module.Base):
         nullable=True,
         default=None,
     )
+    # Track popularity (0-100) feeding the hit_depth generator parameter (#114).
+    # NULL = unknown (treated as 0 at scoring time). Populated by track discovery
+    # and, later, by Spotify's authoritative popularity.
+    popularity_score: orm.Mapped[int | None] = orm.mapped_column(
+        sa.Integer, nullable=True, default=None
+    )
 
     artist: orm.Mapped[Artist] = orm.relationship(back_populates="tracks")
 

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -983,6 +983,7 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
                             artist_id=artist_uuid,
                             duration_ms=dt.duration_ms,
                             service_links={dt.service.value: dt.external_id},
+                            popularity_score=dt.popularity_score,
                         )
                         session.add(new_track)
                         tracks_found += 1
@@ -993,6 +994,11 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
                     updated_links = dict(existing.service_links)
                     updated_links[dt.service.value] = dt.external_id
                     existing.service_links = updated_links
+                    # Seed popularity from discovery only when unknown; an
+                    # authoritative source (Spotify) must not be clobbered by a
+                    # discovery connector's synthetic rank.
+                    if existing.popularity_score is None:
+                        existing.popularity_score = dt.popularity_score
                     tracks_found += 1
 
             await lifecycle_module.complete_task(
@@ -1269,7 +1275,7 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                         is_target_artist=track.artist_id in artist_ids,
                         listen_count=lc,
                         in_library=in_library,
-                        popularity_score=0,
+                        popularity_score=track.popularity_score or 0,
                         source=(
                             types_module.TrackSource.LIBRARY
                             if in_library

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -400,6 +400,15 @@ class TestTrackModel:
         assert isinstance(col.type, sa.Enum)
         assert col.nullable is True
 
+    def test_popularity_score_is_nullable_integer(self) -> None:
+        col = _get_column(music_module.Track.__table__, "popularity_score")  # type: ignore[arg-type]
+        assert isinstance(col.type, sa.Integer)
+        assert col.nullable is True
+
+    def test_popularity_score_defaults_to_none(self) -> None:
+        track = music_module.Track(title="Song", artist_id=uuid.uuid4())
+        assert track.popularity_score is None
+
     def test_artist_fk(self) -> None:
         col = _get_column(music_module.Track.__table__, "artist_id")  # type: ignore[arg-type]
         fk_targets = {fk.target_fullname for fk in col.foreign_keys}

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2631,6 +2631,7 @@ class TestScoreAndBuildPlaylist:
         mock_track.id = track_id
         mock_track.title = "Test Song"
         mock_track.artist_id = artist_id
+        mock_track.popularity_score = None
         mock_artist = MagicMock(spec=music_models.Artist)
         mock_artist.id = artist_id
         mock_artist.name = "Concert Artist"


### PR DESCRIPTION
## Summary

`hit_depth` was a no-op: `score_and_build_playlist` built every candidate with `popularity_score=0` and `Track` had no popularity column, so the parameter never reordered tracks (#114). This PR adds the column and makes popularity flow.

**This is Phase 1 of #114 — the foundation.** It makes `hit_depth` functional for **discovery-sourced** tracks. Phase 2 (Spotify authoritative popularity + library backfill) is a deliberately separate follow-up — see below.

**⚠️ Has a DB migration — do not merge while unattended.** On deploy, alembic runs as an init container; a bad migration = app won't start. Hold merge until someone can watch the deploy. (Migration validated locally: `upgrade` + `downgrade` + re-`upgrade` all clean.)

<details>
<summary>What's in this PR</summary>

- **Migration** `g8h9i0j1k2l3`: adds nullable `popularity_score` int to `tracks` (NULL = unknown → treated as 0 at scoring time). Reversible.
- **Model**: `Track.popularity_score`.
- **Discovery persist**: `discover_tracks_for_artist` writes `DiscoveredTrack.popularity_score` (ListenBrainz synthetic rank). Seeded **only when currently NULL**, so a future authoritative source (Spotify) can't be clobbered by a discovery connector's synthetic rank.
- **Candidate wiring**: `score_and_build_playlist` reads `track.popularity_score or 0` instead of the hardcoded `0` — the line that un-deadens `hit_depth`.
- **Tests**: model column tests; fixed a `MagicMock(spec=Track)` in the export test to set `popularity_score`.
</details>

<details>
<summary>Phase 2 (follow-up issue) — deliberately not here</summary>

The approved design was source = Spotify-primary + ListenBrainz fallback, plus a backfill. Phase 2 delivers the Spotify half:

- **Spotify authoritative popularity**: `SpotifyConnector.search_track` currently returns only a track ID and ignores the `popularity` field the Spotify API returns. Capturing it means changing the connector's return signature and threading popularity into the export-path persistence (`worker.py:1568`) — a hot-path change worth its own review.
- **Backfill**: a `POPULARITY_BACKFILL` task (new TaskType + CHECK-constraint migration + worker handler + dispatch + CLI), to populate existing library tracks' popularity from Spotify. Without it, library tracks stay at 0 and `hit_depth` only differentiates discovery tracks.

Splitting here keeps each PR reviewable and isolates the export hot-path change. Filed as a follow-up.
</details>

<details>
<summary>Test Plan</summary>

- [x] Migration validated locally: `alembic upgrade head` → `downgrade -1` → `upgrade head`, all clean against local PG.
- [x] `make check` green (ruff + mypy strict + 1344 tests).
- [x] New model tests for the column (nullable integer, defaults to None).
</details>

Part of #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)