### PR TITLE
feat(generators): import recommended artists for adjacent discovery (#115 Phase 2)

### DIFF
--- a/src/resonance/api/v1/artists.py
+++ b/src/resonance/api/v1/artists.py
@@ -16,6 +16,7 @@ import resonance.crypto as crypto_module
 import resonance.dependencies as deps_module
 import resonance.models.music as music_models
 import resonance.models.user as user_models
+import resonance.services.artist_import as artist_import_module
 import resonance.types as types_module
 
 logger = structlog.get_logger()
@@ -320,6 +321,9 @@ async def _find_local_artist_by_mbid(
 ) -> Any | None:
     """Find a local artist by MBID, checking both storage locations.
 
+    Thin wrapper over the shared service helper so the HTTP import path and the
+    worker's adjacent-artist import (issue #115) dedup identically.
+
     Args:
         db: The async database session.
         mbid: The MusicBrainz artist ID.
@@ -327,14 +331,7 @@ async def _find_local_artist_by_mbid(
     Returns:
         The Artist if found, or None.
     """
-    stmt = sa.select(music_models.Artist).where(
-        sa.or_(
-            music_models.Artist.service_links["musicbrainz"]["id"].as_string() == mbid,
-            music_models.Artist.service_links["listenbrainz"].as_string() == mbid,
-        )
-    )
-    result = await db.execute(stmt)
-    return result.scalar_one_or_none()
+    return await artist_import_module.find_local_artist_by_mbid(db, mbid)
 
 
 async def _get_spotify_token(

--- a/src/resonance/services/artist_import.py
+++ b/src/resonance/services/artist_import.py
@@ -1,0 +1,103 @@
+"""Resolve and import artists by MusicBrainz ID.
+
+Centralizes the "find-or-create a local Artist row from an MBID" flow so both
+the HTTP import endpoint (``api/v1/artists.py``) and the background worker
+(adjacent-artist discovery, issue #115 Phase 2) share one dedup + create path.
+
+Dedup is MBID-first and checks both the canonical
+``service_links["musicbrainz"]["id"]`` location and the legacy flat
+``service_links["listenbrainz"]`` location.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import Any
+
+import sqlalchemy as sa
+import structlog
+
+import resonance.models.music as music_models
+
+if typing.TYPE_CHECKING:
+    import sqlalchemy.ext.asyncio as sa_async
+
+logger = structlog.get_logger(__name__)
+
+
+async def find_local_artist_by_mbid(
+    session: sa_async.AsyncSession, mbid: str
+) -> music_models.Artist | None:
+    """Find a local artist by MBID, checking canonical and legacy locations.
+
+    Matches both the canonical ``service_links["musicbrainz"]["id"]`` and the
+    legacy flat ``service_links["listenbrainz"]`` storage so an artist imported
+    under either convention is found.
+
+    Args:
+        session: Async DB session.
+        mbid: The MusicBrainz artist ID.
+
+    Returns:
+        The matching Artist, or None.
+    """
+    stmt = sa.select(music_models.Artist).where(
+        sa.or_(
+            music_models.Artist.service_links["musicbrainz"]["id"].as_string() == mbid,
+            music_models.Artist.service_links["listenbrainz"].as_string() == mbid,
+        )
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def import_artist_by_mbid(
+    session: sa_async.AsyncSession,
+    connector: Any,
+    mbid: str,
+) -> music_models.Artist | None:
+    """Resolve an artist by MBID and create a local Artist row if needed.
+
+    Dedups by MBID first: if an artist with this MBID already exists it is
+    returned without a MusicBrainz call. Otherwise the MBID is resolved via the
+    connector (``get_artist_by_mbid``), an Artist is created with canonical
+    ``service_links``, flushed so it gets an ID, and returned. The caller owns
+    the surrounding transaction (this does not commit).
+
+    Args:
+        session: Async DB session.
+        connector: A connector exposing ``get_artist_by_mbid`` (the
+            ListenBrainz/MusicBrainz connector).
+        mbid: MusicBrainz artist identifier.
+
+    Returns:
+        The existing or newly-created Artist, or None if the MBID could not be
+        resolved on MusicBrainz.
+    """
+    existing = await find_local_artist_by_mbid(session, mbid)
+    if existing is not None:
+        return existing
+
+    data = await connector.get_artist_by_mbid(mbid)
+    if data is None:
+        logger.warning("artist_import_mbid_unresolved", mbid=mbid)
+        return None
+
+    artist = music_models.Artist(
+        name=data["name"],
+        disambiguation=data.get("disambiguation") or None,
+        artist_type=data.get("artist_type") or None,
+        area=data.get("area") or None,
+        begin_year=data.get("begin_year"),
+        end_year=data.get("end_year"),
+        service_links={"musicbrainz": {"id": mbid}},
+    )
+    session.add(artist)
+    await session.flush()
+    logger.info(
+        "artist_imported_by_mbid",
+        mbid=mbid,
+        name=artist.name,
+        artist_id=str(artist.id),
+    )
+    return artist

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -48,6 +48,7 @@ import resonance.models.playlist as playlist_models
 import resonance.models.task as task_module
 import resonance.models.taste as taste_models
 import resonance.models.user as user_models
+import resonance.services.artist_import as artist_import_module
 import resonance.services.artist_utils as artist_utils
 import resonance.services.mbid_mapper as mbid_mapper_module
 import resonance.sync.backfill as backfill_module
@@ -712,6 +713,14 @@ _DISCOVERY_FAMILIARITY_THRESHOLD = 50
 # rank, and bounds BOTH the discovery fan-out and the scoring candidate pool.
 _MAX_ADJACENT_DISCOVERY = 10
 
+# Independent ceiling on NEW artist imports per generation (issue #115 Phase 2).
+# Importing a recommended artist who is not yet in the library costs one
+# MusicBrainz artist lookup plus a TRACK_DISCOVERY catalog fetch, so a
+# cold-start library must not silently trigger a flood of imports + fetches
+# every run. Bounds imports separately from the combined adjacent cap above;
+# library-adjacent artists (free) are always preferred first.
+_MAX_IMPORTED_ADJACENT = 10
+
 
 def _artists_needing_discovery(
     artist_ids: collections.abc.Iterable[uuid.UUID],
@@ -908,19 +917,44 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
             # similarity rank, and persist the capped set onto the parent task so
             # scoring expands the candidate pool to exactly this fetched set.
             adjacent_artist_ids: list[uuid.UUID] = []
+            library_adjacent_count = 0
+            imported_adjacent_count = 0
             similar_ratio = gen_params.get("similar_artist_ratio", 0)
             if similar_ratio > 0 and discovery_wanted:
                 similar_connectors = wctx["connector_registry"].get_by_capability(
                     base_module.ConnectorCapability.SIMILAR_ARTISTS
                 )
                 if similar_connectors:
-                    resolved = await _resolve_similar_library_artists(
+                    resolution = await _resolve_adjacent_artists(
                         session,
                         similar_connectors,
                         list(artists_by_id.values()),
                         set(artist_ids),
                     )
-                    adjacent_artist_ids = resolved[:_MAX_ADJACENT_DISCOVERY]
+                    # Prefer library-adjacent artists (free: no import, no extra
+                    # MusicBrainz lookup); fill any remaining slots with newly
+                    # imported recommended artists by rank (#115 Phase 2).
+                    library_ids = resolution.library_ids[:_MAX_ADJACENT_DISCOVERY]
+                    library_adjacent_count = len(library_ids)
+                    remaining = _MAX_ADJACENT_DISCOVERY - len(library_ids)
+                    imported_ids: list[uuid.UUID] = []
+                    if remaining > 0 and resolution.import_candidates:
+                        lb_connector = wctx["connector_registry"].get_base_connector(
+                            types_module.ServiceType.LISTENBRAINZ
+                        )
+                        if lb_connector is not None:
+                            imported_ids = await _import_adjacent_candidates(
+                                session,
+                                lb_connector,
+                                resolution.import_candidates,
+                                limit=min(remaining, _MAX_IMPORTED_ADJACENT),
+                                exclude_ids=set(library_ids),
+                                log=log,
+                            )
+                    imported_adjacent_count = len(imported_ids)
+                    adjacent_artist_ids = (library_ids + imported_ids)[
+                        :_MAX_ADJACENT_DISCOVERY
+                    ]
 
             # Persist the capped adjacent set (possibly empty) so scoring reads
             # the SAME artists this fan-out fetched, not a fresh re-resolve.
@@ -1013,6 +1047,8 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 discovery_tasks=len(discovery_artist_ids),
                 target_discovery_tasks=len(artists_needing_discovery),
                 adjacent_discovery_tasks=len(adjacent_artist_ids),
+                library_adjacent_count=library_adjacent_count,
+                imported_adjacent_count=imported_adjacent_count,
                 total_children=len(children),
             )
 
@@ -1273,6 +1309,174 @@ async def _resolve_similar_library_artists(
             seen.add(aid)
             ordered_ids.append(aid)
     return ordered_ids
+
+
+@dataclasses.dataclass(frozen=True)
+class _AdjacentResolution:
+    """Resolved adjacent artists for discovery (issue #115 Phase 2).
+
+    ``library_ids`` are similar artists already in the library (free to use).
+    ``import_candidates`` are similar artists NOT in the library, as
+    ``(name, mbid)`` pairs in provider similarity rank, ready to import. Both
+    lists preserve first-seen (similarity) order so the caller can cap by rank.
+    """
+
+    library_ids: list[uuid.UUID]
+    import_candidates: list[tuple[str, str]]
+
+
+async def _resolve_adjacent_artists(
+    session: sa_async.AsyncSession,
+    connectors: collections.abc.Sequence[Any],
+    target_artists: collections.abc.Sequence[music_models.Artist],
+    exclude_ids: set[uuid.UUID],
+    *,
+    per_artist_limit: int = 30,
+) -> _AdjacentResolution:
+    """Resolve similar artists into library matches AND import candidates.
+
+    Phase 2 of issue #115. Where ``_resolve_similar_library_artists`` returns
+    only neighbors already in the library, this also surfaces neighbors NOT in
+    the library as import candidates (name + MBID), so the caller can import
+    them and run the same catalog discovery the library-adjacent artists get.
+
+    Dedup follows design decision (d): a neighbor whose MBID matches a library
+    artist is treated as a library match even under a different name (MBID
+    first), then by normalized name. A neighbor without an MBID cannot be
+    imported cleanly in v1, so it is never an import candidate (it may still
+    match the library by name). Target artists are excluded from both lists.
+
+    Args:
+        session: Async DB session (reads only; the caller does imports/writes).
+        connectors: Connectors exposing ``get_similar_artists``.
+        target_artists: The event's target (lineup) artists.
+        exclude_ids: Artist IDs to exclude (the target set).
+        per_artist_limit: Max neighbors to request per target.
+
+    Returns:
+        An ``_AdjacentResolution`` with library IDs and import candidates, both
+        in provider similarity rank.
+    """
+    # First-seen order of lowercased neighbor names = approximate similarity
+    # rank across providers/targets. Track the original name + best-known MBID
+    # per neighbor (a later provider may supply an MBID an earlier one lacked).
+    ordered: dict[str, dict[str, str | None]] = {}
+    for artist in target_artists:
+        mbid = artist_utils.get_mbid(artist.service_links)
+        for connector in connectors:
+            neighbors = await connector.get_similar_artists(
+                artist.name, mbid=mbid, limit=per_artist_limit
+            )
+            for neighbor in neighbors:
+                name = neighbor.get("name")
+                if not name:
+                    continue
+                key = name.lower()
+                nbr_mbid = neighbor.get("mbid") or None
+                if key not in ordered:
+                    ordered[key] = {"name": name, "mbid": nbr_mbid}
+                elif ordered[key]["mbid"] is None and nbr_mbid:
+                    ordered[key]["mbid"] = nbr_mbid
+
+    if not ordered:
+        return _AdjacentResolution(library_ids=[], import_candidates=[])
+
+    neighbor_mbids = {v["mbid"] for v in ordered.values() if v["mbid"]}
+    # Library artists matching any neighbor by name OR by MBID. Select
+    # service_links too so MBID-dedup can map a neighbor MBID to a library id
+    # even when the stored name differs.
+    conds = [sa.func.lower(music_models.Artist.name).in_(ordered.keys())]
+    if neighbor_mbids:
+        conds.append(
+            music_models.Artist.service_links["musicbrainz"]["id"]
+            .as_string()
+            .in_(neighbor_mbids)
+        )
+        conds.append(
+            music_models.Artist.service_links["listenbrainz"]
+            .as_string()
+            .in_(neighbor_mbids)
+        )
+    result = await session.execute(
+        sa.select(
+            music_models.Artist.id,
+            sa.func.lower(music_models.Artist.name),
+            music_models.Artist.service_links,
+        ).where(sa.or_(*conds))
+    )
+    id_by_name: dict[str, uuid.UUID] = {}
+    id_by_mbid: dict[str, uuid.UUID] = {}
+    for row in result.all():
+        aid, lname, links = row[0], row[1], row[2]
+        id_by_name.setdefault(lname, aid)
+        lib_mbid = artist_utils.get_mbid(links)
+        if lib_mbid:
+            id_by_mbid.setdefault(lib_mbid, aid)
+
+    target_names = {a.name.lower() for a in target_artists}
+    library_ids: list[uuid.UUID] = []
+    import_candidates: list[tuple[str, str]] = []
+    seen_ids: set[uuid.UUID] = set(exclude_ids)
+    for key, meta in ordered.items():
+        nbr_mbid = meta["mbid"]
+        # MBID match first (decision d), then normalized name.
+        aid = (id_by_mbid.get(nbr_mbid) if nbr_mbid else None) or id_by_name.get(key)
+        if aid is not None:
+            if aid not in seen_ids:
+                seen_ids.add(aid)
+                library_ids.append(aid)
+            continue
+        # Not in the library: import only with an MBID and not a target name.
+        if nbr_mbid and key not in target_names:
+            import_candidates.append((str(meta["name"]), nbr_mbid))
+    return _AdjacentResolution(
+        library_ids=library_ids, import_candidates=import_candidates
+    )
+
+
+async def _import_adjacent_candidates(
+    session: sa_async.AsyncSession,
+    connector: Any,
+    candidates: collections.abc.Sequence[tuple[str, str]],
+    *,
+    limit: int,
+    exclude_ids: set[uuid.UUID],
+    log: Any,
+) -> list[uuid.UUID]:
+    """Import up to ``limit`` recommended artists by MBID (issue #115 Phase 2).
+
+    Each ``(name, mbid)`` candidate is resolved and created via the
+    artist-import service. Failures are logged and skipped (best-effort: a
+    flaky MusicBrainz lookup degrades to fewer imports rather than failing the
+    whole playlist generation). Returns the newly-imported artist IDs in
+    candidate order, deduped against ``exclude_ids`` and each other.
+
+    Args:
+        session: Async DB session (the caller owns the transaction/commit).
+        connector: Connector exposing ``get_artist_by_mbid`` (ListenBrainz).
+        candidates: ``(name, mbid)`` import candidates in similarity rank.
+        limit: Max number of candidates to import this generation.
+        exclude_ids: Artist IDs already selected (library-adjacent), so an
+            import that resolves to one of them is not double-counted.
+        log: Bound structlog logger for per-candidate failure reporting.
+
+    Returns:
+        The imported artist IDs, in candidate order.
+    """
+    imported_ids: list[uuid.UUID] = []
+    seen = set(exclude_ids)
+    for name, mbid in candidates[:limit]:
+        try:
+            imported = await artist_import_module.import_artist_by_mbid(
+                session, connector, mbid
+            )
+        except Exception:
+            log.warning("adjacent_import_failed", mbid=mbid, name=name)
+            continue
+        if imported is not None and imported.id not in seen:
+            seen.add(imported.id)
+            imported_ids.append(imported.id)
+    return imported_ids
 
 
 async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:

--- a/tests/test_artist_import.py
+++ b/tests/test_artist_import.py
@@ -1,0 +1,131 @@
+"""Tests for the artist-import-by-MBID service (issue #115 Phase 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import resonance.models.music as music_models
+import resonance.services.artist_import as artist_import_module
+
+
+def _session_returning(scalar: object) -> MagicMock:
+    """Build a session whose execute() yields ``scalar`` from scalar_one_or_none."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    session.flush = AsyncMock()
+    return session
+
+
+class TestFindLocalArtistByMbid:
+    """Dedup lookup by MBID (canonical + legacy storage)."""
+
+    @pytest.mark.anyio()
+    async def test_returns_match(self) -> None:
+        existing = MagicMock(spec=music_models.Artist)
+        session = _session_returning(existing)
+
+        found = await artist_import_module.find_local_artist_by_mbid(session, "mbid-1")
+
+        assert found is existing
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.anyio()
+    async def test_returns_none_when_absent(self) -> None:
+        session = _session_returning(None)
+
+        found = await artist_import_module.find_local_artist_by_mbid(
+            session, "mbid-missing"
+        )
+
+        assert found is None
+
+
+class TestImportArtistByMbid:
+    """Find-or-create an Artist from an MBID."""
+
+    @pytest.mark.anyio()
+    async def test_returns_existing_without_mb_lookup(self) -> None:
+        existing = MagicMock(spec=music_models.Artist)
+        session = _session_returning(existing)
+        connector = AsyncMock()
+
+        result = await artist_import_module.import_artist_by_mbid(
+            session, connector, "mbid-existing"
+        )
+
+        assert result is existing
+        connector.get_artist_by_mbid.assert_not_awaited()
+        session.add.assert_not_called()
+
+    @pytest.mark.anyio()
+    async def test_creates_artist_from_mb_dict(self) -> None:
+        session = _session_returning(None)
+        connector = AsyncMock()
+        connector.get_artist_by_mbid.return_value = {
+            "mbid": "mbid-new",
+            "name": "Elder",
+            "disambiguation": "stoner rock",
+            "artist_type": "Group",
+            "area": "United States",
+            "begin_year": 2005,
+            "end_year": None,
+        }
+
+        result = await artist_import_module.import_artist_by_mbid(
+            session, connector, "mbid-new"
+        )
+
+        connector.get_artist_by_mbid.assert_awaited_once_with("mbid-new")
+        session.add.assert_called_once()
+        added = session.add.call_args.args[0]
+        assert added is result
+        assert isinstance(result, music_models.Artist)
+        assert result.name == "Elder"
+        assert result.disambiguation == "stoner rock"
+        assert result.artist_type == "Group"
+        assert result.area == "United States"
+        assert result.begin_year == 2005
+        assert result.end_year is None
+        assert result.service_links == {"musicbrainz": {"id": "mbid-new"}}
+        session.flush.assert_awaited_once()
+
+    @pytest.mark.anyio()
+    async def test_blank_optional_fields_become_none(self) -> None:
+        session = _session_returning(None)
+        connector = AsyncMock()
+        connector.get_artist_by_mbid.return_value = {
+            "mbid": "mbid-min",
+            "name": "Minimal",
+            "disambiguation": "",
+            "artist_type": "",
+            "area": "",
+            "begin_year": None,
+            "end_year": None,
+        }
+
+        result = await artist_import_module.import_artist_by_mbid(
+            session, connector, "mbid-min"
+        )
+
+        assert isinstance(result, music_models.Artist)
+        assert result.disambiguation is None
+        assert result.artist_type is None
+        assert result.area is None
+
+    @pytest.mark.anyio()
+    async def test_returns_none_when_mb_unresolved(self) -> None:
+        session = _session_returning(None)
+        connector = AsyncMock()
+        connector.get_artist_by_mbid.return_value = None
+
+        result = await artist_import_module.import_artist_by_mbid(
+            session, connector, "mbid-ghost"
+        )
+
+        assert result is None
+        session.add.assert_not_called()
+        session.flush.assert_not_awaited()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@
 import datetime
 import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -2453,9 +2453,11 @@ class TestGeneratePlaylist:
         listen_counts = MagicMock()
         listen_counts.all.return_value = [(target_id, 25)]
 
-        # Resolver's library name->id query returns one adjacent artist.
+        # Resolver's library query returns one adjacent artist as
+        # (id, lowered_name, service_links). The neighbor "Elder" has no MBID,
+        # so it matches the library by name and is treated as library-adjacent.
         resolver_result = MagicMock()
-        resolver_result.all.return_value = [("elder", adjacent_id)]
+        resolver_result.all.return_value = [(adjacent_id, "elder", None)]
 
         # Adjacent artist objects loaded for the discovery children.
         adjacent_obj = MagicMock(spec=music_models.Artist)
@@ -2753,11 +2755,12 @@ class TestGeneratePlaylist:
         listen_counts = MagicMock()
         listen_counts.all.return_value = [(target_id, 25)]
 
-        # Resolver returns rows in rank order (names ordered to match neighbor
-        # rank); the implementation orders by neighbor rank.
+        # Resolver returns library rows as (id, lowered_name, service_links);
+        # the implementation orders them by neighbor (similarity) rank. All
+        # neighbors lack an MBID, so each matches the library by name.
         resolver_result = MagicMock()
         resolver_result.all.return_value = [
-            (f"a{i}", aid) for i, aid in enumerate(adjacent_ids)
+            (aid, f"a{i}", None) for i, aid in enumerate(adjacent_ids)
         ]
 
         # Adjacent artist objects loaded for the capped discovery children.
@@ -3844,3 +3847,277 @@ class TestArtistsNeedingDiscovery:
             [covered, under], {covered: 50, under: 1}, discovery_wanted=True
         )
         assert set(result) == {covered, under}
+
+
+class TestMaxImportedAdjacent:
+    """The per-generation new-import ceiling constant (issue #115 Phase 2)."""
+
+    def test_constant_default(self) -> None:
+        assert worker_module._MAX_IMPORTED_ADJACENT == 10
+
+
+class TestResolveAdjacentArtists:
+    """_resolve_adjacent_artists splits neighbors into library + imports (#115 Ph2)."""
+
+    @pytest.mark.anyio()
+    async def test_splits_library_matches_and_import_candidates(self) -> None:
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = {"musicbrainz": {"id": "mbid-kb"}}
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = [
+            {"name": "Elder", "mbid": "mbid-elder", "match": 0.9},
+            {"name": "Newcomer", "mbid": "mbid-new", "match": 0.5},
+        ]
+
+        elder_id = uuid.uuid4()
+        # Library query returns only Elder (Newcomer is not in the library).
+        result = MagicMock()
+        result.all.return_value = [
+            (elder_id, "elder", {"musicbrainz": {"id": "mbid-elder"}}),
+        ]
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [target], set()
+        )
+
+        assert resolution.library_ids == [elder_id]
+        assert resolution.import_candidates == [("Newcomer", "mbid-new")]
+        connector.get_similar_artists.assert_awaited_once_with(
+            "King Buffalo", mbid="mbid-kb", limit=30
+        )
+
+    @pytest.mark.anyio()
+    async def test_mbid_match_dedups_name_variant_to_library(self) -> None:
+        """A neighbor whose MBID matches a library artist under a different name
+        is a library match, not an import (decision d)."""
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = None
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = [
+            {"name": "Eldar", "mbid": "mbid-elder", "match": 0.9},
+        ]
+
+        elder_id = uuid.uuid4()
+        # Library has the artist under canonical name "elder" with the same MBID.
+        result = MagicMock()
+        result.all.return_value = [
+            (elder_id, "elder", {"musicbrainz": {"id": "mbid-elder"}}),
+        ]
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [target], set()
+        )
+
+        assert resolution.library_ids == [elder_id]
+        assert resolution.import_candidates == []
+
+    @pytest.mark.anyio()
+    async def test_name_only_neighbor_is_not_an_import_candidate(self) -> None:
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = None
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = [
+            {"name": "NoMbid", "mbid": None, "match": 0.9},
+        ]
+
+        result = MagicMock()
+        result.all.return_value = []  # not in the library
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [target], set()
+        )
+
+        assert resolution.library_ids == []
+        assert resolution.import_candidates == []
+
+    @pytest.mark.anyio()
+    async def test_excludes_target_ids_from_library_matches(self) -> None:
+        kb = MagicMock()
+        kb.name = "King Buffalo"
+        kb.service_links = None
+        sleep = MagicMock()
+        sleep.name = "Sleep"
+        sleep.service_links = None
+        kb_id, sleep_id = uuid.uuid4(), uuid.uuid4()
+
+        connector = AsyncMock()
+        # King Buffalo's neighbors include the other target (Sleep) and Elder.
+        connector.get_similar_artists.side_effect = [
+            [
+                {"name": "Sleep", "mbid": "mbid-sleep", "match": 0.9},
+                {"name": "Elder", "mbid": "mbid-elder", "match": 0.6},
+            ],
+            [],  # Sleep's neighbors (none for simplicity)
+        ]
+
+        elder_id = uuid.uuid4()
+        result = MagicMock()
+        result.all.return_value = [
+            (sleep_id, "sleep", {"musicbrainz": {"id": "mbid-sleep"}}),
+            (elder_id, "elder", {"musicbrainz": {"id": "mbid-elder"}}),
+        ]
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [kb, sleep], {kb_id, sleep_id}
+        )
+
+        # Sleep (a target) is excluded; only Elder remains. Nothing imported.
+        assert resolution.library_ids == [elder_id]
+        assert resolution.import_candidates == []
+
+    @pytest.mark.anyio()
+    async def test_import_candidates_preserve_similarity_rank(self) -> None:
+        target = MagicMock()
+        target.name = "King Buffalo"
+        target.service_links = None
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = [
+            {"name": "First", "mbid": "mbid-1", "match": 0.9},
+            {"name": "Second", "mbid": "mbid-2", "match": 0.7},
+            {"name": "Third", "mbid": "mbid-3", "match": 0.5},
+        ]
+
+        result = MagicMock()
+        result.all.return_value = []  # none in the library
+        session = AsyncMock()
+        session.execute.return_value = result
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [target], set()
+        )
+
+        assert resolution.library_ids == []
+        assert resolution.import_candidates == [
+            ("First", "mbid-1"),
+            ("Second", "mbid-2"),
+            ("Third", "mbid-3"),
+        ]
+
+    @pytest.mark.anyio()
+    async def test_no_neighbors_returns_empty_without_query(self) -> None:
+        target = MagicMock()
+        target.name = "Obscure"
+        target.service_links = None
+
+        connector = AsyncMock()
+        connector.get_similar_artists.return_value = []
+        session = AsyncMock()
+
+        resolution = await worker_module._resolve_adjacent_artists(
+            session, [connector], [target], set()
+        )
+
+        assert resolution.library_ids == []
+        assert resolution.import_candidates == []
+        session.execute.assert_not_called()
+
+
+class TestImportAdjacentCandidates:
+    """_import_adjacent_candidates imports recommended artists (#115 Phase 2)."""
+
+    @pytest.mark.anyio()
+    async def test_imports_up_to_limit_in_order(self) -> None:
+        a1, a2, a3 = MagicMock(), MagicMock(), MagicMock()
+        a1.id, a2.id, a3.id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        session = AsyncMock()
+        connector = AsyncMock()
+        log = MagicMock()
+        candidates = [("A", "m1"), ("B", "m2"), ("C", "m3")]
+
+        with patch.object(
+            worker_module.artist_import_module,
+            "import_artist_by_mbid",
+            new=AsyncMock(side_effect=[a1, a2, a3]),
+        ) as imp:
+            result = await worker_module._import_adjacent_candidates(
+                session, connector, candidates, limit=2, exclude_ids=set(), log=log
+            )
+
+        assert result == [a1.id, a2.id]
+        assert imp.await_count == 2  # limit honored
+
+    @pytest.mark.anyio()
+    async def test_skips_unresolved_none(self) -> None:
+        a1 = MagicMock()
+        a1.id = uuid.uuid4()
+        session = AsyncMock()
+        connector = AsyncMock()
+        log = MagicMock()
+        candidates = [("A", "m1"), ("Ghost", "m2")]
+
+        with patch.object(
+            worker_module.artist_import_module,
+            "import_artist_by_mbid",
+            new=AsyncMock(side_effect=[a1, None]),
+        ):
+            result = await worker_module._import_adjacent_candidates(
+                session, connector, candidates, limit=10, exclude_ids=set(), log=log
+            )
+
+        assert result == [a1.id]
+
+    @pytest.mark.anyio()
+    async def test_dedups_against_exclude_and_self(self) -> None:
+        shared_id = uuid.uuid4()
+        a_lib = MagicMock()
+        a_lib.id = shared_id  # resolves to an already-selected library artist
+        a_dup1 = MagicMock()
+        a_dup1.id = uuid.uuid4()
+        a_dup2 = MagicMock()
+        a_dup2.id = a_dup1.id  # a second candidate resolves to the same artist
+        session = AsyncMock()
+        connector = AsyncMock()
+        log = MagicMock()
+        candidates = [("Lib", "m1"), ("Dup", "m2"), ("DupAgain", "m3")]
+
+        with patch.object(
+            worker_module.artist_import_module,
+            "import_artist_by_mbid",
+            new=AsyncMock(side_effect=[a_lib, a_dup1, a_dup2]),
+        ):
+            result = await worker_module._import_adjacent_candidates(
+                session,
+                connector,
+                candidates,
+                limit=10,
+                exclude_ids={shared_id},
+                log=log,
+            )
+
+        assert result == [a_dup1.id]  # library dup excluded; self-dup collapsed
+
+    @pytest.mark.anyio()
+    async def test_failure_is_logged_and_skipped(self) -> None:
+        a2 = MagicMock()
+        a2.id = uuid.uuid4()
+        session = AsyncMock()
+        connector = AsyncMock()
+        log = MagicMock()
+        candidates = [("Boom", "m1"), ("Ok", "m2")]
+
+        with patch.object(
+            worker_module.artist_import_module,
+            "import_artist_by_mbid",
+            new=AsyncMock(side_effect=[RuntimeError("mb 500"), a2]),
+        ):
+            result = await worker_module._import_adjacent_candidates(
+                session, connector, candidates, limit=10, exclude_ids=set(), log=log
+            )
+
+        assert result == [a2.id]  # one failure does not abort the rest
+        log.warning.assert_called_once()


### PR DESCRIPTION
## Summary

Brings a **recommended (similar) artist into a discovery playlist even when the user has zero listened tracks for them** — the conceptual 1.0 feature. Until now, the adjacent-artist resolver dropped every similar artist that wasn't already in the library. This imports them (from MusicBrainz by MBID) and runs them through the same catalog discovery library-adjacent artists already get, so their absent catalog gets populated (with #123, up to `max_tracks` per artist) and blended in as adjacent candidates.

Closes the deferred Phase 2 half of #115.

<details>
<summary>How to Review</summary>

Two logical commits:

1. **`f83b01b` feat(services): add find-or-create artist import by MBID** — new `services/artist_import.py` with `find_local_artist_by_mbid` (MBID-first dedup across canonical `service_links["musicbrainz"]["id"]` and legacy `service_links["listenbrainz"]`) and `import_artist_by_mbid` (resolves via the ListenBrainz/MusicBrainz connector, builds canonical service_links, flushes without committing — caller owns the txn). The artists API import endpoint now delegates its dedup to the shared helper. Review the service + `tests/test_artist_import.py`.

2. **`3519f21` feat(generators): import recommended artists (#115 Phase 2)** — worker changes:
   - `_resolve_adjacent_artists` splits similar-artist neighbors into **library matches** + **import candidates** (name + MBID), preserving similarity rank. Dedup is MBID-first then normalized name (a neighbor whose MBID matches a library artist under a different name is a library match, not an import). Neighbors without an MBID are never import candidates in v1.
   - `_import_adjacent_candidates` imports up to a per-generation bound, best-effort (a flaky MusicBrainz lookup degrades to fewer imports rather than failing the whole generation).
   - `generate_playlist` prefers library-adjacent artists (free — no import, no extra MB lookup) and fills remaining adjacent slots with imports, bounded by both the combined adjacent cap (`_MAX_ADJACENT_DISCOVERY=10`) and a separate new-import ceiling (`_MAX_IMPORTED_ADJACENT=10`). Adds `library_adjacent_count` / `imported_adjacent_count` to the planning log.

   The original `_resolve_similar_library_artists` is untouched and still serves the scoring-side re-resolve fallback for older tasks.

**Suggested order:** commit 1 (service) then commit 2 (worker), since the worker uses the service.
</details>

<details>
<summary>Why scoring needs no changes</summary>

`score_and_build_playlist` already reads the capped `adjacent_artist_ids` verbatim from the parent task params (resolve-once-and-persist, #115). Since `generate_playlist` persists the full set (library + imported), the imported artists flow into the scoring candidate pool automatically once their `Artist` rows exist and their `TRACK_DISCOVERY` children have run. No scoring-side change.
</details>

<details>
<summary>Test Plan</summary>

- [x] `make check` green: ruff (lint+format), mypy --strict, pytest
- [x] **1396 passed, 1 skipped**
- [x] New `tests/test_artist_import.py`: dedup found/absent; import existing-without-MB-lookup; create-from-MB-dict (field mapping + service_links); blank optionals → None; MB-unresolved → None
- [x] New worker tests: `_resolve_adjacent_artists` (library/import split, MBID-dedup of a name variant, name-only excluded from imports, target exclusion, rank preserved, no-neighbors short-circuit); `_import_adjacent_candidates` (limit, skip-None, dedup vs library + self, failure logged-and-skipped); `_MAX_IMPORTED_ADJACENT` constant
- [x] Updated the 2 existing adjacent-discovery `generate_playlist` tests for the new 3-column resolver query
- [ ] **Post-merge live verify** (CI auto-deploys): generate a playlist for an event whose lineup's similar artists are NOT in the library → confirm new artists imported + their tracks populate the playlist. The `generate_playlist` import wiring (the orchestration seam) is unit-tested via `_import_adjacent_candidates`; the full end-to-end path is validated live per the design.
</details>

<details>
<summary>Impact</summary>

- Discovery-leaning profiles (`similar_artist_ratio > 0` AND `familiarity < 50`) now import recommended artists not yet in the library. Bounded MusicBrainz cost per generation: ≤ `_MAX_IMPORTED_ADJACENT` artist lookups + ≤ adjacent-cap catalog fetches.
- No new generator parameter — reuses the existing gate.
- No schema change. No scoring change. Library-adjacent behavior is preserved (preferred first).
- API import endpoint behavior unchanged (refactored to share the dedup helper).
</details>