### PR TITLE
feat: source POPULARITY_BACKFILL from ListenBrainz, drop dead Spotify path (hit_depth Phase 2 redo)

### DIFF
--- a/src/resonance/api/v1/admin.py
+++ b/src/resonance/api/v1/admin.py
@@ -413,42 +413,43 @@ async def admin_backfill_coverage_endpoint(
 
 
 async def get_popularity_coverage(db: sa_async.AsyncSession) -> dict[str, object]:
-    """Popularity-backfill coverage: Spotify-linked tracks vs. scored tracks (#117).
+    """Popularity-backfill coverage: MB-recording-linked tracks vs. scored tracks.
 
-    ``spotify_linked`` is how many tracks carry a ``service_links["spotify"]`` id
-    (the backfill candidate set); ``scored`` is how many of those already have a
-    ``popularity_score``.
+    ``mb_linked`` is how many tracks carry a MusicBrainz recording MBID at
+    ``service_links["musicbrainz"]["id"]`` (the backfill candidate set, since LB
+    popularity is keyed by recording MBID); ``scored`` is how many of those
+    already have a ``popularity_score``.
     """
-    spotify_link = music_models.Track.service_links["spotify"].as_string()
+    mb_link = music_models.Track.service_links["musicbrainz"]["id"].as_string()
     linked = await db.scalar(
         sa.select(sa.func.count())
         .select_from(music_models.Track)
-        .where(spotify_link.isnot(None))
+        .where(mb_link.isnot(None))
     )
     scored = await db.scalar(
         sa.select(sa.func.count())
         .select_from(music_models.Track)
         .where(
-            spotify_link.isnot(None),
+            mb_link.isnot(None),
             music_models.Track.popularity_score.isnot(None),
         )
     )
-    return {"spotify_linked": linked or 0, "scored": scored or 0}
+    return {"mb_linked": linked or 0, "scored": scored or 0}
 
 
 @router.post(
     "/backfill-popularity",
-    summary="Enqueue Spotify popularity backfill",
+    summary="Enqueue ListenBrainz popularity backfill",
 )
 async def admin_backfill_popularity_endpoint(
     request: fastapi.Request,
     db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
 ) -> dict[str, str]:
-    """Enqueue a POPULARITY_BACKFILL task (#117).
+    """Enqueue a POPULARITY_BACKFILL task.
 
-    Refreshes ``Track.popularity_score`` from Spotify's authoritative 0-100
-    popularity for every Spotify-linked track, overwriting discovery-sourced
-    synthetic values.
+    Refreshes ``Track.popularity_score`` from ListenBrainz recording popularity
+    (global listen counts, normalized to 0-100) for every track carrying a
+    MusicBrainz recording MBID, overwriting discovery-sourced synthetic values.
     """
     task = task_models.Task(
         task_type=types_module.TaskType.POPULARITY_BACKFILL,
@@ -471,7 +472,7 @@ async def admin_backfill_popularity_endpoint(
 
 @router.get(
     "/backfill-popularity",
-    summary="Spotify popularity backfill coverage",
+    summary="ListenBrainz popularity backfill coverage",
 )
 async def admin_backfill_popularity_coverage_endpoint(
     db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -79,7 +79,7 @@ Commands:
   feed-sync <conn_id|all>      Sync a calendar connection (or all)
   dedup <type> [--no-wait]     Run deduplication
   backfill-mbids [opts]        Backfill MusicBrainz MBIDs (#71)
-  backfill-popularity [opts]   Backfill Spotify popularity (#117)
+  backfill-popularity [opts]   Backfill ListenBrainz popularity
   task <task_id>               Check task status
   track <query>                Search tracks by title
   profile <subcommand>         Manage generator profiles
@@ -1016,12 +1016,13 @@ _POPULARITY_BACKFILL_USAGE = """\
 Usage: resonance-api backfill-popularity [opts]
 
 Options:
-  --status       Show coverage (spotify-linked vs scored), do not enqueue
+  --status       Show coverage (mb-linked vs scored), do not enqueue
   --no-wait      Enqueue and return immediately (don't poll)
 
-Refreshes Track.popularity_score from Spotify's authoritative 0-100 popularity for
-every Spotify-linked track, overwriting discovery-sourced synthetic values. Default
-polls the task to completion and prints the updated/no-popularity counts.
+Refreshes Track.popularity_score from ListenBrainz recording popularity (global
+listen counts, normalized to 0-100) for every track carrying a MusicBrainz recording
+MBID, overwriting discovery-sourced synthetic values. Default polls the task to
+completion and prints the updated/no-popularity counts.
 """
 
 
@@ -1055,7 +1056,10 @@ _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "feed-sync": ("Sync a calendar connection", _cmd_feed_sync),
     "dedup": ("Run deduplication", _cmd_dedup),
     "backfill-mbids": ("Backfill MusicBrainz MBIDs", _cmd_backfill_mbids),
-    "backfill-popularity": ("Backfill Spotify popularity", _cmd_backfill_popularity),
+    "backfill-popularity": (
+        "Backfill ListenBrainz popularity",
+        _cmd_backfill_popularity,
+    ),
     "task": ("Check task status", _cmd_task),
     "track": ("Search tracks by title", _cmd_track),
     "profile": ("Manage generator profiles", _cmd_profile),

--- a/src/resonance/connectors/listenbrainz.py
+++ b/src/resonance/connectors/listenbrainz.py
@@ -21,6 +21,11 @@ MUSICBRAINZ_USERINFO_URL = "https://musicbrainz.org/oauth2/userinfo"
 LISTENBRAINZ_API_BASE = "https://api.listenbrainz.org/1"
 LISTENBRAINZ_LABS_BASE = "https://labs.api.listenbrainz.org"
 
+# Max recording MBIDs per POST /1/popularity/recording request. The endpoint
+# caps at MAX_ITEMS_PER_GET (1000 server-side); 50 keeps each request small and
+# matches the conservative batching used elsewhere.
+MAX_RECORDING_POPULARITY_BATCH = 50
+
 # The labs similar-artists endpoint bakes its result limit into the algorithm
 # name (limit_100). There is no separate limit query param, so the caller's
 # limit is applied client-side after fetching.
@@ -313,6 +318,46 @@ class ListenBrainzConnector(base_module.BaseConnector):
                 return track_id
 
         return None
+
+    async def get_recording_popularity(
+        self, recording_mbids: list[str]
+    ) -> dict[str, int]:
+        """Fetch global listen counts for recordings by MusicBrainz recording MBID.
+
+        Calls the public ``POST /1/popularity/recording`` endpoint (unauthenticated),
+        batching at ``MAX_RECORDING_POPULARITY_BATCH`` per request. The endpoint
+        returns ``total_listen_count``/``total_user_count`` per recording, with
+        nulls for recordings it has no data on.
+
+        Args:
+            recording_mbids: MusicBrainz recording UUIDs to look up.
+
+        Returns:
+            A mapping of recording MBID -> ``total_listen_count`` for every
+            requested MBID that resolved to a non-null listen count. Recordings
+            with no data (null counts) are omitted.
+        """
+        if not recording_mbids:
+            return {}
+        out: dict[str, int] = {}
+        for i in range(0, len(recording_mbids), MAX_RECORDING_POPULARITY_BATCH):
+            batch = recording_mbids[i : i + MAX_RECORDING_POPULARITY_BATCH]
+            response = await self._request(
+                "POST",
+                f"{LISTENBRAINZ_API_BASE}/popularity/recording",
+                json={"recording_mbids": batch},
+            )
+            for entry in response.json():
+                mbid = entry.get("recording_mbid")
+                count = entry.get("total_listen_count")
+                if mbid and count is not None:
+                    out[str(mbid)] = int(count)
+        logger.info(
+            "listenbrainz_recording_popularity",
+            requested=len(recording_mbids),
+            resolved=len(out),
+        )
+        return out
 
     async def get_similar_artists(
         self,

--- a/src/resonance/connectors/spotify.py
+++ b/src/resonance/connectors/spotify.py
@@ -50,17 +50,6 @@ class SavedTrackPage(pydantic.BaseModel):
     next_url: str | None
 
 
-class TrackSearchResult(pydantic.BaseModel):
-    """A matched Spotify track from a search.
-
-    ``popularity`` is Spotify's authoritative 0-100 score; it is None when the
-    track object omits the field (rare).
-    """
-
-    track_id: str
-    popularity: int | None
-
-
 class SpotifyConnector(base_module.BaseConnector):
     """Connector for the Spotify Web API."""
 
@@ -368,13 +357,8 @@ class SpotifyConnector(base_module.BaseConnector):
         access_token: str,
         title: str,
         artist_name: str,
-    ) -> TrackSearchResult | None:
-        """Search Spotify for a track by title and artist.
-
-        Returns the matched track's ID and its authoritative 0-100 popularity
-        score, or None when no track matches. The popularity field feeds
-        ``Track.popularity_score`` (Spotify is authoritative — see #117).
-        """
+    ) -> str | None:
+        """Search Spotify for a track by title and artist. Returns track ID or None."""
         query = f"track:{title} artist:{artist_name}"
         response = await self._request(
             "GET",
@@ -386,45 +370,8 @@ class SpotifyConnector(base_module.BaseConnector):
         items = data.get("tracks", {}).get("items", [])
         if not items:
             return None
-        item = items[0]
-        return TrackSearchResult(
-            track_id=item["id"],
-            popularity=item.get("popularity"),
-        )
-
-    async def get_tracks(
-        self,
-        access_token: str,
-        track_ids: list[str],
-    ) -> dict[str, int]:
-        """Fetch popularity for tracks by Spotify ID, batching at 50 per request.
-
-        Returns a mapping of track ID -> 0-100 popularity for every requested ID
-        that resolved to a track exposing a ``popularity`` field. Unknown IDs
-        (Spotify returns a null entry) and tracks without a popularity field are
-        omitted. Used by the POPULARITY_BACKFILL task (#117) to populate
-        ``Track.popularity_score`` for tracks already linked to Spotify.
-        """
-        if not track_ids:
-            return {}
-        out: dict[str, int] = {}
-        for i in range(0, len(track_ids), 50):
-            batch = track_ids[i : i + 50]
-            response = await self._request(
-                "GET",
-                f"{SPOTIFY_API_BASE}/tracks",
-                headers={"Authorization": f"Bearer {access_token}"},
-                params={"ids": ",".join(batch)},
-            )
-            data = response.json()
-            for track in data.get("tracks", []):
-                if track is None:
-                    continue
-                popularity = track.get("popularity")
-                if popularity is None:
-                    continue
-                out[track["id"]] = popularity
-        return out
+        result: str = items[0]["id"]
+        return result
 
     async def get_artist_by_id(
         self,

--- a/src/resonance/sync/backfill.py
+++ b/src/resonance/sync/backfill.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import math
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -52,7 +53,6 @@ import structlog
 
 import resonance.config as config_module
 import resonance.connectors.listenbrainz as listenbrainz_module
-import resonance.connectors.spotify as spotify_module
 import resonance.models.music as music_module
 import resonance.normalize as normalize_module
 import resonance.services.artist_utils as artist_utils
@@ -317,39 +317,68 @@ async def backfill_artists(
 
 @dataclasses.dataclass
 class PopularityBackfillCounts:
-    """Outcome tally for a Spotify popularity backfill run."""
+    """Outcome tally for a ListenBrainz popularity backfill run."""
 
     candidates: int = 0
     updated: int = 0
     no_popularity: int = 0
+    skipped_no_mbid: int = 0
+
+
+# Listen-count ceiling for the 0-100 normalization. A global hit recording
+# (e.g. "Closer" at ~1.38M listens) saturates the scale; 10^6 gives a clean
+# log10 denominator of 6.
+_POPULARITY_CEILING = 1_000_000
+_POPULARITY_LOG_CEILING = math.log10(_POPULARITY_CEILING)
+
+
+def normalize_popularity(listen_count: int) -> int:
+    """Map a raw ListenBrainz listen count to a 0-100 popularity score.
+
+    Listen counts are heavy-tailed (a handful of recordings dominate), so a
+    linear scale would collapse almost everything to 0. A log10 mapping spreads
+    the distribution: ``score = 100 * log10(count) / log10(10^6)``, clamped to
+    0-100. A recording with ~1M listens saturates to 100; ~1000 listens lands at
+    50; a single listen rounds to ~0.
+
+    Args:
+        listen_count: ``total_listen_count`` from the LB popularity endpoint.
+
+    Returns:
+        An integer popularity score in ``[0, 100]``.
+    """
+    if listen_count <= 0:
+        return 0
+    ratio = math.log10(listen_count) / _POPULARITY_LOG_CEILING
+    return max(0, min(100, round(ratio * 100)))
 
 
 async def run_popularity_backfill(
     session: Any,
     settings: config_module.Settings,
-    connector: spotify_module.SpotifyConnector,
-    access_token: str,
+    connector: listenbrainz_module.ListenBrainzConnector,
 ) -> PopularityBackfillCounts:
-    """Backfill ``Track.popularity_score`` from Spotify for Spotify-linked tracks.
+    """Backfill ``Track.popularity_score`` from ListenBrainz recording popularity.
 
-    Iterates tracks whose ``service_links["spotify"]`` is set, in batches, and
-    fetches Spotify's authoritative 0-100 popularity via ``connector.get_tracks``.
-    Spotify is authoritative, so the fetched value overwrites any prior
-    discovery-sourced synthetic ``popularity_score`` (#117).
+    Iterates library tracks that carry a MusicBrainz recording MBID
+    (``service_links["musicbrainz"]["id"]``), in batches, and fetches each
+    recording's global listen count via ``connector.get_recording_popularity``
+    (the public ``POST /1/popularity/recording`` endpoint — no auth token). The
+    listen count is normalized to a 0-100 score (see ``normalize_popularity``) and
+    overwrites any prior discovery-sourced synthetic ``popularity_score``.
 
-    Tracks Spotify reports without a popularity field are counted under
-    ``no_popularity`` and left untouched. Batched + committed per batch so a worker
-    restart re-enters and re-scans (the scan is idempotent — re-reading popularity
-    is cheap and converges).
+    Tracks without a recording MBID are counted under ``skipped_no_mbid`` and left
+    untouched — there is no MBID-keyed popularity to fetch for them. Recordings LB
+    has no data on are counted under ``no_popularity`` and left untouched. Batched
+    and committed per batch so a worker restart re-enters and re-scans (the scan is
+    idempotent — re-reading popularity is cheap and converges).
     """
     counts = PopularityBackfillCounts()
-    spotify_link = music_module.Track.service_links["spotify"].as_string()
     offset = 0
     batch_size = settings.mbid_mapper_batch_size
     while True:
         stmt = (
             sa.select(music_module.Track)
-            .where(spotify_link.isnot(None))
             .order_by(music_module.Track.id)
             .offset(offset)
             .limit(batch_size)
@@ -360,23 +389,27 @@ async def run_popularity_backfill(
         offset += len(tracks)
         counts.candidates += len(tracks)
 
-        by_spotify_id: dict[str, list[music_module.Track]] = {}
+        by_recording_mbid: dict[str, list[music_module.Track]] = {}
         for track in tracks:
-            spotify_id = (track.service_links or {}).get("spotify")
-            if isinstance(spotify_id, str):
-                by_spotify_id.setdefault(spotify_id, []).append(track)
+            recording_mbid = artist_utils.get_mbid(track.service_links)
+            if recording_mbid:
+                by_recording_mbid.setdefault(recording_mbid, []).append(track)
+            else:
+                counts.skipped_no_mbid += 1
 
-        popularity = await connector.get_tracks(
-            access_token, list(by_spotify_id.keys())
-        )
-        for spotify_id, group in by_spotify_id.items():
-            score = popularity.get(spotify_id)
-            if score is None:
-                counts.no_popularity += len(group)
-                continue
-            for track in group:
-                track.popularity_score = score
-                counts.updated += 1
+        if by_recording_mbid:
+            popularity = await connector.get_recording_popularity(
+                list(by_recording_mbid.keys())
+            )
+            for recording_mbid, group in by_recording_mbid.items():
+                listen_count = popularity.get(recording_mbid)
+                if listen_count is None:
+                    counts.no_popularity += len(group)
+                    continue
+                score = normalize_popularity(listen_count)
+                for track in group:
+                    track.popularity_score = score
+                    counts.updated += 1
 
         await session.commit()
 

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -625,66 +625,15 @@ async def backfill_mbids(ctx: dict[str, Any], task_id: str) -> None:
             await mapper.aclose()
 
 
-async def _get_spotify_access_token(
-    session: sa_async.AsyncSession,
-    connector: spotify_module.SpotifyConnector,
-    settings: config_module.Settings,
-) -> str | None:
-    """Find a Spotify connection and return a valid (refreshed) access token.
-
-    Returns None when no Spotify connection has a usable access token. Picks the
-    most-recently-created connection so a re-auth supersedes a stale one. Mirrors
-    the token decrypt+refresh dance the export task does inline.
-    """
-    conn_result = await session.execute(
-        sa.select(user_models.ServiceConnection)
-        .where(
-            user_models.ServiceConnection.service_type
-            == types_module.ServiceType.SPOTIFY,
-            user_models.ServiceConnection.encrypted_access_token.isnot(None),
-        )
-        .order_by(user_models.ServiceConnection.created_at.desc())
-        .limit(1)
-    )
-    connection = conn_result.scalar_one_or_none()
-    if connection is None or connection.encrypted_access_token is None:
-        return None
-
-    access_token = crypto_module.decrypt_token(
-        connection.encrypted_access_token, settings.token_encryption_key
-    )
-    if (
-        connection.token_expires_at is not None
-        and connection.token_expires_at <= datetime.datetime.now(datetime.UTC)
-        and connection.encrypted_refresh_token is not None
-    ):
-        refresh_token = crypto_module.decrypt_token(
-            connection.encrypted_refresh_token, settings.token_encryption_key
-        )
-        token_response = await connector.refresh_access_token(refresh_token)
-        access_token = token_response.access_token
-        connection.encrypted_access_token = crypto_module.encrypt_token(
-            access_token, settings.token_encryption_key
-        )
-        if token_response.expires_in is not None:
-            connection.token_expires_at = datetime.datetime.now(
-                datetime.UTC
-            ) + datetime.timedelta(seconds=token_response.expires_in)
-        await session.commit()
-        logger.info("popularity_backfill_token_refreshed")
-
-    return access_token
-
-
 async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
-    """Execute a POPULARITY_BACKFILL task (#117): refresh Track.popularity_score.
+    """Execute a POPULARITY_BACKFILL task: refresh Track.popularity_score from LB.
 
-    Fetches Spotify's authoritative 0-100 popularity for every track linked to
-    Spotify (``service_links["spotify"]``) and overwrites ``popularity_score``.
-    Spotify is authoritative, so this supersedes the discovery-sourced synthetic
-    values seeded in #116. Sequential + batched (like the Spotify sync strategy)
-    to stay within rate limits; resumable across worker restarts because the scan
-    is idempotent.
+    Fetches each library track's global listen count from ListenBrainz's public
+    recording-popularity endpoint (keyed by MusicBrainz recording MBID),
+    normalizes it to a 0-100 score, and overwrites ``popularity_score``. This
+    supersedes the discovery-sourced synthetic values seeded in #116. The LB
+    endpoint is unauthenticated, so no token is needed. Sequential + batched and
+    resumable across worker restarts because the scan is idempotent.
 
     Args:
         ctx: arq worker context dict.
@@ -696,7 +645,7 @@ async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
     log = logger.bind(task_id=task_id)
 
     connector = wctx["connector_registry"].get_base_connector(
-        types_module.ServiceType.SPOTIFY
+        types_module.ServiceType.LISTENBRAINZ
     )
 
     async with session_factory() as session:
@@ -714,11 +663,11 @@ async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
                 await session.commit()
                 return
 
-            if not isinstance(connector, spotify_module.SpotifyConnector):
+            if not isinstance(connector, listenbrainz_module.ListenBrainzConnector):
                 await lifecycle_module.fail_task(
                     session,
                     task,
-                    "Spotify connector unavailable for popularity backfill",
+                    "ListenBrainz connector unavailable for popularity backfill",
                 )
                 await session.commit()
                 log.error("popularity_backfill_no_connector")
@@ -728,20 +677,9 @@ async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
             task.started_at = datetime.datetime.now(datetime.UTC)
             await session.commit()
 
-            access_token = await _get_spotify_access_token(session, connector, settings)
-            if access_token is None:
-                await lifecycle_module.fail_task(
-                    session,
-                    task,
-                    "No Spotify connection with an access token",
-                )
-                await session.commit()
-                log.error("popularity_backfill_no_connection")
-                return
-
             log.info("popularity_backfill_started")
             counts = await backfill_module.run_popularity_backfill(
-                session, settings, connector, access_token
+                session, settings, connector
             )
             result: dict[str, object] = dataclasses.asdict(counts)
             await lifecycle_module.complete_task(session, task, result)
@@ -1698,19 +1636,15 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
 
                 if spotify_id is None:
                     artist_name = track.artist.name if track.artist else ""
-                    search_result = await connector.search_track(
+                    found_spotify_id = await connector.search_track(
                         access_token, track.title, artist_name
                     )
-                    if search_result is not None:
+                    if found_spotify_id is not None:
                         updated_links = dict(track_links)
-                        updated_links["spotify"] = search_result.track_id
+                        updated_links["spotify"] = found_spotify_id
                         track.service_links = updated_links
-                        spotify_id = search_result.track_id
+                        spotify_id = found_spotify_id
                         search_matched += 1
-                        # Spotify is authoritative for popularity — overwrite any
-                        # discovery-sourced synthetic value (#117).
-                        if search_result.popularity is not None:
-                            track.popularity_score = search_result.popularity
                     else:
                         skipped_tracks.append(track.title)
                         continue

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -330,41 +330,69 @@ class TestRunMbidBackfill:
         assert out["artist"].matched == 1
 
 
-def _pop_track(spotify_id: str | None, popularity_score: int | None = None) -> Any:
-    links = {"spotify": spotify_id} if spotify_id is not None else None
+def _pop_track(recording_mbid: str | None, popularity_score: int | None = None) -> Any:
+    links = {"musicbrainz": {"id": recording_mbid}} if recording_mbid else None
     return _entity(service_links=links, popularity_score=popularity_score)
+
+
+class TestNormalizePopularity:
+    """The log10 mapping from a raw listen count to a 0-100 score."""
+
+    def test_zero_count_is_zero(self) -> None:
+        assert backfill_module.normalize_popularity(0) == 0
+
+    def test_one_million_listens_saturates_to_100(self) -> None:
+        # 10^6 is the ceiling (a global hit like "Closer" at ~1.38M -> capped 100).
+        assert backfill_module.normalize_popularity(1_000_000) == 100
+        assert backfill_module.normalize_popularity(2_000_000) == 100
+
+    def test_monotonic_increasing(self) -> None:
+        scores = [backfill_module.normalize_popularity(c) for c in (1, 100, 10_000)]
+        assert scores == sorted(scores)
+        assert all(0 <= s <= 100 for s in scores)
+
+    def test_thousand_listens_is_midscale(self) -> None:
+        # log10(1000)/log10(1e6) = 3/6 = 0.5 -> 50.
+        assert backfill_module.normalize_popularity(1000) == 50
 
 
 class TestRunPopularityBackfill:
     @pytest.mark.anyio()
-    async def test_overwrites_score_for_spotify_linked_tracks(self) -> None:
-        # Spotify is authoritative: overwrite a prior synthetic value (#117).
-        a = _pop_track("sp-a", popularity_score=3)
-        b = _pop_track("sp-b", popularity_score=None)
+    async def test_normalizes_and_overwrites_for_mb_linked_tracks(self) -> None:
+        # LB is the source: overwrite any prior synthetic value with the
+        # normalized listen count.
+        a = _pop_track("rec-a", popularity_score=3)
+        b = _pop_track("rec-b", popularity_score=None)
         session = _session([[a, b], []])
         connector = AsyncMock()
-        connector.get_tracks = AsyncMock(return_value={"sp-a": 71, "sp-b": 12})
-
-        counts = await backfill_module.run_popularity_backfill(
-            session, _settings(), connector, access_token="tok"
+        # rec-a: 10^6 listens -> 100; rec-b: 1000 listens -> 50.
+        connector.get_recording_popularity = AsyncMock(
+            return_value={"rec-a": 1_000_000, "rec-b": 1000}
         )
 
-        assert a.popularity_score == 71  # overwrote synthetic 3
-        assert b.popularity_score == 12
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector
+        )
+
+        assert a.popularity_score == 100  # overwrote synthetic 3
+        assert b.popularity_score == 50
         assert counts.candidates == 2
         assert counts.updated == 2
         assert counts.no_popularity == 0
-        connector.get_tracks.assert_awaited_once_with("tok", ["sp-a", "sp-b"])
+        assert counts.skipped_no_mbid == 0
+        connector.get_recording_popularity.assert_awaited_once_with(["rec-a", "rec-b"])
 
     @pytest.mark.anyio()
     async def test_no_popularity_leaves_score_untouched(self) -> None:
-        a = _pop_track("sp-a", popularity_score=5)
+        a = _pop_track("rec-a", popularity_score=5)
         session = _session([[a], []])
         connector = AsyncMock()
-        connector.get_tracks = AsyncMock(return_value={})  # Spotify gave nothing
+        connector.get_recording_popularity = AsyncMock(
+            return_value={}
+        )  # LB had no data
 
         counts = await backfill_module.run_popularity_backfill(
-            session, _settings(), connector, access_token="tok"
+            session, _settings(), connector
         )
 
         assert a.popularity_score == 5  # untouched
@@ -373,33 +401,54 @@ class TestRunPopularityBackfill:
         assert counts.no_popularity == 1
 
     @pytest.mark.anyio()
-    async def test_dedupes_shared_spotify_id_into_one_lookup(self) -> None:
-        # Two tracks pointing at the same Spotify id -> one lookup, both updated.
+    async def test_skips_tracks_without_recording_mbid(self) -> None:
+        # A track with no MB recording MBID is counted and skipped (not looked up).
+        a = _pop_track("rec-a")
+        b = _pop_track(None)  # no musicbrainz link
+        session = _session([[a, b], []])
+        connector = AsyncMock()
+        connector.get_recording_popularity = AsyncMock(return_value={"rec-a": 1000})
+
+        counts = await backfill_module.run_popularity_backfill(
+            session, _settings(), connector
+        )
+
+        assert a.popularity_score == 50
+        assert b.popularity_score is None  # left untouched
+        assert counts.candidates == 2
+        assert counts.updated == 1
+        assert counts.skipped_no_mbid == 1
+        # Only the MB-linked track is looked up.
+        connector.get_recording_popularity.assert_awaited_once_with(["rec-a"])
+
+    @pytest.mark.anyio()
+    async def test_dedupes_shared_recording_mbid_into_one_lookup(self) -> None:
+        # Two tracks pointing at the same recording MBID -> one lookup, both updated.
         a = _pop_track("dup")
         b = _pop_track("dup")
         session = _session([[a, b], []])
         connector = AsyncMock()
-        connector.get_tracks = AsyncMock(return_value={"dup": 40})
+        connector.get_recording_popularity = AsyncMock(return_value={"dup": 1000})
 
         counts = await backfill_module.run_popularity_backfill(
-            session, _settings(), connector, access_token="tok"
+            session, _settings(), connector
         )
 
-        assert a.popularity_score == 40
-        assert b.popularity_score == 40
+        assert a.popularity_score == 50
+        assert b.popularity_score == 50
         assert counts.updated == 2
-        connector.get_tracks.assert_awaited_once_with("tok", ["dup"])
+        connector.get_recording_popularity.assert_awaited_once_with(["dup"])
 
     @pytest.mark.anyio()
     async def test_empty_library_no_lookup(self) -> None:
         session = _session([[]])
         connector = AsyncMock()
-        connector.get_tracks = AsyncMock()
+        connector.get_recording_popularity = AsyncMock()
 
         counts = await backfill_module.run_popularity_backfill(
-            session, _settings(), connector, access_token="tok"
+            session, _settings(), connector
         )
 
         assert counts.candidates == 0
         assert counts.updated == 0
-        connector.get_tracks.assert_not_awaited()
+        connector.get_recording_popularity.assert_not_awaited()

--- a/tests/test_listenbrainz_connector.py
+++ b/tests/test_listenbrainz_connector.py
@@ -1,5 +1,6 @@
 """Tests for the ListenBrainz connector."""
 
+import json
 import urllib.parse
 
 import httpx
@@ -401,6 +402,114 @@ class TestDiscoverTracks:
         assert result[0].popularity_score == 100
         assert result[1].popularity_score == 95
         assert result[2].popularity_score == 90
+
+
+class TestGetRecordingPopularity:
+    """Tests for get_recording_popularity (POST /1/popularity/recording)."""
+
+    def _connector_with_handler(
+        self, handler: object
+    ) -> listenbrainz_module.ListenBrainzConnector:
+        transport = httpx.MockTransport(handler)  # type: ignore[arg-type]
+        connector = listenbrainz_module.ListenBrainzConnector(settings=_make_settings())
+        connector._http_client = httpx.AsyncClient(transport=transport)
+        connector._budget = ratelimit_module.RateLimitBudget(default_interval=0.0)
+        return connector
+
+    @pytest.mark.anyio()
+    async def test_posts_mbids_and_returns_listen_counts(self) -> None:
+        api_response = [
+            {
+                "recording_mbid": "rec-a",
+                "total_listen_count": 1000,
+                "total_user_count": 10,
+            },
+            {
+                "recording_mbid": "rec-b",
+                "total_listen_count": 25,
+                "total_user_count": 3,
+            },
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert "api.listenbrainz.org/1/popularity/recording" in str(request.url)
+            # Public endpoint — no Authorization header threaded through.
+            assert "Authorization" not in request.headers
+            body = json.loads(request.content)
+            assert body["recording_mbids"] == ["rec-a", "rec-b"]
+            return httpx.Response(200, json=api_response)
+
+        connector = self._connector_with_handler(handler)
+        result = await connector.get_recording_popularity(["rec-a", "rec-b"])
+
+        assert result == {"rec-a": 1000, "rec-b": 25}
+
+    @pytest.mark.anyio()
+    async def test_skips_null_listen_counts(self) -> None:
+        api_response = [
+            {
+                "recording_mbid": "rec-a",
+                "total_listen_count": 500,
+                "total_user_count": 8,
+            },
+            {
+                "recording_mbid": "rec-b",
+                "total_listen_count": None,
+                "total_user_count": None,
+            },
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=api_response)
+
+        connector = self._connector_with_handler(handler)
+        result = await connector.get_recording_popularity(["rec-a", "rec-b"])
+
+        assert result == {"rec-a": 500}
+
+    @pytest.mark.anyio()
+    async def test_empty_input_returns_empty_without_request(self) -> None:
+        called = False
+
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            nonlocal called
+            called = True
+            return httpx.Response(200, json=[])
+
+        connector = self._connector_with_handler(handler)
+        result = await connector.get_recording_popularity([])
+
+        assert result == {}
+        assert called is False
+
+    @pytest.mark.anyio()
+    async def test_batches_over_limit(self) -> None:
+        mbids = [f"rec-{i:03d}" for i in range(120)]
+        batches: list[list[str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            posted = body["recording_mbids"]
+            batches.append(posted)
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "recording_mbid": m,
+                        "total_listen_count": 1,
+                        "total_user_count": 1,
+                    }
+                    for m in posted
+                ],
+            )
+
+        connector = self._connector_with_handler(handler)
+        result = await connector.get_recording_popularity(mbids)
+
+        # Batched at MAX_RECORDING_POPULARITY_BATCH (50) -> 50 + 50 + 20.
+        assert [len(b) for b in batches] == [50, 50, 20]
+        assert len(result) == 120
 
 
 class TestGetSimilarArtists:

--- a/tests/test_spotify_export.py
+++ b/tests/test_spotify_export.py
@@ -188,14 +188,13 @@ class TestSearchTrack:
     """Tests for search_track."""
 
     @pytest.mark.anyio()
-    async def test_returns_result_with_id_and_popularity_when_found(self) -> None:
+    async def test_returns_track_id_when_found(self) -> None:
         search_response = {
             "tracks": {
                 "items": [
                     {
                         "id": "track-xyz",
                         "name": "Bohemian Rhapsody",
-                        "popularity": 87,
                         "artists": [{"id": "art1", "name": "Queen"}],
                     }
                 ]
@@ -220,41 +219,7 @@ class TestSearchTrack:
             artist_name="Queen",
         )
 
-        assert result is not None
-        assert result.track_id == "track-xyz"
-        assert result.popularity == 87
-
-    @pytest.mark.anyio()
-    async def test_popularity_none_when_field_absent(self) -> None:
-        """A track object without a ``popularity`` field yields popularity=None."""
-        search_response = {
-            "tracks": {
-                "items": [
-                    {
-                        "id": "track-no-pop",
-                        "name": "Obscure Track",
-                        "artists": [{"id": "art1", "name": "Nobody"}],
-                    }
-                ]
-            }
-        }
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=search_response)
-
-        transport = httpx.MockTransport(handler)
-        connector = _make_connector()
-        connector._http_client = httpx.AsyncClient(transport=transport)
-
-        result = await connector.search_track(
-            access_token="tok",
-            title="Obscure Track",
-            artist_name="Nobody",
-        )
-
-        assert result is not None
-        assert result.track_id == "track-no-pop"
-        assert result.popularity is None
+        assert result == "track-xyz"
 
     @pytest.mark.anyio()
     async def test_returns_none_when_not_found(self) -> None:
@@ -298,105 +263,3 @@ class TestSearchTrack:
         # URL-encoded query should contain track: and artist: prefixes
         assert "track%3ATest" in captured_url or "track:Test" in captured_url
         assert "artist%3ATest" in captured_url or "artist:Test" in captured_url
-
-
-class TestGetTracks:
-    """Tests for get_tracks (batch popularity lookup by Spotify track ID)."""
-
-    @pytest.mark.anyio()
-    async def test_returns_popularity_keyed_by_id(self) -> None:
-        api_response = {
-            "tracks": [
-                {"id": "id-a", "name": "A", "popularity": 50},
-                {"id": "id-b", "name": "B", "popularity": 10},
-            ]
-        }
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            assert request.method == "GET"
-            assert request.url.path == "/v1/tracks"
-            params = dict(request.url.params)
-            assert params["ids"] == "id-a,id-b"
-            assert request.headers["Authorization"] == "Bearer tok"
-            return httpx.Response(200, json=api_response)
-
-        transport = httpx.MockTransport(handler)
-        connector = _make_connector()
-        connector._http_client = httpx.AsyncClient(transport=transport)
-
-        result = await connector.get_tracks(
-            access_token="tok", track_ids=["id-a", "id-b"]
-        )
-
-        assert result == {"id-a": 50, "id-b": 10}
-
-    @pytest.mark.anyio()
-    async def test_skips_null_tracks_and_missing_popularity(self) -> None:
-        """Null track entries (unknown IDs) and absent popularity are skipped."""
-        api_response = {
-            "tracks": [
-                {"id": "id-a", "name": "A", "popularity": 50},
-                None,
-                {"id": "id-c", "name": "C"},
-            ]
-        }
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=api_response)
-
-        transport = httpx.MockTransport(handler)
-        connector = _make_connector()
-        connector._http_client = httpx.AsyncClient(transport=transport)
-
-        result = await connector.get_tracks(
-            access_token="tok", track_ids=["id-a", "missing", "id-c"]
-        )
-
-        assert result == {"id-a": 50}
-
-    @pytest.mark.anyio()
-    async def test_empty_input_returns_empty_dict_without_request(self) -> None:
-        called = False
-
-        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
-            nonlocal called
-            called = True
-            return httpx.Response(200, json={"tracks": []})
-
-        transport = httpx.MockTransport(handler)
-        connector = _make_connector()
-        connector._http_client = httpx.AsyncClient(transport=transport)
-
-        result = await connector.get_tracks(access_token="tok", track_ids=[])
-
-        assert result == {}
-        assert called is False
-
-    @pytest.mark.anyio()
-    async def test_batches_over_50_ids(self) -> None:
-        ids = [f"id-{i:03d}" for i in range(120)]
-        batches: list[list[str]] = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            ids_param = dict(request.url.params)["ids"]
-            batches.append(ids_param.split(","))
-            return httpx.Response(
-                200,
-                json={
-                    "tracks": [
-                        {"id": tid, "popularity": 1} for tid in ids_param.split(",")
-                    ]
-                },
-            )
-
-        transport = httpx.MockTransport(handler)
-        connector = _make_connector()
-        connector._http_client = httpx.AsyncClient(transport=transport)
-
-        result = await connector.get_tracks(access_token="tok", track_ids=ids)
-
-        assert len(batches) == 3
-        assert len(batches[0]) == 50
-        assert len(batches[1]) == 50
-        assert len(batches[2]) == 20
-        assert len(result) == 120

--- a/tests/test_worker_backfill.py
+++ b/tests/test_worker_backfill.py
@@ -10,7 +10,6 @@ import pytest
 
 import resonance.config as config_module
 import resonance.connectors.listenbrainz as listenbrainz_module
-import resonance.connectors.spotify as spotify_module
 import resonance.sync.backfill as backfill_module
 import resonance.types as types_module
 import resonance.worker as worker_module
@@ -148,18 +147,6 @@ async def test_missing_connector_fails_task() -> None:
     assert task.status == types_module.SyncStatus.FAILED
 
 
-def _spotify_ctx(session: AsyncMock) -> dict[str, Any]:
-    registry = MagicMock()
-    registry.get_base_connector.return_value = MagicMock(
-        spec=spotify_module.SpotifyConnector
-    )
-    return {
-        "session_factory": _mock_session_factory(session),
-        "connector_registry": registry,
-        "settings": config_module.Settings(),
-    }
-
-
 @pytest.mark.asyncio
 async def test_popularity_backfill_runs_and_completes() -> None:
     session = AsyncMock()
@@ -172,21 +159,17 @@ async def test_popularity_backfill_runs_and_completes() -> None:
             AsyncMock(return_value=False),
         ),
         patch.object(
-            worker_module,
-            "_get_spotify_access_token",
-            AsyncMock(return_value="tok"),
-        ),
-        patch.object(
             worker_module.backfill_module,
             "run_popularity_backfill",
             AsyncMock(
                 return_value=backfill_module.PopularityBackfillCounts(
-                    candidates=3, updated=2, no_popularity=1
+                    candidates=3, updated=2, no_popularity=1, skipped_no_mbid=0
                 )
             ),
         ) as run_mock,
     ):
-        await worker_module.backfill_popularity(_spotify_ctx(session), str(task.id))
+        # _ctx wires a ListenBrainz connector (popularity is sourced from LB).
+        await worker_module.backfill_popularity(_ctx(session), str(task.id))
 
     run_mock.assert_awaited_once()
     assert task.status == types_module.SyncStatus.COMPLETED
@@ -198,7 +181,7 @@ async def test_popularity_backfill_runs_and_completes() -> None:
 async def test_popularity_backfill_missing_connector_fails_task() -> None:
     session = AsyncMock()
     task = _task()
-    ctx = _spotify_ctx(session)
+    ctx = _ctx(session)
     ctx["connector_registry"].get_base_connector.return_value = None
     with (
         patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
@@ -214,34 +197,6 @@ async def test_popularity_backfill_missing_connector_fails_task() -> None:
         ) as run_mock,
     ):
         await worker_module.backfill_popularity(ctx, str(task.id))
-
-    run_mock.assert_not_awaited()
-    assert task.status == types_module.SyncStatus.FAILED
-
-
-@pytest.mark.asyncio
-async def test_popularity_backfill_no_connection_fails_task() -> None:
-    session = AsyncMock()
-    task = _task()
-    with (
-        patch.object(worker_module, "_load_task", AsyncMock(return_value=task)),
-        patch.object(
-            worker_module.lifecycle_module,
-            "is_cancelled",
-            AsyncMock(return_value=False),
-        ),
-        patch.object(
-            worker_module,
-            "_get_spotify_access_token",
-            AsyncMock(return_value=None),
-        ),
-        patch.object(
-            worker_module.backfill_module,
-            "run_popularity_backfill",
-            AsyncMock(),
-        ) as run_mock,
-    ):
-        await worker_module.backfill_popularity(_spotify_ctx(session), str(task.id))
 
     run_mock.assert_not_awaited()
     assert task.status == types_module.SyncStatus.FAILED


### PR DESCRIPTION
Re-aims the Phase 2 popularity backfill from Spotify to ListenBrainz, and removes the now-dead Spotify-popularity code. Supersedes the Spotify approach merged in #118.

**Why:** Spotify's dev-mode API can't support the original design (see `docs/spotify-api-constraints.md`): the `GET /tracks` batch endpoint was removed (the #118 backfill 403'd on it), and the `popularity` field was removed from the Track object on all endpoints (so the export-path capture read a field that no longer exists). ListenBrainz is the only viable popularity source now.

**No migration** — `POPULARITY_BACKFILL` TaskType + its CHECK constraint already landed in #118 (migration `h9i0j1k2l3m4`, on main). This PR only changes what the task *does*, so it's deploy-safe without a migration watch.

Closes #117. Relates to #114.

<details>
<summary>What changed</summary>

**ListenBrainz popularity source**
- New `ListenBrainzConnector.get_recording_popularity(recording_mbids)` → `POST /1/popularity/recording` (public, batched 50/req), keyed by MusicBrainz recording MBID, returns `total_listen_count`.
- `run_popularity_backfill` now iterates library tracks that have a MusicBrainz recording MBID (`service_links["musicbrainz"]`), fetches real listen counts, normalizes to 0–100, and persists `popularity_score`. Tracks with no MB recording MBID are counted (`skipped_no_mbid`) and skipped. Coverage reporting counts `mb_linked` instead of `spotify_linked`.
- **Normalization:** `score = round(100 * log10(count) / log10(1e6))`, clamped [0,100]. Listen counts are heavy-tailed so a linear scale collapses to 0; log10 spreads it (~1M listens → 100, 1000 → 50, 1 → ~0).

**Dead Spotify code removed**
- `SpotifyConnector.get_tracks` (removed batch endpoint), `TrackSearchResult` model, `_get_spotify_access_token` worker helper.
- `search_track` reverted to `str | None` (id only); export search-match loop no longer persists popularity. Phase 1's discovery-sourced popularity in `discover_tracks_for_artist` is untouched.
</details>

<details>
<summary>⚠️ Design note — two different popularity scales now share one column</summary>

Worth a look before merge. `popularity_score` is now populated by two different mechanisms with different meanings:
- **Discovery (Phase 1 / unchanged):** synthetic rank by position — `max(0, 100 - i*5)` in `ListenBrainzConnector.discover_tracks`. NOT real popularity; just "this was the Nth similar/popular result."
- **Library backfill (this PR):** real LB listen counts, log10-normalized.

So `hit_depth` scoring will mix synthetic-rank values (discovery tracks) and real-listen-count values (backfilled library tracks) on the same 0–100 field. The backfill is correct and gives the library real data, but if you want consistency you may eventually want discovery to also use real LB listen counts (or to document the two-source semantics). Flagging rather than deciding — not in scope here.
</details>

<details>
<summary>Test Plan</summary>

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/` clean (strict; no new `type: ignore`)
- [x] `pytest`: **1360 passed**
- [x] `alembic heads` unchanged (`h9i0j1k2l3m4`); no new migration
- [ ] Post-merge: run `resonance-api backfill-popularity` and confirm library tracks with a MB recording MBID get real popularity_score values; spot-check hit_depth differentiation
</details>