### PR TITLE
feat(generators): scale per-artist discovery fetch to max_tracks

### DIFF
--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -954,7 +954,11 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
             arq_redis = wctx["redis"]
             children: list[task_module.Task] = []
 
-            # Discovery tasks (one per artist needing tracks)
+            # Discovery tasks (one per artist needing tracks). Thread max_tracks
+            # through so each artist's catalog fetch scales with the playlist
+            # target (a single deep artist can fill the whole list; round-robin
+            # in scoring balances across artists).
+            max_tracks = int(str(task.params.get("max_tracks", 50)))
             for aid in discovery_artist_ids:
                 artist_obj = artist_lookup.get(aid)
                 artist_name = artist_obj.name if artist_obj else "Unknown"
@@ -969,6 +973,7 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
                         "artist_id": str(aid),
                         "artist_name": artist_name,
                         "service_links": service_links,
+                        "max_tracks": max_tracks,
                     },
                     description=f"Discover tracks: {artist_name}",
                 )
@@ -1064,8 +1069,15 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
             artist_id_str = str(task.params.get("artist_id", ""))
             artist_name = str(task.params.get("artist_name", ""))
             service_links = task.params.get("service_links")
+            # Per-artist catalog fetch size scales with the playlist target so a
+            # single deep artist can fill the whole list (round-robin balances
+            # across artists). Bounding the fetch by max_tracks keeps the
+            # MusicBrainz request volume proportional to what the playlist can
+            # actually use, never more. Fallback to the playlist default (50) for
+            # older child tasks created before max_tracks was threaded through.
+            discovery_limit = int(str(task.params.get("max_tracks", 50)))
             log = log.bind(artist_name=artist_name, artist_id=artist_id_str)
-            log.info("discover_tracks_started")
+            log.info("discover_tracks_started", discovery_limit=discovery_limit)
 
             # Get a connector with TRACK_DISCOVERY capability
             connectors = connector_registry.get_by_capability(
@@ -1095,7 +1107,7 @@ async def discover_tracks_for_artist(ctx: dict[str, Any], task_id: str) -> None:
                 ] = await connector.discover_tracks(
                     artist_name,
                     service_links_dict,
-                    limit=20,
+                    limit=discovery_limit,
                 )
             except base_module.RateLimitExceededError as exc:
                 task.status = types_module.SyncStatus.DEFERRED

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2195,6 +2195,12 @@ class TestGeneratePlaylist:
         assert len(discovery_tasks) == 2
         assert len(scoring_tasks) == 1
 
+        # Each discovery child carries max_tracks so its catalog fetch scales
+        # with the playlist target. Parent has no max_tracks here, so the
+        # dispatch default (50) is threaded through.
+        for dt in discovery_tasks:
+            assert dt.params["max_tracks"] == 50
+
     @pytest.mark.asyncio
     async def test_enqueues_first_discovery_task(self) -> None:
         """Only the first discovery task is enqueued (sequential dispatch)."""
@@ -2883,10 +2889,79 @@ class TestDiscoverTracksForArtist:
 
         await worker_module.discover_tracks_for_artist(ctx, str(task_id))
 
+        # No max_tracks in params (legacy child) -> falls back to the playlist
+        # default of 50, not the old hardcoded 20.
         mock_connector.discover_tracks.assert_awaited_once_with(
             "Test Artist",
             {"listenbrainz": "mb-id-1"},
-            limit=20,
+            limit=50,
+        )
+
+    @pytest.mark.asyncio
+    async def test_discovery_limit_scales_with_max_tracks(self) -> None:
+        """The per-artist catalog fetch limit comes from the child's max_tracks.
+
+        A single deep artist must be able to fill the whole playlist, so the
+        discovery fetch scales with the requested length rather than a fixed cap.
+        """
+        task_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        artist_id = uuid.uuid4()
+
+        task = task_module.Task(
+            id=task_id,
+            user_id=user_id,
+            parent_id=parent_id,
+            task_type=types_module.TaskType.TRACK_DISCOVERY,
+            status=types_module.SyncStatus.PENDING,
+            params={
+                "artist_id": str(artist_id),
+                "artist_name": "Test Artist",
+                "service_links": {"listenbrainz": "mb-id-1"},
+                "max_tracks": 120,
+            },
+        )
+
+        session = AsyncMock()
+        arq_redis = AsyncMock()
+
+        task_result = MagicMock()
+        task_result.scalar_one_or_none.return_value = task
+
+        mock_connector = AsyncMock()
+        mock_connector.discover_tracks = AsyncMock(return_value=[])
+
+        mock_registry = MagicMock()
+        mock_registry.get_by_capability.return_value = [mock_connector]
+
+        pending_count = MagicMock()
+        pending_count.scalar_one.return_value = 1
+        next_pending_task = MagicMock(spec=task_module.Task)
+        next_pending_task.id = uuid.uuid4()
+        next_pending_task.task_type = types_module.TaskType.TRACK_SCORING
+        next_pending_result = MagicMock()
+        next_pending_result.scalar_one_or_none.return_value = next_pending_task
+
+        session.execute.side_effect = [
+            task_result,
+            _not_cancelled_result(parent_id),
+            pending_count,
+            next_pending_result,
+        ]
+
+        ctx: dict[str, Any] = {
+            "session_factory": _mock_session_factory(session),
+            "connector_registry": mock_registry,
+            "redis": arq_redis,
+        }
+
+        await worker_module.discover_tracks_for_artist(ctx, str(task_id))
+
+        mock_connector.discover_tracks.assert_awaited_once_with(
+            "Test Artist",
+            {"listenbrainz": "mb-id-1"},
+            limit=120,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The per-artist `TRACK_DISCOVERY` catalog fetch was hardcoded to `limit=20`. With `similar_artist_ratio=0` (target-only) and a few lightly-listened artists, this capped playlist length below the requested `max_tracks`: a 50-track / 3-artist request topped out at **43** (3×20 fetched → 43 distinct after MusicBrainz dedup), so the target was unreachable no matter how deep the artists' catalogs were.

This threads the parent task's `max_tracks` through to each discovery child and uses it as the fetch limit. A single deep artist can now fill the whole list; the round-robin interleave in scoring (#122) still balances across artists. MusicBrainz request volume stays proportional to what the playlist can use (≤ `max_tracks` per artist), not a fixed 20.

<details>
<summary>How to Review</summary>

- `worker.py` `generate_playlist`: read `max_tracks` from the parent task, add it to each `TRACK_DISCOVERY` child's params.
- `worker.py` `discover_tracks_for_artist`: read `max_tracks` from the child params (fallback 50 for legacy children) and pass it as `discover_tracks(..., limit=...)`.
- Tests: existing limit assertion updated (legacy fallback → 50); new `test_discovery_limit_scales_with_max_tracks` asserts the child's `max_tracks` drives the fetch limit; dispatch test asserts children carry `max_tracks`.
</details>

<details>
<summary>Test Plan</summary>

- [x] `make check` — ruff, mypy strict, 1379 passed / 1 skipped
- [ ] Post-deploy: regenerate the 3-thin-artist / 50-track case and confirm it fills toward 50 (catalog-depth permitting)
</details>

<details>
<summary>Impact</summary>

- Behavior change: discovery-leaning playlists fetch more catalog per target artist (bounded by `max_tracks`). More MB requests per generation for deep artists, but generation is already a background arq task with rate-limiting.
- No schema change. Legacy in-flight discovery children fall back to a 50-track fetch instead of 20.
</details>