### PR TITLE
feat: Spotify-authoritative popularity + library backfill (hit_depth Phase 2)

### DIFF
--- a/alembic/versions/h9i0j1k2l3m4_add_popularity_backfill_task_type.py
+++ b/alembic/versions/h9i0j1k2l3m4_add_popularity_backfill_task_type.py
@@ -1,0 +1,72 @@
+"""add POPULARITY_BACKFILL to the sync_tasks task_type CHECK constraint
+
+TaskType.POPULARITY_BACKFILL (#117) was added in code; the sync_tasks.task_type
+CHECK constraint must list it or inserts of popularity-backfill tasks fail with a
+check violation (same class of bug fixed for MBID_BACKFILL in f7g8h9i0j1k2).
+
+SQLAlchemy stores the enum .name (UPPERCASE) for native_enum=False columns, so the
+constraint lists 'POPULARITY_BACKFILL', not the lowercase value.
+
+Revision ID: h9i0j1k2l3m4
+Revises: g8h9i0j1k2l3
+Create Date: 2026-06-20
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "h9i0j1k2l3m4"
+down_revision: str = "g8h9i0j1k2l3"
+branch_labels: None = None
+depends_on: None = None
+
+_ALL_TYPES = (
+    "'SYNC_JOB', 'TIME_RANGE', 'PAGE_FETCH', 'BULK_JOB', "
+    "'CALENDAR_SYNC', 'PLAYLIST_GENERATION', "
+    "'TRACK_DISCOVERY', 'TRACK_SCORING', "
+    "'CONCERT_ARCHIVES_IMPORT', 'CONCERT_ARCHIVES_CHUNK', "
+    "'PLAYLIST_EXPORT', 'MBID_BACKFILL', 'POPULARITY_BACKFILL'"
+)
+
+_ALL_TYPES_WITHOUT_POPULARITY = (
+    "'SYNC_JOB', 'TIME_RANGE', 'PAGE_FETCH', 'BULK_JOB', "
+    "'CALENDAR_SYNC', 'PLAYLIST_GENERATION', "
+    "'TRACK_DISCOVERY', 'TRACK_SCORING', "
+    "'CONCERT_ARCHIVES_IMPORT', 'CONCERT_ARCHIVES_CHUNK', "
+    "'PLAYLIST_EXPORT', 'MBID_BACKFILL'"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks DROP CONSTRAINT IF EXISTS "
+            '"ck_sync_tasks_task_type_tasktype"'
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks ADD CONSTRAINT "
+            '"ck_sync_tasks_task_type_tasktype" '
+            f"CHECK (task_type IN ({_ALL_TYPES}))"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks DROP CONSTRAINT IF EXISTS "
+            '"ck_sync_tasks_task_type_tasktype"'
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks ADD CONSTRAINT "
+            '"ck_sync_tasks_task_type_tasktype" '
+            f"CHECK (task_type IN ({_ALL_TYPES_WITHOUT_POPULARITY}))"
+        )
+    )

--- a/src/resonance/api/v1/admin.py
+++ b/src/resonance/api/v1/admin.py
@@ -412,6 +412,73 @@ async def admin_backfill_coverage_endpoint(
     return await get_backfill_coverage(db)
 
 
+async def get_popularity_coverage(db: sa_async.AsyncSession) -> dict[str, object]:
+    """Popularity-backfill coverage: Spotify-linked tracks vs. scored tracks (#117).
+
+    ``spotify_linked`` is how many tracks carry a ``service_links["spotify"]`` id
+    (the backfill candidate set); ``scored`` is how many of those already have a
+    ``popularity_score``.
+    """
+    spotify_link = music_models.Track.service_links["spotify"].as_string()
+    linked = await db.scalar(
+        sa.select(sa.func.count())
+        .select_from(music_models.Track)
+        .where(spotify_link.isnot(None))
+    )
+    scored = await db.scalar(
+        sa.select(sa.func.count())
+        .select_from(music_models.Track)
+        .where(
+            spotify_link.isnot(None),
+            music_models.Track.popularity_score.isnot(None),
+        )
+    )
+    return {"spotify_linked": linked or 0, "scored": scored or 0}
+
+
+@router.post(
+    "/backfill-popularity",
+    summary="Enqueue Spotify popularity backfill",
+)
+async def admin_backfill_popularity_endpoint(
+    request: fastapi.Request,
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, str]:
+    """Enqueue a POPULARITY_BACKFILL task (#117).
+
+    Refreshes ``Track.popularity_score`` from Spotify's authoritative 0-100
+    popularity for every Spotify-linked track, overwriting discovery-sourced
+    synthetic values.
+    """
+    task = task_models.Task(
+        task_type=types_module.TaskType.POPULARITY_BACKFILL,
+        status=types_module.SyncStatus.PENDING,
+        params={},
+        description="Popularity Backfill",
+    )
+    db.add(task)
+    await db.commit()
+    task_id = str(task.id)
+
+    arq_redis = request.app.state.arq_redis
+    await arq_redis.enqueue_job(
+        "backfill_popularity",
+        task_id,
+        _job_id=f"popularity-backfill:{task_id}",
+    )
+    return {"task_id": task_id, "status": "started"}
+
+
+@router.get(
+    "/backfill-popularity",
+    summary="Spotify popularity backfill coverage",
+)
+async def admin_backfill_popularity_coverage_endpoint(
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, object]:
+    return await get_popularity_coverage(db)
+
+
 # ---------------------------------------------------------------------------
 # Legacy endpoints
 # ---------------------------------------------------------------------------

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -79,6 +79,7 @@ Commands:
   feed-sync <conn_id|all>      Sync a calendar connection (or all)
   dedup <type> [--no-wait]     Run deduplication
   backfill-mbids [opts]        Backfill MusicBrainz MBIDs (#71)
+  backfill-popularity [opts]   Backfill Spotify popularity (#117)
   task <task_id>               Check task status
   track <query>                Search tracks by title
   profile <subcommand>         Manage generator profiles
@@ -1011,6 +1012,39 @@ def _cmd_backfill_mbids() -> None:
     print(json.dumps(result, indent=2))
 
 
+_POPULARITY_BACKFILL_USAGE = """\
+Usage: resonance-api backfill-popularity [opts]
+
+Options:
+  --status       Show coverage (spotify-linked vs scored), do not enqueue
+  --no-wait      Enqueue and return immediately (don't poll)
+
+Refreshes Track.popularity_score from Spotify's authoritative 0-100 popularity for
+every Spotify-linked track, overwriting discovery-sourced synthetic values. Default
+polls the task to completion and prints the updated/no-popularity counts.
+"""
+
+
+def _cmd_backfill_popularity() -> None:
+    args = sys.argv[2:]
+    if "--help" in args or "-h" in args:
+        print(_POPULARITY_BACKFILL_USAGE)
+        return
+    if "--status" in args:
+        resp = _api_request("GET", "/api/v1/admin/backfill-popularity")
+        print(json.dumps(resp.json(), indent=2))
+        return
+
+    resp = _api_request("POST", "/api/v1/admin/backfill-popularity")
+    task_id = resp.json().get("task_id", "")
+
+    if "--no-wait" in args:
+        print(f"backfill-popularity: task {task_id}")
+        return
+    result = _poll_task(task_id, "Backfilling popularity")
+    print(json.dumps(result, indent=2))
+
+
 _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "healthz": ("Health + deployed revision", _cmd_healthz),
     "status": ("Recent sync job overview", _cmd_status),
@@ -1021,6 +1055,7 @@ _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "feed-sync": ("Sync a calendar connection", _cmd_feed_sync),
     "dedup": ("Run deduplication", _cmd_dedup),
     "backfill-mbids": ("Backfill MusicBrainz MBIDs", _cmd_backfill_mbids),
+    "backfill-popularity": ("Backfill Spotify popularity", _cmd_backfill_popularity),
     "task": ("Check task status", _cmd_task),
     "track": ("Search tracks by title", _cmd_track),
     "profile": ("Manage generator profiles", _cmd_profile),

--- a/src/resonance/connectors/spotify.py
+++ b/src/resonance/connectors/spotify.py
@@ -50,6 +50,17 @@ class SavedTrackPage(pydantic.BaseModel):
     next_url: str | None
 
 
+class TrackSearchResult(pydantic.BaseModel):
+    """A matched Spotify track from a search.
+
+    ``popularity`` is Spotify's authoritative 0-100 score; it is None when the
+    track object omits the field (rare).
+    """
+
+    track_id: str
+    popularity: int | None
+
+
 class SpotifyConnector(base_module.BaseConnector):
     """Connector for the Spotify Web API."""
 
@@ -357,8 +368,13 @@ class SpotifyConnector(base_module.BaseConnector):
         access_token: str,
         title: str,
         artist_name: str,
-    ) -> str | None:
-        """Search Spotify for a track by title and artist. Returns track ID or None."""
+    ) -> TrackSearchResult | None:
+        """Search Spotify for a track by title and artist.
+
+        Returns the matched track's ID and its authoritative 0-100 popularity
+        score, or None when no track matches. The popularity field feeds
+        ``Track.popularity_score`` (Spotify is authoritative — see #117).
+        """
         query = f"track:{title} artist:{artist_name}"
         response = await self._request(
             "GET",
@@ -370,8 +386,45 @@ class SpotifyConnector(base_module.BaseConnector):
         items = data.get("tracks", {}).get("items", [])
         if not items:
             return None
-        result: str = items[0]["id"]
-        return result
+        item = items[0]
+        return TrackSearchResult(
+            track_id=item["id"],
+            popularity=item.get("popularity"),
+        )
+
+    async def get_tracks(
+        self,
+        access_token: str,
+        track_ids: list[str],
+    ) -> dict[str, int]:
+        """Fetch popularity for tracks by Spotify ID, batching at 50 per request.
+
+        Returns a mapping of track ID -> 0-100 popularity for every requested ID
+        that resolved to a track exposing a ``popularity`` field. Unknown IDs
+        (Spotify returns a null entry) and tracks without a popularity field are
+        omitted. Used by the POPULARITY_BACKFILL task (#117) to populate
+        ``Track.popularity_score`` for tracks already linked to Spotify.
+        """
+        if not track_ids:
+            return {}
+        out: dict[str, int] = {}
+        for i in range(0, len(track_ids), 50):
+            batch = track_ids[i : i + 50]
+            response = await self._request(
+                "GET",
+                f"{SPOTIFY_API_BASE}/tracks",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"ids": ",".join(batch)},
+            )
+            data = response.json()
+            for track in data.get("tracks", []):
+                if track is None:
+                    continue
+                popularity = track.get("popularity")
+                if popularity is None:
+                    continue
+                out[track["id"]] = popularity
+        return out
 
     async def get_artist_by_id(
         self,

--- a/src/resonance/sync/backfill.py
+++ b/src/resonance/sync/backfill.py
@@ -52,6 +52,7 @@ import structlog
 
 import resonance.config as config_module
 import resonance.connectors.listenbrainz as listenbrainz_module
+import resonance.connectors.spotify as spotify_module
 import resonance.models.music as music_module
 import resonance.normalize as normalize_module
 import resonance.services.artist_utils as artist_utils
@@ -311,6 +312,75 @@ async def backfill_artists(
         await session.commit()
 
     logger.info("mbid_backfill_artists_done", **dataclasses.asdict(counts))
+    return counts
+
+
+@dataclasses.dataclass
+class PopularityBackfillCounts:
+    """Outcome tally for a Spotify popularity backfill run."""
+
+    candidates: int = 0
+    updated: int = 0
+    no_popularity: int = 0
+
+
+async def run_popularity_backfill(
+    session: Any,
+    settings: config_module.Settings,
+    connector: spotify_module.SpotifyConnector,
+    access_token: str,
+) -> PopularityBackfillCounts:
+    """Backfill ``Track.popularity_score`` from Spotify for Spotify-linked tracks.
+
+    Iterates tracks whose ``service_links["spotify"]`` is set, in batches, and
+    fetches Spotify's authoritative 0-100 popularity via ``connector.get_tracks``.
+    Spotify is authoritative, so the fetched value overwrites any prior
+    discovery-sourced synthetic ``popularity_score`` (#117).
+
+    Tracks Spotify reports without a popularity field are counted under
+    ``no_popularity`` and left untouched. Batched + committed per batch so a worker
+    restart re-enters and re-scans (the scan is idempotent — re-reading popularity
+    is cheap and converges).
+    """
+    counts = PopularityBackfillCounts()
+    spotify_link = music_module.Track.service_links["spotify"].as_string()
+    offset = 0
+    batch_size = settings.mbid_mapper_batch_size
+    while True:
+        stmt = (
+            sa.select(music_module.Track)
+            .where(spotify_link.isnot(None))
+            .order_by(music_module.Track.id)
+            .offset(offset)
+            .limit(batch_size)
+        )
+        tracks = list((await session.execute(stmt)).scalars().all())
+        if not tracks:
+            break
+        offset += len(tracks)
+        counts.candidates += len(tracks)
+
+        by_spotify_id: dict[str, list[music_module.Track]] = {}
+        for track in tracks:
+            spotify_id = (track.service_links or {}).get("spotify")
+            if isinstance(spotify_id, str):
+                by_spotify_id.setdefault(spotify_id, []).append(track)
+
+        popularity = await connector.get_tracks(
+            access_token, list(by_spotify_id.keys())
+        )
+        for spotify_id, group in by_spotify_id.items():
+            score = popularity.get(spotify_id)
+            if score is None:
+                counts.no_popularity += len(group)
+                continue
+            for track in group:
+                track.popularity_score = score
+                counts.updated += 1
+
+        await session.commit()
+
+    logger.info("popularity_backfill_done", **dataclasses.asdict(counts))
     return counts
 
 

--- a/src/resonance/types.py
+++ b/src/resonance/types.py
@@ -64,6 +64,7 @@ class TaskType(enum.StrEnum):
     CONCERT_ARCHIVES_CHUNK = "concert_archives_chunk"
     PLAYLIST_EXPORT = "playlist_export"
     MBID_BACKFILL = "mbid_backfill"
+    POPULARITY_BACKFILL = "popularity_backfill"
 
 
 class SyncStatus(enum.StrEnum):

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -106,6 +106,10 @@ _TASK_DISPATCH: dict[
         "backfill_mbids",
         lambda t: (str(t.id),),
     ),
+    types_module.TaskType.POPULARITY_BACKFILL: (
+        "backfill_popularity",
+        lambda t: (str(t.id),),
+    ),
 }
 
 
@@ -619,6 +623,135 @@ async def backfill_mbids(ctx: dict[str, Any], task_id: str) -> None:
                 await session.commit()
         finally:
             await mapper.aclose()
+
+
+async def _get_spotify_access_token(
+    session: sa_async.AsyncSession,
+    connector: spotify_module.SpotifyConnector,
+    settings: config_module.Settings,
+) -> str | None:
+    """Find a Spotify connection and return a valid (refreshed) access token.
+
+    Returns None when no Spotify connection has a usable access token. Picks the
+    most-recently-created connection so a re-auth supersedes a stale one. Mirrors
+    the token decrypt+refresh dance the export task does inline.
+    """
+    conn_result = await session.execute(
+        sa.select(user_models.ServiceConnection)
+        .where(
+            user_models.ServiceConnection.service_type
+            == types_module.ServiceType.SPOTIFY,
+            user_models.ServiceConnection.encrypted_access_token.isnot(None),
+        )
+        .order_by(user_models.ServiceConnection.created_at.desc())
+        .limit(1)
+    )
+    connection = conn_result.scalar_one_or_none()
+    if connection is None or connection.encrypted_access_token is None:
+        return None
+
+    access_token = crypto_module.decrypt_token(
+        connection.encrypted_access_token, settings.token_encryption_key
+    )
+    if (
+        connection.token_expires_at is not None
+        and connection.token_expires_at <= datetime.datetime.now(datetime.UTC)
+        and connection.encrypted_refresh_token is not None
+    ):
+        refresh_token = crypto_module.decrypt_token(
+            connection.encrypted_refresh_token, settings.token_encryption_key
+        )
+        token_response = await connector.refresh_access_token(refresh_token)
+        access_token = token_response.access_token
+        connection.encrypted_access_token = crypto_module.encrypt_token(
+            access_token, settings.token_encryption_key
+        )
+        if token_response.expires_in is not None:
+            connection.token_expires_at = datetime.datetime.now(
+                datetime.UTC
+            ) + datetime.timedelta(seconds=token_response.expires_in)
+        await session.commit()
+        logger.info("popularity_backfill_token_refreshed")
+
+    return access_token
+
+
+async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
+    """Execute a POPULARITY_BACKFILL task (#117): refresh Track.popularity_score.
+
+    Fetches Spotify's authoritative 0-100 popularity for every track linked to
+    Spotify (``service_links["spotify"]``) and overwrites ``popularity_score``.
+    Spotify is authoritative, so this supersedes the discovery-sourced synthetic
+    values seeded in #116. Sequential + batched (like the Spotify sync strategy)
+    to stay within rate limits; resumable across worker restarts because the scan
+    is idempotent.
+
+    Args:
+        ctx: arq worker context dict.
+        task_id: UUID string of the POPULARITY_BACKFILL Task.
+    """
+    wctx = typing.cast("WorkerContext", ctx)
+    settings = wctx["settings"]
+    session_factory = wctx["session_factory"]
+    log = logger.bind(task_id=task_id)
+
+    connector = wctx["connector_registry"].get_base_connector(
+        types_module.ServiceType.SPOTIFY
+    )
+
+    async with session_factory() as session:
+        task: task_module.Task | None = None
+        try:
+            task = await _load_task(session, task_id)
+            if task is None:
+                log.error("popularity_backfill_task_not_found")
+                return
+
+            if await lifecycle_module.is_cancelled(session, task):
+                await lifecycle_module.fail_task(
+                    session, task, "Parent task was cancelled"
+                )
+                await session.commit()
+                return
+
+            if not isinstance(connector, spotify_module.SpotifyConnector):
+                await lifecycle_module.fail_task(
+                    session,
+                    task,
+                    "Spotify connector unavailable for popularity backfill",
+                )
+                await session.commit()
+                log.error("popularity_backfill_no_connector")
+                return
+
+            task.status = types_module.SyncStatus.RUNNING
+            task.started_at = datetime.datetime.now(datetime.UTC)
+            await session.commit()
+
+            access_token = await _get_spotify_access_token(session, connector, settings)
+            if access_token is None:
+                await lifecycle_module.fail_task(
+                    session,
+                    task,
+                    "No Spotify connection with an access token",
+                )
+                await session.commit()
+                log.error("popularity_backfill_no_connection")
+                return
+
+            log.info("popularity_backfill_started")
+            counts = await backfill_module.run_popularity_backfill(
+                session, settings, connector, access_token
+            )
+            result: dict[str, object] = dataclasses.asdict(counts)
+            await lifecycle_module.complete_task(session, task, result)
+            await session.commit()
+            log.info("popularity_backfill_done", result=result)
+        except Exception:
+            log.exception("popularity_backfill_failed")
+            if task is not None:
+                await lifecycle_module.fail_task(session, task, traceback.format_exc())
+                await session.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -1565,15 +1698,19 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
 
                 if spotify_id is None:
                     artist_name = track.artist.name if track.artist else ""
-                    found_id = await connector.search_track(
+                    search_result = await connector.search_track(
                         access_token, track.title, artist_name
                     )
-                    if found_id is not None:
+                    if search_result is not None:
                         updated_links = dict(track_links)
-                        updated_links["spotify"] = found_id
+                        updated_links["spotify"] = search_result.track_id
                         track.service_links = updated_links
-                        spotify_id = found_id
+                        spotify_id = search_result.track_id
                         search_matched += 1
+                        # Spotify is authoritative for popularity — overwrite any
+                        # discovery-sourced synthetic value (#117).
+                        if search_result.popularity is not None:
+                            track.popularity_score = search_result.popularity
                     else:
                         skipped_tracks.append(track.title)
                         continue
@@ -2261,6 +2398,7 @@ class WorkerSettings:
         ),
         arq.func(heartbeat_module.with_heartbeat(export_playlist), timeout=600),
         arq.func(heartbeat_module.with_heartbeat(backfill_mbids), timeout=3600),
+        arq.func(heartbeat_module.with_heartbeat(backfill_popularity), timeout=3600),
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -328,3 +328,78 @@ class TestRunMbidBackfill:
         connector.search_artists.assert_not_awaited()
         assert out["track"].matched == 1
         assert out["artist"].matched == 1
+
+
+def _pop_track(spotify_id: str | None, popularity_score: int | None = None) -> Any:
+    links = {"spotify": spotify_id} if spotify_id is not None else None
+    return _entity(service_links=links, popularity_score=popularity_score)
+
+
+class TestRunPopularityBackfill:
+    @pytest.mark.anyio()
+    async def test_overwrites_score_for_spotify_linked_tracks(self) -> None:
+        # Spotify is authoritative: overwrite a prior synthetic value (#117).
+        a = _pop_track("sp-a", popularity_score=3)
+        b = _pop_track("sp-b", popularity_score=None)
+        session = _session([[a, b], []])
+        connector = AsyncMock()
+        connector.get_tracks = AsyncMock(return_value={"sp-a": 71, "sp-b": 12})
+
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector, access_token="tok"
+        )
+
+        assert a.popularity_score == 71  # overwrote synthetic 3
+        assert b.popularity_score == 12
+        assert counts.candidates == 2
+        assert counts.updated == 2
+        assert counts.no_popularity == 0
+        connector.get_tracks.assert_awaited_once_with("tok", ["sp-a", "sp-b"])
+
+    @pytest.mark.anyio()
+    async def test_no_popularity_leaves_score_untouched(self) -> None:
+        a = _pop_track("sp-a", popularity_score=5)
+        session = _session([[a], []])
+        connector = AsyncMock()
+        connector.get_tracks = AsyncMock(return_value={})  # Spotify gave nothing
+
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector, access_token="tok"
+        )
+
+        assert a.popularity_score == 5  # untouched
+        assert counts.candidates == 1
+        assert counts.updated == 0
+        assert counts.no_popularity == 1
+
+    @pytest.mark.anyio()
+    async def test_dedupes_shared_spotify_id_into_one_lookup(self) -> None:
+        # Two tracks pointing at the same Spotify id -> one lookup, both updated.
+        a = _pop_track("dup")
+        b = _pop_track("dup")
+        session = _session([[a, b], []])
+        connector = AsyncMock()
+        connector.get_tracks = AsyncMock(return_value={"dup": 40})
+
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector, access_token="tok"
+        )
+
+        assert a.popularity_score == 40
+        assert b.popularity_score == 40
+        assert counts.updated == 2
+        connector.get_tracks.assert_awaited_once_with("tok", ["dup"])
+
+    @pytest.mark.anyio()
+    async def test_empty_library_no_lookup(self) -> None:
+        session = _session([[]])
+        connector = AsyncMock()
+        connector.get_tracks = AsyncMock()
+
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector, access_token="tok"
+        )
+
+        assert counts.candidates == 0
+        assert counts.updated == 0
+        connector.get_tracks.assert_not_awaited()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,7 @@ class TestTaskType:
         assert types_module.TaskType.CALENDAR_SYNC == "calendar_sync"
 
     def test_task_type_count(self) -> None:
-        assert len(types_module.TaskType) == 12
+        assert len(types_module.TaskType) == 13
 
 
 class TestAttendanceStatus:

--- a/tests/test_spotify_export.py
+++ b/tests/test_spotify_export.py
@@ -188,13 +188,14 @@ class TestSearchTrack:
     """Tests for search_track."""
 
     @pytest.mark.anyio()
-    async def test_returns_track_id_when_found(self) -> None:
+    async def test_returns_result_with_id_and_popularity_when_found(self) -> None:
         search_response = {
             "tracks": {
                 "items": [
                     {
                         "id": "track-xyz",
                         "name": "Bohemian Rhapsody",
+                        "popularity": 87,
                         "artists": [{"id": "art1", "name": "Queen"}],
                     }
                 ]
@@ -219,7 +220,41 @@ class TestSearchTrack:
             artist_name="Queen",
         )
 
-        assert result == "track-xyz"
+        assert result is not None
+        assert result.track_id == "track-xyz"
+        assert result.popularity == 87
+
+    @pytest.mark.anyio()
+    async def test_popularity_none_when_field_absent(self) -> None:
+        """A track object without a ``popularity`` field yields popularity=None."""
+        search_response = {
+            "tracks": {
+                "items": [
+                    {
+                        "id": "track-no-pop",
+                        "name": "Obscure Track",
+                        "artists": [{"id": "art1", "name": "Nobody"}],
+                    }
+                ]
+            }
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=search_response)
+
+        transport = httpx.MockTransport(handler)
+        connector = _make_connector()
+        connector._http_client = httpx.AsyncClient(transport=transport)
+
+        result = await connector.search_track(
+            access_token="tok",
+            title="Obscure Track",
+            artist_name="Nobody",
+        )
+
+        assert result is not None
+        assert result.track_id == "track-no-pop"
+        assert result.popularity is None
 
     @pytest.mark.anyio()
     async def test_returns_none_when_not_found(self) -> None:
@@ -263,3 +298,105 @@ class TestSearchTrack:
         # URL-encoded query should contain track: and artist: prefixes
         assert "track%3ATest" in captured_url or "track:Test" in captured_url
         assert "artist%3ATest" in captured_url or "artist:Test" in captured_url
+
+
+class TestGetTracks:
+    """Tests for get_tracks (batch popularity lookup by Spotify track ID)."""
+
+    @pytest.mark.anyio()
+    async def test_returns_popularity_keyed_by_id(self) -> None:
+        api_response = {
+            "tracks": [
+                {"id": "id-a", "name": "A", "popularity": 50},
+                {"id": "id-b", "name": "B", "popularity": 10},
+            ]
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "GET"
+            assert request.url.path == "/v1/tracks"
+            params = dict(request.url.params)
+            assert params["ids"] == "id-a,id-b"
+            assert request.headers["Authorization"] == "Bearer tok"
+            return httpx.Response(200, json=api_response)
+
+        transport = httpx.MockTransport(handler)
+        connector = _make_connector()
+        connector._http_client = httpx.AsyncClient(transport=transport)
+
+        result = await connector.get_tracks(
+            access_token="tok", track_ids=["id-a", "id-b"]
+        )
+
+        assert result == {"id-a": 50, "id-b": 10}
+
+    @pytest.mark.anyio()
+    async def test_skips_null_tracks_and_missing_popularity(self) -> None:
+        """Null track entries (unknown IDs) and absent popularity are skipped."""
+        api_response = {
+            "tracks": [
+                {"id": "id-a", "name": "A", "popularity": 50},
+                None,
+                {"id": "id-c", "name": "C"},
+            ]
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=api_response)
+
+        transport = httpx.MockTransport(handler)
+        connector = _make_connector()
+        connector._http_client = httpx.AsyncClient(transport=transport)
+
+        result = await connector.get_tracks(
+            access_token="tok", track_ids=["id-a", "missing", "id-c"]
+        )
+
+        assert result == {"id-a": 50}
+
+    @pytest.mark.anyio()
+    async def test_empty_input_returns_empty_dict_without_request(self) -> None:
+        called = False
+
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            nonlocal called
+            called = True
+            return httpx.Response(200, json={"tracks": []})
+
+        transport = httpx.MockTransport(handler)
+        connector = _make_connector()
+        connector._http_client = httpx.AsyncClient(transport=transport)
+
+        result = await connector.get_tracks(access_token="tok", track_ids=[])
+
+        assert result == {}
+        assert called is False
+
+    @pytest.mark.anyio()
+    async def test_batches_over_50_ids(self) -> None:
+        ids = [f"id-{i:03d}" for i in range(120)]
+        batches: list[list[str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            ids_param = dict(request.url.params)["ids"]
+            batches.append(ids_param.split(","))
+            return httpx.Response(
+                200,
+                json={
+                    "tracks": [
+                        {"id": tid, "popularity": 1} for tid in ids_param.split(",")
+                    ]
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        connector = _make_connector()
+        connector._http_client = httpx.AsyncClient(transport=transport)
+
+        result = await connector.get_tracks(access_token="tok", track_ids=ids)
+
+        assert len(batches) == 3
+        assert len(batches[0]) == 50
+        assert len(batches[1]) == 50
+        assert len(batches[2]) == 20
+        assert len(result) == 120

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -96,7 +96,10 @@ class TestTaskTypeNewValues:
 
     def test_tasktype_member_count(self) -> None:
         """TaskType members (bump when adding a task type)."""
-        assert len(types_module.TaskType) == 12
+        assert len(types_module.TaskType) == 13
 
     def test_mbid_backfill_value(self) -> None:
         assert types_module.TaskType.MBID_BACKFILL == "mbid_backfill"
+
+    def test_popularity_backfill_value(self) -> None:
+        assert types_module.TaskType.POPULARITY_BACKFILL == "popularity_backfill"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -44,7 +44,7 @@ class TestWorkerSettings:
 
     def test_functions_registered(self) -> None:
         funcs = worker_module.WorkerSettings.functions
-        assert len(funcs) == 11
+        assert len(funcs) == 12
         names = {f.name for f in funcs}
         assert names == {
             "plan_sync",
@@ -58,6 +58,7 @@ class TestWorkerSettings:
             "score_and_build_playlist",
             "export_playlist",
             "backfill_mbids",
+            "backfill_popularity",
         }
 
     def test_lifecycle_hooks(self) -> None:

--- a/tests/test_worker_backfill.py
+++ b/tests/test_worker_backfill.py
@@ -10,6 +10,7 @@ import pytest
 
 import resonance.config as config_module
 import resonance.connectors.listenbrainz as listenbrainz_module
+import resonance.connectors.spotify as spotify_module
 import resonance.sync.backfill as backfill_module
 import resonance.types as types_module
 import resonance.worker as worker_module
@@ -142,6 +143,105 @@ async def test_missing_connector_fails_task() -> None:
         ) as run_mock,
     ):
         await worker_module.backfill_mbids(ctx, str(task.id))
+
+    run_mock.assert_not_awaited()
+    assert task.status == types_module.SyncStatus.FAILED
+
+
+def _spotify_ctx(session: AsyncMock) -> dict[str, Any]:
+    registry = MagicMock()
+    registry.get_base_connector.return_value = MagicMock(
+        spec=spotify_module.SpotifyConnector
+    )
+    return {
+        "session_factory": _mock_session_factory(session),
+        "connector_registry": registry,
+        "settings": config_module.Settings(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_popularity_backfill_runs_and_completes() -> None:
+    session = AsyncMock()
+    task = _task()
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module,
+            "_get_spotify_access_token",
+            AsyncMock(return_value="tok"),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_popularity_backfill",
+            AsyncMock(
+                return_value=backfill_module.PopularityBackfillCounts(
+                    candidates=3, updated=2, no_popularity=1
+                )
+            ),
+        ) as run_mock,
+    ):
+        await worker_module.backfill_popularity(_spotify_ctx(session), str(task.id))
+
+    run_mock.assert_awaited_once()
+    assert task.status == types_module.SyncStatus.COMPLETED
+    assert task.result["updated"] == 2
+    assert task.result["no_popularity"] == 1
+
+
+@pytest.mark.asyncio
+async def test_popularity_backfill_missing_connector_fails_task() -> None:
+    session = AsyncMock()
+    task = _task()
+    ctx = _spotify_ctx(session)
+    ctx["connector_registry"].get_base_connector.return_value = None
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_popularity_backfill",
+            AsyncMock(),
+        ) as run_mock,
+    ):
+        await worker_module.backfill_popularity(ctx, str(task.id))
+
+    run_mock.assert_not_awaited()
+    assert task.status == types_module.SyncStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_popularity_backfill_no_connection_fails_task() -> None:
+    session = AsyncMock()
+    task = _task()
+    with (
+        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
+        patch.object(
+            worker_module.lifecycle_module,
+            "is_cancelled",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(
+            worker_module,
+            "_get_spotify_access_token",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            worker_module.backfill_module,
+            "run_popularity_backfill",
+            AsyncMock(),
+        ) as run_mock,
+    ):
+        await worker_module.backfill_popularity(_spotify_ctx(session), str(task.id))
 
     run_mock.assert_not_awaited()
     assert task.status == types_module.SyncStatus.FAILED


### PR DESCRIPTION
Phase 2 of #114 (Phase 1 was #116). Makes `hit_depth` work across the **existing library**, not just discovery tracks.

Phase 1 added the `popularity_score` column, wired it into scoring, and seeded it from ListenBrainz synthetic rank during discovery — but existing library tracks stayed at 0. This PR adds the Spotify-authoritative half: capture real Spotify popularity on the export path, and a backfill task to populate the existing library.

**Held as draft:** carries an alembic migration (`h9i0j1k2l3m4`, new `POPULARITY_BACKFILL` TaskType CHECK constraint). Migration runs as an init container on deploy, so this should merge when someone can watch the rollout.

Closes #117. Relates to #114.

<details>
<summary>What changed</summary>

**Part A — Spotify authoritative popularity (export path)**
- `SpotifyConnector.search_track` now returns a `TrackSearchResult` pydantic model (`track_id` + `popularity: int | None`) instead of a bare `str | None` — it was discarding the `popularity` field the Spotify API already returns.
- The export match loop in `worker.py` persists `track.popularity_score` on each match. Spotify is authoritative and overwrites any synthetic discovery value (Phase 1 only seeds when NULL, so this is intended).

**Part B — Library backfill (`POPULARITY_BACKFILL` task)**
- New `TaskType.POPULARITY_BACKFILL` + CHECK-constraint migration (mirrors the `MBID_BACKFILL` precedent `f7g8h9i0j1k2`).
- Worker handler `backfill_popularity` + `_TASK_DISPATCH` entry + arq registration; core logic in `sync/backfill.py` fetches Spotify popularity for tracks that already have a `spotify` service_link, rate-limited/sequential.
- New `get_tracks` connector method (batch `/v1/tracks?ids=`, 50/batch) so the backfill reads popularity without re-searching.
- Admin API `POST`/`GET /api/v1/admin/backfill-popularity` + `resonance-api backfill-popularity` CLI.
</details>

<details>
<summary>Test Plan</summary>

- [x] `ruff check` + `ruff format --check` clean (164 files)
- [x] `mypy src/` clean (89 files, zero new `type: ignore`)
- [x] `pytest`: **1357 passed** (+13 over Phase 1's 1344)
- [x] Migration `h9i0j1k2l3m4` validated up → down → up against local DB
- [ ] Post-merge: watch the deploy — alembic init container must apply `h9i0j1k2l3m4` cleanly; then run `resonance-api backfill-popularity` to populate the existing library and confirm `hit_depth` differentiates known tracks
</details>

<details>
<summary>Impact</summary>

- After merge + backfill, `hit_depth` scoring differentiates existing library tracks by real Spotify popularity (currently they're all 0, making hit_depth inert for the library).
- `search_track`'s return type changed (`str | None` → `TrackSearchResult | None`); the one internal caller is updated. No external API contract change.
- New admin endpoint + CLI command for triggering the backfill.
</details>