### PR TITLE
fix(concert_prep): round-robin interleave for per-artist fairness

### DIFF
--- a/src/resonance/generators/concert_prep.py
+++ b/src/resonance/generators/concert_prep.py
@@ -81,6 +81,52 @@ def _round_half_up(value: float) -> int:
     return int(value + 0.5)
 
 
+def _round_robin_order(
+    pool: list[tuple[CandidateTrack, float]],
+) -> list[tuple[CandidateTrack, float]]:
+    """Re-order a score-desc pool so slots spread fairly across artists.
+
+    Per-artist fairness: instead of taking the strict top-N by score (which lets
+    one prolific artist flood the playlist), the pool is interleaved by rounds.
+    Round 0 yields each artist's best track, round 1 each artist's second-best,
+    and so on. Slicing the result is proportional-to-artist-count by
+    construction -- no artist gets a 2nd track until every artist has had a 1st.
+
+    The input pool must already be sorted by score descending; that order is the
+    within-artist tie-break (preserving the existing ranking, e.g. score then a
+    stable secondary). Artist groups lead with the strongest artists: groups are
+    ordered by their best track's score descending, ties broken by first
+    appearance in the pool for deterministic output.
+    """
+    # Group by artist, preserving the pool's score-desc order within each group.
+    groups: dict[uuid.UUID, list[tuple[CandidateTrack, float]]] = {}
+    first_seen: dict[uuid.UUID, int] = {}
+    for index, pair in enumerate(pool):
+        artist_id = pair[0].artist_id
+        if artist_id not in groups:
+            groups[artist_id] = []
+            first_seen[artist_id] = index
+        groups[artist_id].append(pair)
+
+    # Order artist groups by their best (first, since score-desc) track's score
+    # descending; tie-break by first appearance for stable, deterministic output.
+    ordered_artists = sorted(
+        groups,
+        key=lambda aid: (-groups[aid][0][1], first_seen[aid]),
+    )
+
+    # Fill by rounds: round r takes each artist's track at index r, in artist
+    # order, until every track is consumed.
+    result: list[tuple[CandidateTrack, float]] = []
+    max_depth = max((len(g) for g in groups.values()), default=0)
+    for depth in range(max_depth):
+        for artist_id in ordered_artists:
+            group = groups[artist_id]
+            if depth < len(group):
+                result.append(group[depth])
+    return result
+
+
 def _select_with_quota(
     target_pool: list[tuple[CandidateTrack, float]],
     adjacent_pool: list[tuple[CandidateTrack, float]],
@@ -92,8 +138,14 @@ def _select_with_quota(
     Both pools must already be sorted by score descending. The adjacent quota is
     ``round_half_up(max_tracks * ratio / 100)``; the rest go to the target pool.
 
+    Within each pool, tracks are chosen by a round-robin interleave across
+    artists (see :func:`_round_robin_order`) rather than a strict top-N slice, so
+    a single prolific artist cannot flood the playlist. The quota split is
+    unchanged -- this governs *which* tracks fill each quota, not the quota sizes.
+
     When a pool cannot fill its quota, the shortfall is backfilled from the other
-    pool -- but only if the other pool was allocated at least one slot. This keeps
+    pool -- but only if the other pool was allocated at least one slot. The
+    backfilled tracks also come via round-robin from the donor pool. This keeps
     the extremes literal: at ratio=0 no adjacent track is ever added, and at
     ratio=100 no target track is ever added (matching the design intent that 0 is
     target-only and 100 is adjacent-only).
@@ -102,8 +154,13 @@ def _select_with_quota(
     adj_quota = _round_half_up(max_tracks * ratio / 100)
     tgt_quota = max_tracks - adj_quota
 
-    tgt_take = target_pool[:tgt_quota]
-    adj_take = adjacent_pool[:adj_quota]
+    # Round-robin order each pool once; slicing this order is fair selection, and
+    # the slice past the quota is the donor remainder for backfill (still fair).
+    target_ordered = _round_robin_order(target_pool)
+    adjacent_ordered = _round_robin_order(adjacent_pool)
+
+    tgt_take = target_ordered[:tgt_quota]
+    adj_take = adjacent_ordered[:adj_quota]
 
     tgt_short = tgt_quota - len(tgt_take)
     adj_short = adj_quota - len(adj_take)
@@ -111,9 +168,9 @@ def _select_with_quota(
     # Backfill a pool's shortfall from the other pool's remainder, but only when
     # the other pool was allocated slots (so 0/100 stay pure).
     if tgt_short > 0 and adj_quota > 0:
-        adj_take += adjacent_pool[adj_quota : adj_quota + tgt_short]
+        adj_take += adjacent_ordered[adj_quota : adj_quota + tgt_short]
     if adj_short > 0 and tgt_quota > 0:
-        tgt_take += target_pool[tgt_quota : tgt_quota + adj_short]
+        tgt_take += target_ordered[tgt_quota : tgt_quota + adj_short]
 
     return (tgt_take + adj_take)[:max_tracks]
 

--- a/tests/test_concert_prep_generator.py
+++ b/tests/test_concert_prep_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import uuid
 
 import resonance.generators.concert_prep as concert_prep_module
@@ -490,3 +491,251 @@ class TestBlendQuota:
             freshness_target=None,
         )
         assert len(result.tracks) == 0
+
+
+# Parameters that make track score a strict monotonic function of listen_count:
+# familiarity=100 gives familiarity full positive weight, hit_depth=50 makes
+# popularity neutral. So higher listen_count => strictly higher score, which lets
+# the per-artist fairness tests control ranking deterministically.
+_FAMILIARITY_DRIVEN = {"familiarity": 100, "hit_depth": 50}
+
+
+def _artist_candidate(
+    *,
+    artist_id: uuid.UUID,
+    listen_count: int,
+    is_target: bool,
+) -> concert_prep_module.CandidateTrack:
+    """Build a candidate whose score is driven solely by listen_count.
+
+    Used by the per-artist fairness tests, where ranking must be deterministic
+    and grouping by artist_id matters.
+    """
+    return concert_prep_module.CandidateTrack(
+        track_id=uuid.uuid4(),
+        title=f"Song {listen_count}",
+        artist_name=str(artist_id),
+        artist_id=artist_id,
+        is_target_artist=is_target,
+        listen_count=listen_count,
+        in_library=True,
+        popularity_score=0,
+        source=types_module.TrackSource.LIBRARY,
+    )
+
+
+class TestPerArtistFairness:
+    """Round-robin interleave spreads quota slots across artists in a pool.
+
+    The fix replaces "sort-by-score-and-slice" with a round-robin fill: round 0
+    takes each artist's best track, round 1 their second-best, etc. No artist
+    gets a 2nd track until every artist has had a 1st (issue #115 / PR #121).
+    """
+
+    def test_anti_flooding_one_artist_cannot_dominate(self) -> None:
+        # One artist with 15 high-scoring tracks; 5 others with enough tracks that
+        # the quota can be filled fairly (so the constraint is fairness, not
+        # scarcity). Pool = 15 + 5*8 = 55 tracks for a quota of 30.
+        flooder = uuid.uuid4()
+        others = [uuid.uuid4() for _ in range(5)]
+        candidates: list[concert_prep_module.CandidateTrack] = [
+            # Flooder's tracks all outscore everyone else's.
+            _artist_candidate(artist_id=flooder, listen_count=90 + i, is_target=True)
+            for i in range(15)
+        ]
+        for other in others:
+            candidates += [
+                _artist_candidate(artist_id=other, listen_count=10 + i, is_target=True)
+                for i in range(8)
+            ]
+
+        max_tracks = 30
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params={**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 0},
+            max_tracks=max_tracks,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+
+        # Map each returned track back to its artist via title (carries listen_count
+        # is not unique enough) -- instead rebuild an id->artist map.
+        artist_by_track = {c.track_id: c.artist_id for c in candidates}
+        per_artist: dict[uuid.UUID, int] = {}
+        for t in result.tracks:
+            aid = artist_by_track[t.track_id]
+            per_artist[aid] = per_artist.get(aid, 0) + 1
+
+        # The pool has 6 artists. Round-robin guarantees no artist exceeds
+        # ceil(quota / num_artists) by more than the rounding remainder; with 6
+        # artists and quota 30, the cap is ceil(30/6) = 5. The flooder should be
+        # held to roughly that, not ~15. Compute the cap from the pool's distinct
+        # artist count (NOT the result's) -- a flooding bug collapses the result
+        # to one artist and would otherwise hide itself.
+        num_artists_in_pool = len({c.artist_id for c in candidates})
+        cap = math.ceil(max_tracks / num_artists_in_pool)
+        assert per_artist[flooder] <= cap + 1, per_artist
+        # And the quota is fully filled (enough tracks exist: 15 + 15 = 30).
+        assert len(result.tracks) == max_tracks
+
+    def test_few_artists_alternate_without_starvation(self) -> None:
+        # Only 2 artists, quota of 10: must alternate and fill all 10.
+        a1 = uuid.uuid4()
+        a2 = uuid.uuid4()
+        candidates: list[concert_prep_module.CandidateTrack] = []
+        for i in range(10):
+            candidates.append(
+                _artist_candidate(artist_id=a1, listen_count=80 + i, is_target=True)
+            )
+            candidates.append(
+                _artist_candidate(artist_id=a2, listen_count=20 + i, is_target=True)
+            )
+
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params={**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 0},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+
+        artist_by_track = {c.track_id: c.artist_id for c in candidates}
+        per_artist: dict[uuid.UUID, int] = {}
+        for t in result.tracks:
+            aid = artist_by_track[t.track_id]
+            per_artist[aid] = per_artist.get(aid, 0) + 1
+
+        assert len(result.tracks) == 10
+        # Two artists, quota 10 -> 5 each (round-robin, no starvation).
+        assert per_artist[a1] == 5
+        assert per_artist[a2] == 5
+
+    def test_round_robin_in_adjacent_pool(self) -> None:
+        # Fairness also applies to the adjacent pool. One adjacent flooder, several
+        # adjacent others; ratio=100 routes the whole playlist through adjacent.
+        flooder = uuid.uuid4()
+        others = [uuid.uuid4() for _ in range(4)]
+        candidates: list[concert_prep_module.CandidateTrack] = [
+            _artist_candidate(artist_id=flooder, listen_count=90 + i, is_target=False)
+            for i in range(15)
+        ]
+        for other in others:
+            candidates += [
+                _artist_candidate(artist_id=other, listen_count=10 + i, is_target=False)
+                for i in range(3)
+            ]
+
+        max_tracks = 10
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params={**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 100},
+            max_tracks=max_tracks,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+
+        artist_by_track = {c.track_id: c.artist_id for c in candidates}
+        per_artist: dict[uuid.UUID, int] = {}
+        for t in result.tracks:
+            aid = artist_by_track[t.track_id]
+            per_artist[aid] = per_artist.get(aid, 0) + 1
+
+        # Cap from the pool's distinct artist count, not the result's, so a
+        # flooding regression cannot hide by collapsing the result to one artist.
+        num_artists_in_pool = len({c.artist_id for c in candidates})
+        cap = math.ceil(max_tracks / num_artists_in_pool)
+        assert per_artist[flooder] <= cap + 1, per_artist
+        assert len(result.tracks) == max_tracks
+
+    def test_backfill_uses_round_robin_from_donor_pool(self) -> None:
+        # Adjacent pool underflows its quota, so the target pool backfills. The
+        # backfilled target tracks must come via round-robin, not a naive top-N
+        # slice that would let the target flooder dominate the backfill.
+        tgt_flooder = uuid.uuid4()
+        tgt_others = [uuid.uuid4() for _ in range(4)]
+        target: list[concert_prep_module.CandidateTrack] = [
+            _artist_candidate(
+                artist_id=tgt_flooder, listen_count=90 + i, is_target=True
+            )
+            for i in range(15)
+        ]
+        for other in tgt_others:
+            target += [
+                _artist_candidate(artist_id=other, listen_count=30 + i, is_target=True)
+                for i in range(3)
+            ]
+        # Only 1 adjacent track -> adjacent quota of 5 underflows by 4.
+        adjacent = [
+            _artist_candidate(artist_id=uuid.uuid4(), listen_count=50, is_target=False)
+        ]
+
+        max_tracks = 10
+        result = concert_prep_module.score_and_select(
+            candidates=target + adjacent,
+            params={**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 50},
+            max_tracks=max_tracks,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+
+        assert len(result.tracks) == max_tracks
+        artist_by_track = {c.track_id: c.artist_id for c in (target + adjacent)}
+        # Count how many slots the target flooder grabbed across base + backfill.
+        flooder_count = sum(
+            1 for t in result.tracks if artist_by_track[t.track_id] == tgt_flooder
+        )
+        # tgt quota is 5, backfill adds 4 more from target = 9 target slots over
+        # 5 target artists. Round-robin caps the flooder well below a top-N slice
+        # (which would give the flooder all 9).
+        assert flooder_count <= 3, flooder_count
+
+    def test_deterministic_same_input_same_output(self) -> None:
+        flooder = uuid.uuid4()
+        others = [uuid.uuid4() for _ in range(3)]
+        candidates: list[concert_prep_module.CandidateTrack] = [
+            _artist_candidate(artist_id=flooder, listen_count=90 + i, is_target=True)
+            for i in range(10)
+        ]
+        for other in others:
+            candidates += [
+                _artist_candidate(artist_id=other, listen_count=20 + i, is_target=True)
+                for i in range(4)
+            ]
+        params = {**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 0}
+        run1 = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=params,
+            max_tracks=15,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        run2 = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=params,
+            max_tracks=15,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert [t.track_id for t in run1.tracks] == [t.track_id for t in run2.tracks]
+
+    def test_strongest_artist_still_leads(self) -> None:
+        # Round-robin orders artist groups by their best track's score, so the
+        # top-scoring track overall still appears (first in score-desc output).
+        strong = uuid.uuid4()
+        weak = uuid.uuid4()
+        candidates = [
+            _artist_candidate(artist_id=strong, listen_count=99, is_target=True),
+            _artist_candidate(artist_id=strong, listen_count=98, is_target=True),
+            _artist_candidate(artist_id=weak, listen_count=5, is_target=True),
+            _artist_candidate(artist_id=weak, listen_count=4, is_target=True),
+        ]
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params={**_FAMILIARITY_DRIVEN, "similar_artist_ratio": 0},
+            max_tracks=4,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        artist_by_track = {c.track_id: c.artist_id for c in candidates}
+        # Final output is score-desc; the very first track is the strong artist's best.
+        assert artist_by_track[result.tracks[0].track_id] == strong


### PR DESCRIPTION
## Summary

The `concert_prep` generator filled each pool (target / adjacent) by taking the top-N tracks by score. When one artist had many high-scoring tracks, it dominated: a live 30-track run gave one adjacent artist (Elder) ~10 of 30 slots. This replaces the "sort-by-score-and-slice" fill with a round-robin interleave so slots spread fairly across artists.

**Before:** Elder took ~10/30 slots (top-N let the prolific artist flood).
**After:** with N artists in a pool, no artist gets a 2nd track until every artist has had a 1st. The Elder-style flooder is held to ~`ceil(quota / num_artists)`.

**Migration-free, `concert_prep`-only.** No schema change. This builds on the adjacent-artist discovery work in #115 / PR #121, which widened the adjacent pool's variety — flooding by a single prolific artist was the remaining gap.

<details>
<summary>Design — round-robin interleave</summary>

`_select_with_quota` no longer slices the top-N of each score-desc pool. New helper `_round_robin_order`:

1. Group the pool's `(track, score)` pairs by `track.artist_id`, preserving the pool's score-desc order within each group (this is the within-artist tie-break, unchanged from before).
2. Order the artist groups by their best (highest) track's score descending; ties broken by first appearance for deterministic output — so the strongest artists still lead.
3. Fill by ROUNDS: round 0 takes each artist's #1 track (in artist order), round 1 each artist's #2, etc., until the pool is exhausted.

Slicing this re-ordered pool is proportional-to-artist-count by construction — no magic constant. Few artists naturally concentrate (alternate); many artists spread.

**What is preserved:**
- The `adj_quota` / `tgt_quota` split from `similar_artist_ratio` is untouched — this fix changes WHICH tracks fill each quota, not the quota sizes.
- Cross-pool backfill still works (a pool that underflows its quota draws from the other), and the backfilled tracks now also come via round-robin from the donor pool: the pool is round-robin-ordered once, so the slice past the quota is the fair donor remainder.
- Final output ordering is unchanged: `score_and_select` re-sorts the merged selection by score descending before assigning positions. Round-robin governs SELECTION (which tracks), not display ORDER (still score-desc). The `test_scores_are_descending` regression confirms this.
</details>

<details>
<summary>Test Plan</summary>

`make check` (ruff + mypy strict + full pytest): **1365 passed, 1 skipped** (the skip is pre-existing and unrelated).

New tests in `tests/test_concert_prep_generator.py` (`TestPerArtistFairness`), written first (TDD):
- **Anti-flooding**: a pool with one 15-track flooder + 5 artists with enough tracks to fill the quota fairly — asserts the flooder is held to `ceil(quota / num_artists_in_pool) + 1` and the quota is fully filled. (Cap computed from the *pool's* distinct artist count, not the result's, so a flooding regression can't hide.)
- **Few artists**: 2 artists, quota 10 — asserts a clean 5/5 alternation, no starvation, all 10 filled.
- **Adjacent-pool fairness**: ratio=100 routes the playlist through the adjacent pool; the same anti-flooding guarantee holds there.
- **Backfill via round-robin**: adjacent pool underflows, target backfills — asserts the target flooder can't dominate the backfill (round-robin caps it well below a top-N slice).
- **Deterministic**: same input → same output.
- **Strongest-artist-still-leads**: the top-scoring track overall still appears first.

Regression coverage retained: the existing `TestBlendQuota` (quota split, ratio rounding, both backfill directions, ratio=0 target-only, ratio=100 adjacent-only) and `test_scores_are_descending` all pass — quota sizes and final ordering are unchanged.
</details>

<details>
<summary>Impact</summary>

- No breaking changes; no schema change; migration-free.
- `concert_prep`-only. No other generator is affected.
- Quota sizes from `similar_artist_ratio` are unchanged — only the per-pool track selection changes.
- Observable playlist ordering (score-descending) is unchanged; only the *set* of selected tracks shifts toward diversity.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
