### PR TITLE
feat(generators): #128 PR2 — layered pool sources + generalization

### DIFF
--- a/alembic/versions/i0j1k2l3m4n5_migrate_input_references_to_sources.py
+++ b/alembic/versions/i0j1k2l3m4n5_migrate_input_references_to_sources.py
@@ -1,0 +1,106 @@
+"""migrate generator_profiles.input_references {event_id} -> {sources}
+
+#128 generalizes a profile's pool from a single event to a layered list of
+sources. Existing concert_prep profiles store the legacy single-event shape
+``{"event_id": "<uuid>"}``; rewrite each to the layered shape
+``{"sources": [{"kind": "event", "event_id": "<uuid>", "enabled": true}],
+"exclude_artist_ids": []}``.
+
+The resolver (generators.pool.normalize_sources) already tolerates the legacy
+shape, so this migration and the worker cutover need not be perfectly atomic --
+a profile still resolves whether or not this has run. The migration only
+normalizes stored data to the new canonical shape.
+
+input_references is a sa.JSON column, so a lightweight table with the JSON type
+handles per-dialect (de)serialization for both Postgres and SQLite.
+
+Revision ID: i0j1k2l3m4n5
+Revises: h9i0j1k2l3m4
+Create Date: 2026-06-23
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "i0j1k2l3m4n5"
+down_revision: str = "h9i0j1k2l3m4"
+branch_labels: None = None
+depends_on: None = None
+
+
+_profiles = sa.table(
+    "generator_profiles",
+    sa.column("id", sa.Uuid),
+    sa.column("input_references", sa.JSON),
+)
+
+
+def _legacy_to_layered(refs: object) -> dict[str, object] | None:
+    """Return the layered shape for a legacy {event_id} dict, else None."""
+    if not isinstance(refs, dict):
+        return None
+    if "sources" in refs:
+        return None  # already layered
+    event_id = refs.get("event_id")
+    if not event_id:
+        return None  # nothing to migrate (no event_id)
+    return {
+        "sources": [
+            {"kind": "event", "event_id": str(event_id), "enabled": True}
+        ],
+        "exclude_artist_ids": [],
+    }
+
+
+def _layered_to_legacy(refs: object) -> dict[str, object] | None:
+    """Reverse only the exact single-event shape this migration produced."""
+    if not isinstance(refs, dict):
+        return None
+    sources = refs.get("sources")
+    excludes = refs.get("exclude_artist_ids")
+    if not isinstance(sources, list) or len(sources) != 1:
+        return None
+    if excludes:  # had a non-empty exclude set -> not a clean legacy reversal
+        return None
+    source = sources[0]
+    if not isinstance(source, dict):
+        return None
+    if source.get("kind") != "event" or not source.get("enabled", True):
+        return None
+    event_id = source.get("event_id")
+    if not event_id:
+        return None
+    return {"event_id": str(event_id)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.select(_profiles.c.id, _profiles.c.input_references)
+    ).all()
+    for row in rows:
+        new_refs = _legacy_to_layered(row.input_references)
+        if new_refs is not None:
+            bind.execute(
+                sa.update(_profiles)
+                .where(_profiles.c.id == row.id)
+                .values(input_references=new_refs)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.select(_profiles.c.id, _profiles.c.input_references)
+    ).all()
+    for row in rows:
+        old_refs = _layered_to_legacy(row.input_references)
+        if old_refs is not None:
+            bind.execute(
+                sa.update(_profiles)
+                .where(_profiles.c.id == row.id)
+                .values(input_references=old_refs)
+            )

--- a/alembic/versions/j1k2l3m4n5o6_add_generation_pool_snapshot.py
+++ b/alembic/versions/j1k2l3m4n5o6_add_generation_pool_snapshot.py
@@ -1,0 +1,36 @@
+"""add pool_snapshot column to generation_records
+
+#128: live source re-resolution (events re-read each run, related artists hit
+nondeterministic external connectors) means two runs of the same profile can
+produce different pools. parameter_snapshot already records the params; add a
+pool_snapshot JSON column so the resolved artist pool (ids + provenance) is also
+captured, making a generation auditable and reproducible.
+
+Nullable: rows written before this migration have no snapshot.
+
+Revision ID: j1k2l3m4n5o6
+Revises: i0j1k2l3m4n5
+Create Date: 2026-06-23
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "j1k2l3m4n5o6"
+down_revision: str = "i0j1k2l3m4n5"
+branch_labels: None = None
+depends_on: None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generation_records",
+        sa.Column("pool_snapshot", sa.JSON, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("generation_records", "pool_snapshot")

--- a/src/resonance/api/v1/generators.py
+++ b/src/resonance/api/v1/generators.py
@@ -254,6 +254,7 @@ async def get_profile(
                 "freshness_actual": gen.freshness_actual,
                 "generation_duration_ms": gen.generation_duration_ms,
                 "track_sources_summary": gen.track_sources_summary,
+                "pool_snapshot": gen.pool_snapshot,
                 "created_at": gen.created_at.isoformat(),
             }
             for gen in generations

--- a/src/resonance/api/v1/generators.py
+++ b/src/resonance/api/v1/generators.py
@@ -13,6 +13,7 @@ import structlog
 
 import resonance.dependencies as deps_module
 import resonance.generators.parameters as params_module
+import resonance.generators.pool as pool_module
 import resonance.models.generator as generator_models
 import resonance.models.task as task_models
 import resonance.types as types_module
@@ -25,11 +26,19 @@ router = fastapi.APIRouter(
 
 
 class CreateProfileRequest(pydantic.BaseModel):
-    """Request body for creating a generator profile."""
+    """Request body for creating a generator profile.
+
+    ``input_references`` accepts both the layered source spec
+    (``{"sources": [...], "exclude_artist_ids": [...]}``) and the legacy
+    single-event shape (``{"event_id": "<uuid>"}``); the shape is parsed and
+    validated by :func:`validate_profile_inputs` via ``generators.pool``, so the
+    grammar lives in one place (#128). ``dict[str, Any]`` (not ``dict[str, str]``)
+    is required because the layered shape nests lists/objects under ``sources``.
+    """
 
     name: str
     generator_type: types_module.GeneratorType
-    input_references: dict[str, str]
+    input_references: dict[str, Any]
     parameter_values: dict[str, int] = pydantic.Field(default_factory=dict)
 
 
@@ -38,7 +47,7 @@ class UpdateProfileRequest(pydantic.BaseModel):
 
     name: str | None = None
     parameter_values: dict[str, int] | None = None
-    input_references: dict[str, str] | None = None
+    input_references: dict[str, Any] | None = None
 
 
 class GenerateRequest(pydantic.BaseModel):
@@ -48,22 +57,47 @@ class GenerateRequest(pydantic.BaseModel):
     max_tracks: int = 30
 
 
-def validate_profile_inputs(request: CreateProfileRequest) -> None:
-    """Validate that required inputs are present for the generator type.
+def validate_profile_inputs(
+    input_references: dict[str, Any],
+    generator_type: types_module.GeneratorType,
+) -> None:
+    """Validate that a profile's input_references can resolve to a pool.
+
+    Parses the layered source spec (reusing :func:`pool.normalize_sources`, which
+    also tolerates the legacy ``{"event_id": ...}`` shape), so the grammar is
+    defined in one place. Raises a clear error on a malformed shape, a missing
+    legacy-required key (for types that still declare one), or a structurally
+    empty pool (no enabled source). Resolution-time emptiness -- an event with no
+    lineup, or excludes that empty the pool -- is handled gracefully by the worker,
+    not here.
 
     Args:
-        request: The create profile request to validate.
+        input_references: The profile's input reference spec.
+        generator_type: The generator type (selects the type config).
 
     Raises:
-        ValueError: If a required input is missing.
+        ValueError: If the spec is malformed, a required key is missing, or the
+            pool is structurally empty.
     """
-    config = params_module.GENERATOR_TYPE_CONFIG.get(request.generator_type)
-    if config is None:
-        return
-    for required in config.required_inputs:
-        if required not in request.input_references:
-            msg = f"Missing required input: {required}"
-            raise ValueError(msg)
+    try:
+        sources = pool_module.normalize_sources(input_references)
+    except ValueError as exc:
+        msg = f"Invalid input_references: {exc}"
+        raise ValueError(msg) from exc
+
+    config = params_module.GENERATOR_TYPE_CONFIG.get(generator_type)
+    if config is not None:
+        for required in config.required_inputs:
+            if required not in input_references:
+                msg = f"Missing required input: {required}"
+                raise ValueError(msg)
+
+    if not any(source.enabled for source in sources):
+        msg = (
+            "input_references resolves to an empty pool: add at least one enabled "
+            "source (event, artist, or related)"
+        )
+        raise ValueError(msg)
 
 
 @router.post(
@@ -90,7 +124,7 @@ async def create_profile(
         HTTPException: 400 if required inputs are missing.
     """
     try:
-        validate_profile_inputs(body)
+        validate_profile_inputs(body.input_references, body.generator_type)
     except ValueError as exc:
         raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -267,6 +301,10 @@ async def update_profile(
     if body.parameter_values is not None:
         profile.parameter_values = dict(body.parameter_values)
     if body.input_references is not None:
+        try:
+            validate_profile_inputs(body.input_references, profile.generator_type)
+        except ValueError as exc:
+            raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
         profile.input_references = dict(body.input_references)
 
     await db.commit()

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -442,13 +442,20 @@ Subcommands:
   list                              List all profiles
   show <profile-id>                 Show profile with generation history
   create --type <type> --name <n>   Create a profile
-           [--input key=val ...]
+           [--source event:<uuid> ...]    Layered pool sources (#128)
+           [--source artist:<uuid> ...]
+           [--source related:<n>[:seed] ...]
+           [--exclude <artist-uuid> ...]  Drop artists from the pool
            [--param key=val ...]
+           [--input key=val ...]          Legacy (e.g. event_id=<uuid>)
   update <profile-id>               Update a profile
            [--name <n>]
            [--param key=val ...]
-           [--input key=val ...]
+           [--source ... | --exclude ... | --input key=val ...]
   delete <profile-id>               Delete a profile
+
+Sources and --input are mutually exclusive: if any --source/--exclude is given,
+the layered spec is sent; otherwise --input key=value is used (legacy).
 """
 
 
@@ -474,6 +481,74 @@ def _parse_key_value_args(args: list[str], flag: str) -> dict[str, str]:
         else:
             i += 1
     return result
+
+
+def _parse_source_spec(spec: str) -> dict[str, object]:
+    """Parse one ``--source`` spec into a layered pool source dict.
+
+    Grammar:
+      ``event:<uuid>``                -> an event source
+      ``artist:<uuid>``               -> a single artist source
+      ``related:<amount>[:<seed>]``   -> fold in N related artists (seed defaults
+                                         to "target")
+
+    Exits with a usage error on an unknown kind or a non-integer related amount.
+    """
+    kind, _, rest = spec.partition(":")
+    if kind == "event":
+        return {"kind": "event", "event_id": rest, "enabled": True}
+    if kind == "artist":
+        return {"kind": "artist", "artist_id": rest, "enabled": True}
+    if kind == "related":
+        amount_str, _, seed = rest.partition(":")
+        try:
+            amount = int(amount_str)
+        except ValueError:
+            print(f"Invalid related amount: {amount_str!r} (expected an integer)")
+            sys.exit(1)
+        return {
+            "kind": "related",
+            "amount": amount,
+            "seed": seed or "target",
+            "enabled": True,
+        }
+    print(f"Unknown source kind: {kind!r} (expected event, artist, or related)")
+    sys.exit(1)
+
+
+def _parse_pool_sources(args: list[str]) -> dict[str, object] | None:
+    """Parse ``--source`` / ``--exclude`` flags into a layered input_references dict.
+
+    Grammar (both flags repeatable)::
+
+        --source event:<uuid>
+        --source artist:<uuid>
+        --source related:<amount>[:<seed>]
+        --exclude <artist-uuid>
+
+    Returns the ``{"sources": [...], "exclude_artist_ids": [...]}`` dict, or None
+    when neither flag is present so the caller can fall back to the legacy
+    ``--input key=value`` form (e.g. ``--input event_id=<uuid>``). This keeps the
+    CLI at parity with the API, which accepts both shapes (#128).
+    """
+    sources: list[dict[str, object]] = []
+    excludes: list[str] = []
+    saw_flag = False
+    i = 0
+    while i < len(args):
+        if args[i] == "--source" and i + 1 < len(args):
+            saw_flag = True
+            sources.append(_parse_source_spec(args[i + 1]))
+            i += 2
+        elif args[i] == "--exclude" and i + 1 < len(args):
+            saw_flag = True
+            excludes.append(args[i + 1])
+            i += 2
+        else:
+            i += 1
+    if not saw_flag:
+        return None
+    return {"sources": sources, "exclude_artist_ids": excludes}
 
 
 def _cmd_profile() -> None:
@@ -552,12 +627,19 @@ def _cmd_profile() -> None:
         if not name or not gen_type:
             print("Usage: resonance-api profile create --type <type> --name <name>")
             sys.exit(1)
-        inputs = _parse_key_value_args(remaining, "--input")
+        # Prefer the layered --source/--exclude grammar; fall back to the legacy
+        # --input key=value form (e.g. --input event_id=<uuid>) (#128).
+        layered = _parse_pool_sources(remaining)
+        input_refs: dict[str, object] = (
+            layered
+            if layered is not None
+            else dict(_parse_key_value_args(remaining, "--input"))
+        )
         params = _parse_key_value_args(remaining, "--param")
         body: dict[str, object] = {
             "name": name,
             "generator_type": gen_type,
-            "input_references": inputs,
+            "input_references": input_refs,
         }
         if params:
             body["parameter_values"] = {k: int(v) for k, v in params.items()}
@@ -584,11 +666,18 @@ def _cmd_profile() -> None:
         params = _parse_key_value_args(remaining, "--param")
         if params:
             body_update["parameter_values"] = {k: int(v) for k, v in params.items()}
-        inputs = _parse_key_value_args(remaining, "--input")
-        if inputs:
-            body_update["input_references"] = inputs
+        layered = _parse_pool_sources(remaining)
+        if layered is not None:
+            body_update["input_references"] = layered
+        else:
+            legacy_inputs = _parse_key_value_args(remaining, "--input")
+            if legacy_inputs:
+                body_update["input_references"] = dict(legacy_inputs)
         if not body_update:
-            print("Nothing to update. Use --name, --param, or --input.")
+            print(
+                "Nothing to update. Use --name, --param, --source, --exclude, "
+                "or --input."
+            )
             sys.exit(1)
         resp = _api_request(
             "PATCH",

--- a/src/resonance/generators/parameters.py
+++ b/src/resonance/generators/parameters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 
+import resonance.generators.pool as pool_module
 import resonance.types as types_module
 
 
@@ -21,11 +22,29 @@ class ParameterDefinition:
 
 @dataclasses.dataclass(frozen=True)
 class GeneratorTypeConfig:
-    """Configuration for a generator type."""
+    """Configuration / preset for a generator type.
+
+    A generator type is a *preset* over the single generation engine, not a
+    distinct engine (#128). It declares which parameters the UI features, the
+    default parameter values and default pool seed a new profile of this type
+    starts from, and a human description.
+
+    ``required_inputs`` is retained for any type that still wants a specific key
+    present, but pool sufficiency is now enforced structurally (a non-empty set of
+    enabled sources) rather than by a hard-coded key like ``event_id`` -- see
+    ``api.v1.generators.validate_profile_inputs``.
+    """
 
     featured_parameters: frozenset[str]
     required_inputs: frozenset[str]
     description: str
+    # Parameter values a new profile of this type starts from (overrides registry
+    # defaults). Empty means "use the registry defaults".
+    default_param_values: dict[str, int] = dataclasses.field(default_factory=dict)
+    # The source kind a new profile of this type seeds its pool from (e.g. an
+    # event for concert prep). None means no default seed -- the caller supplies
+    # sources. Value is a ``pool.PoolSourceKind``.
+    default_pool_seed: str | None = None
 
 
 PARAMETER_REGISTRY: dict[str, ParameterDefinition] = {
@@ -62,8 +81,12 @@ PARAMETER_REGISTRY: dict[str, ParameterDefinition] = {
 GENERATOR_TYPE_CONFIG: dict[types_module.GeneratorType, GeneratorTypeConfig] = {
     types_module.GeneratorType.CONCERT_PREP: GeneratorTypeConfig(
         featured_parameters=frozenset({"familiarity", "hit_depth"}),
-        required_inputs=frozenset({"event_id"}),
+        # Pool sufficiency is checked structurally now (#128); concert_prep no
+        # longer hard-requires the legacy "event_id" key -- it seeds from an event
+        # source by default but accepts any non-empty pool.
+        required_inputs=frozenset(),
         description="Generate a playlist to prepare for a concert",
+        default_pool_seed=pool_module.PoolSourceKind.EVENT.value,
     ),
 }
 

--- a/src/resonance/generators/pool.py
+++ b/src/resonance/generators/pool.py
@@ -1,0 +1,256 @@
+"""Pool source spec: pure parsing, validation, and assembly of generation inputs.
+
+A generator profile's ``input_references`` is a layered list of *sources* that each
+resolve to artist IDs at generation time, plus a global ``exclude_artist_ids`` set
+applied last to the union (issue #128). The stored shape is::
+
+    {
+      "sources": [
+        {"kind": "event",   "event_id": "<uuid>", "enabled": true},
+        {"kind": "artist",  "artist_id": "<uuid>", "enabled": true},
+        {"kind": "related", "seed": "target", "amount": 5, "enabled": true}
+      ],
+      "exclude_artist_ids": ["<uuid>"]
+    }
+
+This module is **pure** -- no database, no connectors. It does two jobs:
+
+1. Parse the stored/client shape into typed sources (:func:`normalize_sources`),
+   tolerating the legacy single-event shape ``{"event_id": "<uuid>"}`` so a profile
+   written before #128 still resolves during the migration window.
+2. Assemble a deduplicated, exclude-filtered pool from already-resolved
+   ``(artist_id, provenance)`` pairs (:func:`build_pool`).
+
+The DB/connector resolution step (event -> artists, related -> similar artists)
+lives in the worker's ``resolve_pool`` helper, which calls into this module for the
+pure parts.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import uuid
+from collections.abc import Mapping, Sequence
+
+
+class PoolSourceKind(enum.StrEnum):
+    """The kind of a pool source (also used as resolved-artist provenance)."""
+
+    EVENT = "event"
+    ARTIST = "artist"
+    RELATED = "related"
+
+
+# Provenance shares the source vocabulary: an artist enters the pool *via* the kind
+# of source that produced it (event lineup, manual artist add, or related expansion).
+PoolProvenance = PoolSourceKind
+
+# The only ``seed`` selector today: expand related artists from the non-related
+# ("target") artists already resolved from event + artist sources.
+SEED_TARGET = "target"
+
+
+@dataclasses.dataclass(frozen=True)
+class EventSource:
+    """Resolve an event's lineup (confirmed + accepted candidates) to artists."""
+
+    event_id: uuid.UUID
+    enabled: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class ArtistSource:
+    """Add a single artist directly to the pool."""
+
+    artist_id: uuid.UUID
+    enabled: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class RelatedSource:
+    """Fold in artists similar to the already-resolved seed artists.
+
+    ``amount`` caps how many related artists are folded in. ``seed`` selects which
+    already-resolved artists to expand from; only ``"target"`` (the non-related
+    artists) is supported today.
+    """
+
+    amount: int
+    seed: str = SEED_TARGET
+    enabled: bool = True
+
+
+PoolSource = EventSource | ArtistSource | RelatedSource
+
+
+@dataclasses.dataclass(frozen=True)
+class ResolvedArtist:
+    """An artist resolved into the pool, tagged with how it got there."""
+
+    artist_id: uuid.UUID
+    via: PoolProvenance
+
+
+def _parse_uuid(value: object, field: str) -> uuid.UUID:
+    """Parse a JSON-stored UUID string, raising a clear error on bad input."""
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, AttributeError, TypeError) as exc:
+        msg = f"Invalid UUID for {field}: {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _parse_enabled(raw: Mapping[str, object]) -> bool:
+    """Read the optional ``enabled`` flag, defaulting to True."""
+    value = raw.get("enabled", True)
+    if not isinstance(value, bool):
+        msg = f"Source 'enabled' must be a boolean, got {type(value).__name__}"
+        raise ValueError(msg)
+    return value
+
+
+def _parse_source(raw: object) -> PoolSource:
+    """Parse one source entry into a typed source.
+
+    Raises:
+        ValueError: If the entry is malformed or the kind is unknown.
+    """
+    if not isinstance(raw, Mapping):
+        msg = f"Each source must be an object, got {type(raw).__name__}"
+        raise ValueError(msg)
+
+    kind_raw = raw.get("kind")
+    try:
+        kind = PoolSourceKind(str(kind_raw))
+    except ValueError as exc:
+        msg = f"Unknown source kind: {kind_raw!r}"
+        raise ValueError(msg) from exc
+
+    enabled = _parse_enabled(raw)
+
+    if kind is PoolSourceKind.EVENT:
+        return EventSource(
+            event_id=_parse_uuid(raw.get("event_id"), "event_id"), enabled=enabled
+        )
+    if kind is PoolSourceKind.ARTIST:
+        return ArtistSource(
+            artist_id=_parse_uuid(raw.get("artist_id"), "artist_id"), enabled=enabled
+        )
+    # RELATED
+    amount_raw = raw.get("amount")
+    if not isinstance(amount_raw, int) or isinstance(amount_raw, bool):
+        msg = f"Related source 'amount' must be an integer, got {amount_raw!r}"
+        raise ValueError(msg)
+    if amount_raw < 0:
+        msg = f"Related source 'amount' must be non-negative, got {amount_raw}"
+        raise ValueError(msg)
+    seed = str(raw.get("seed", SEED_TARGET))
+    if seed != SEED_TARGET:
+        msg = f"Unsupported related 'seed': {seed!r} (only {SEED_TARGET!r})"
+        raise ValueError(msg)
+    return RelatedSource(amount=amount_raw, seed=seed, enabled=enabled)
+
+
+def normalize_sources(raw: Mapping[str, object]) -> list[PoolSource]:
+    """Parse ``input_references`` into a list of typed sources.
+
+    Accepts the layered ``{"sources": [...]}`` shape and the legacy single-event
+    shape ``{"event_id": "<uuid>"}`` (so pre-#128 profiles still resolve during the
+    migration window). If both are present, the explicit ``sources`` list wins. An
+    input with neither yields an empty list -- emptiness is validated post-resolution
+    (a profile may resolve to an empty pool, which is a higher-layer error).
+
+    Raises:
+        ValueError: If ``sources`` is not a list or any entry is malformed.
+    """
+    sources_raw = raw.get("sources")
+    if sources_raw is not None:
+        if not isinstance(sources_raw, Sequence) or isinstance(
+            sources_raw, (str, bytes)
+        ):
+            msg = f"'sources' must be a list, got {type(sources_raw).__name__}"
+            raise ValueError(msg)
+        return [_parse_source(entry) for entry in sources_raw]
+
+    # Legacy single-event shape.
+    if raw.get("event_id"):
+        return [EventSource(event_id=_parse_uuid(raw.get("event_id"), "event_id"))]
+
+    return []
+
+
+def extract_excludes(raw: Mapping[str, object]) -> set[uuid.UUID]:
+    """Parse the global ``exclude_artist_ids`` set from ``input_references``.
+
+    Raises:
+        ValueError: If ``exclude_artist_ids`` is present but not a list, or any
+            entry is not a valid UUID.
+    """
+    raw_excludes = raw.get("exclude_artist_ids")
+    if raw_excludes is None:
+        return set()
+    if not isinstance(raw_excludes, Sequence) or isinstance(raw_excludes, (str, bytes)):
+        msg = f"'exclude_artist_ids' must be a list, got {type(raw_excludes).__name__}"
+        raise ValueError(msg)
+    return {_parse_uuid(item, "exclude_artist_ids[]") for item in raw_excludes}
+
+
+def build_pool(
+    resolved: Sequence[ResolvedArtist],
+    exclude_ids: set[uuid.UUID],
+) -> list[ResolvedArtist]:
+    """Assemble the final pool from resolved artists: dedup, then exclude last.
+
+    ``resolved`` is the in-order concatenation of every enabled source's resolved
+    artists (event sources first, then artist sources, then related expansion).
+    The first occurrence of an artist wins, so provenance precedence is
+    event > artist > related by construction. The global exclude set is applied
+    last, so "this event but not the opener" works regardless of which source the
+    opener came from.
+
+    Returns the deduplicated, exclude-filtered artists in first-seen order.
+    """
+    seen: set[uuid.UUID] = set()
+    pool: list[ResolvedArtist] = []
+    for entry in resolved:
+        if entry.artist_id in exclude_ids:
+            continue
+        if entry.artist_id in seen:
+            continue
+        seen.add(entry.artist_id)
+        pool.append(entry)
+    return pool
+
+
+def serialize_source(source: PoolSource) -> dict[str, object]:
+    """Serialize a typed source back to its stored JSON shape."""
+    if isinstance(source, EventSource):
+        return {
+            "kind": PoolSourceKind.EVENT.value,
+            "event_id": str(source.event_id),
+            "enabled": source.enabled,
+        }
+    if isinstance(source, ArtistSource):
+        return {
+            "kind": PoolSourceKind.ARTIST.value,
+            "artist_id": str(source.artist_id),
+            "enabled": source.enabled,
+        }
+    return {
+        "kind": PoolSourceKind.RELATED.value,
+        "seed": source.seed,
+        "amount": source.amount,
+        "enabled": source.enabled,
+    }
+
+
+def serialize_input_references(
+    sources: Sequence[PoolSource],
+    exclude_ids: Sequence[uuid.UUID] = (),
+) -> dict[str, object]:
+    """Build a stored ``input_references`` dict from typed sources + excludes."""
+    return {
+        "sources": [serialize_source(s) for s in sources],
+        "exclude_artist_ids": [str(aid) for aid in exclude_ids],
+    }

--- a/src/resonance/models/generator.py
+++ b/src/resonance/models/generator.py
@@ -97,6 +97,13 @@ class GenerationRecord(base_module.TimestampMixin, base_module.Base):
     track_sources_summary: orm.Mapped[dict[str, int] | None] = orm.mapped_column(
         sa.JSON, nullable=True
     )
+    # Resolved pool snapshot (#128): the artist ids + provenance that fed this
+    # generation, captured for reproducibility/audit since sources re-resolve
+    # live. Shape: [{"artist_id": "<uuid>", "via": "event|artist|related"}].
+    # Nullable: records written before the snapshot column have none.
+    pool_snapshot: orm.Mapped[list[dict[str, str]] | None] = orm.mapped_column(
+        sa.JSON, nullable=True
+    )
 
     profile: orm.Mapped[GeneratorProfile] = orm.relationship(
         back_populates="generations"

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -38,6 +38,7 @@ import resonance.crypto as crypto_module
 import resonance.database as database_module
 import resonance.generators.concert_prep as concert_prep_module
 import resonance.generators.parameters as params_module
+import resonance.generators.pool as pool_module
 import resonance.heartbeat as heartbeat_module
 import resonance.logging as logging_module
 import resonance.migrations as migrations_module
@@ -776,6 +777,87 @@ def _merge_adjacent_discovery_targets(
     return merged
 
 
+async def resolve_pool(
+    session: sa_async.AsyncSession,
+    input_references: collections.abc.Mapping[str, object],
+) -> list[pool_module.ResolvedArtist]:
+    """Resolve a profile's ``input_references`` into a deduplicated artist pool.
+
+    Parses the layered source spec, tolerating the legacy ``{"event_id": ...}``
+    shape via :func:`pool.normalize_sources` (so a pre-#128 profile still resolves
+    during the migration window), resolves the DB-backed sources, then applies the
+    global ``exclude_artist_ids`` set last.
+
+    Resolved here:
+
+    * ``event``  -> the event's confirmed ``EventArtist`` rows plus accepted
+      ``EventArtistCandidate`` matches. Every enabled event source is resolved in
+      one ``event_id IN (...)`` query per table rather than per-event (#128 T14).
+    * ``artist`` -> the artist itself.
+
+    The ``related`` source kind is intentionally NOT resolved here: related /
+    adjacent expansion is driven by the ``similar_artist_ratio`` parameter against
+    the resolved target set (see ``generate_playlist`` / ``score_and_build_playlist``),
+    pending the param-vs-source-count reconciliation deferred to #128 UI work.
+
+    Returns the deduplicated, exclude-filtered artists in first-seen order (event
+    sources before artist sources), each tagged with provenance. This is the single
+    target-resolution path shared by both worker generation functions, replacing the
+    event-resolution blocks that were duplicated across them.
+    """
+    sources = pool_module.normalize_sources(input_references)
+    exclude_ids = pool_module.extract_excludes(input_references)
+
+    resolved: list[pool_module.ResolvedArtist] = []
+
+    # Event sources: batch every enabled event into one IN-query per table (T14).
+    event_ids = [
+        s.event_id
+        for s in sources
+        if isinstance(s, pool_module.EventSource) and s.enabled
+    ]
+    if event_ids:
+        ea_result = await session.execute(
+            sa.select(concert_models.EventArtist).where(
+                concert_models.EventArtist.event_id.in_(event_ids)
+            )
+        )
+        for ea in ea_result.scalars().all():
+            resolved.append(
+                pool_module.ResolvedArtist(
+                    artist_id=ea.artist_id, via=pool_module.PoolProvenance.EVENT
+                )
+            )
+
+        eac_result = await session.execute(
+            sa.select(concert_models.EventArtistCandidate).where(
+                concert_models.EventArtistCandidate.event_id.in_(event_ids),
+                concert_models.EventArtistCandidate.status
+                == types_module.CandidateStatus.ACCEPTED,
+                concert_models.EventArtistCandidate.matched_artist_id.isnot(None),
+            )
+        )
+        for cand in eac_result.scalars().all():
+            if cand.matched_artist_id is not None:
+                resolved.append(
+                    pool_module.ResolvedArtist(
+                        artist_id=cand.matched_artist_id,
+                        via=pool_module.PoolProvenance.EVENT,
+                    )
+                )
+
+    # Artist sources: the artist itself enters the pool directly.
+    for source in sources:
+        if isinstance(source, pool_module.ArtistSource) and source.enabled:
+            resolved.append(
+                pool_module.ResolvedArtist(
+                    artist_id=source.artist_id, via=pool_module.PoolProvenance.ARTIST
+                )
+            )
+
+    return pool_module.build_pool(resolved, exclude_ids)
+
+
 async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
     """Orchestrate playlist generation: create discovery + scoring child tasks.
 
@@ -830,35 +912,16 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 await session.commit()
                 return
 
+            # event_id is retained only for the legacy scoring-child param and
+            # logging; the actual artist set comes from resolve_pool, which handles
+            # both the legacy {"event_id": ...} and layered {"sources": [...]} shapes
+            # and applies the global exclude set (#128).
             event_id = str(profile.input_references.get("event_id", ""))
             log = log.bind(event_id=event_id)
 
-            # Resolve event artists
-            # 1. Confirmed EventArtist rows
-            ea_result = await session.execute(
-                sa.select(concert_models.EventArtist).where(
-                    concert_models.EventArtist.event_id == uuid.UUID(event_id)
-                )
-            )
-            event_artists = ea_result.scalars().all()
-            artist_ids: list[uuid.UUID] = [ea.artist_id for ea in event_artists]
-
-            # 2. Accepted EventArtistCandidate rows
-            eac_result = await session.execute(
-                sa.select(concert_models.EventArtistCandidate).where(
-                    concert_models.EventArtistCandidate.event_id == uuid.UUID(event_id),
-                    concert_models.EventArtistCandidate.status
-                    == types_module.CandidateStatus.ACCEPTED,
-                    concert_models.EventArtistCandidate.matched_artist_id.isnot(None),
-                )
-            )
-            accepted_candidates = eac_result.scalars().all()
-            for cand in accepted_candidates:
-                if (
-                    cand.matched_artist_id is not None
-                    and cand.matched_artist_id not in artist_ids
-                ):
-                    artist_ids.append(cand.matched_artist_id)
+            pool = await resolve_pool(session, profile.input_references)
+            artist_ids: list[uuid.UUID] = [r.artist_id for r in pool]
+            log = log.bind(pool_size=len(artist_ids))
 
             if not artist_ids:
                 await lifecycle_module.complete_task(
@@ -1540,29 +1603,14 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 await _check_parent_completion(session, task, arq_redis, log)
                 return
 
+            # event_id retained for logging only; resolve_pool is the shared
+            # target-resolution path (legacy {"event_id"} + layered {"sources"}
+            # shapes, exclude set applied last) (#128).
             event_id = str(profile.input_references.get("event_id", ""))
             log = log.bind(event_id=event_id)
 
-            # Resolve artist IDs from event
-            ea_result = await session.execute(
-                sa.select(concert_models.EventArtist).where(
-                    concert_models.EventArtist.event_id == uuid.UUID(event_id)
-                )
-            )
-            event_artists = ea_result.scalars().all()
-            artist_ids: set[uuid.UUID] = {ea.artist_id for ea in event_artists}
-
-            eac_result = await session.execute(
-                sa.select(concert_models.EventArtistCandidate).where(
-                    concert_models.EventArtistCandidate.event_id == uuid.UUID(event_id),
-                    concert_models.EventArtistCandidate.status
-                    == types_module.CandidateStatus.ACCEPTED,
-                    concert_models.EventArtistCandidate.matched_artist_id.isnot(None),
-                )
-            )
-            for cand in eac_result.scalars().all():
-                if cand.matched_artist_id is not None:
-                    artist_ids.add(cand.matched_artist_id)
+            pool = await resolve_pool(session, profile.input_references)
+            artist_ids: set[uuid.UUID] = {r.artist_id for r in pool}
 
             # Apply parameter defaults early — adjacent-artist expansion below
             # is gated on similar_artist_ratio.

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -1807,6 +1807,24 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
             generation_duration_ms = int(
                 (time_module.monotonic() - generation_start) * 1000
             )
+            # Snapshot the resolved pool for reproducibility/audit (#128): sources
+            # re-resolve live, so record the exact artists that fed this run. The
+            # source pool keeps its provenance (event/artist); adjacent artists
+            # folded in by similar_artist_ratio are tagged related.
+            pool_snapshot: list[dict[str, str]] = [
+                {"artist_id": str(resolved.artist_id), "via": resolved.via.value}
+                for resolved in pool
+            ]
+            pool_snapshot.extend(
+                {
+                    "artist_id": str(adjacent_id),
+                    "via": pool_module.PoolProvenance.RELATED.value,
+                }
+                for adjacent_id in sorted(
+                    query_artist_ids - {resolved.artist_id for resolved in pool},
+                    key=str,
+                )
+            )
             gen_record = generator_models.GenerationRecord(
                 id=uuid.uuid4(),
                 profile_id=uuid.UUID(profile_id),
@@ -1816,6 +1834,7 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 freshness_actual=selection.freshness_actual,
                 track_sources_summary=selection.sources_summary,
                 generation_duration_ms=generation_duration_ms,
+                pool_snapshot=pool_snapshot,
             )
             session.add(gen_record)
 

--- a/tests/test_api_generators.py
+++ b/tests/test_api_generators.py
@@ -34,7 +34,8 @@ class TestCreateProfileRequest:
         request = generators_module.CreateProfileRequest(**body)
         assert request.parameter_values == {}
 
-    def test_missing_required_input_raises(self) -> None:
+    def test_empty_pool_raises(self) -> None:
+        # No sources at all -> structurally empty pool -> clear error (#128).
         body = {
             "name": "Show Prep",
             "generator_type": "concert_prep",
@@ -42,10 +43,12 @@ class TestCreateProfileRequest:
             "parameter_values": {},
         }
         request = generators_module.CreateProfileRequest(**body)
-        with pytest.raises(ValueError, match="event_id"):
-            generators_module.validate_profile_inputs(request)
+        with pytest.raises(ValueError, match="empty pool"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
 
-    def test_valid_inputs_pass_validation(self) -> None:
+    def test_valid_legacy_inputs_pass_validation(self) -> None:
         body = {
             "name": "Show Prep",
             "generator_type": "concert_prep",
@@ -53,20 +56,67 @@ class TestCreateProfileRequest:
             "parameter_values": {},
         }
         request = generators_module.CreateProfileRequest(**body)
-        # Should not raise
-        generators_module.validate_profile_inputs(request)
+        # Legacy single-event shape resolves to one enabled source -> passes.
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )
 
-    def test_unknown_generator_type_passes_validation(self) -> None:
-        """Generator types not in GENERATOR_TYPE_CONFIG skip validation."""
+    def test_valid_layered_sources_pass_validation(self) -> None:
         body = {
-            "name": "Deep Dive",
-            "generator_type": "artist_deep_dive",
-            "input_references": {},
+            "name": "Show Prep",
+            "generator_type": "concert_prep",
+            "input_references": {
+                "sources": [
+                    {"kind": "event", "event_id": str(uuid.uuid4()), "enabled": True}
+                ]
+            },
             "parameter_values": {},
         }
         request = generators_module.CreateProfileRequest(**body)
-        # Should not raise — no config means no required inputs
-        generators_module.validate_profile_inputs(request)
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )
+
+    def test_unknown_generator_type_still_requires_pool(self) -> None:
+        """No type config skips the legacy key-check but still needs a pool."""
+        valid = {
+            "name": "Deep Dive",
+            "generator_type": "artist_deep_dive",
+            "input_references": {
+                "sources": [
+                    {"kind": "artist", "artist_id": str(uuid.uuid4()), "enabled": True}
+                ]
+            },
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**valid)
+        # A valid source passes even with no type config.
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )
+        # But an empty pool still raises, config or not.
+        empty = generators_module.CreateProfileRequest(
+            name="Deep Dive",
+            generator_type="artist_deep_dive",
+            input_references={},
+        )
+        with pytest.raises(ValueError, match="empty pool"):
+            generators_module.validate_profile_inputs(
+                empty.input_references, empty.generator_type
+            )
+
+    def test_malformed_source_raises(self) -> None:
+        body = {
+            "name": "Bad",
+            "generator_type": "concert_prep",
+            "input_references": {"sources": [{"kind": "nonsense"}]},
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        with pytest.raises(ValueError, match="Invalid input_references"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
 
 
 class TestUpdateProfileRequest:
@@ -118,8 +168,8 @@ class TestGenerateRequest:
 class TestValidateProfileInputs:
     """Tests for validate_profile_inputs function."""
 
-    def test_multiple_missing_inputs_reports_first(self) -> None:
-        """When multiple required inputs are missing, reports one."""
+    def test_empty_input_references_raise_empty_pool(self) -> None:
+        """An input spec with no sources reports a clear empty-pool error."""
         body = {
             "name": "Test",
             "generator_type": "concert_prep",
@@ -127,11 +177,31 @@ class TestValidateProfileInputs:
             "parameter_values": {},
         }
         request = generators_module.CreateProfileRequest(**body)
-        with pytest.raises(ValueError, match="Missing required input"):
-            generators_module.validate_profile_inputs(request)
+        with pytest.raises(ValueError, match="empty pool"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
 
-    def test_extra_inputs_are_allowed(self) -> None:
-        """Extra input references beyond what's required are fine."""
+    def test_disabled_only_sources_raise_empty_pool(self) -> None:
+        """All-disabled sources resolve to an empty pool."""
+        body = {
+            "name": "Test",
+            "generator_type": "concert_prep",
+            "input_references": {
+                "sources": [
+                    {"kind": "event", "event_id": str(uuid.uuid4()), "enabled": False}
+                ]
+            },
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        with pytest.raises(ValueError, match="empty pool"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
+
+    def test_extra_legacy_keys_are_allowed(self) -> None:
+        """Extra keys alongside a legacy event_id are ignored, not rejected."""
         body = {
             "name": "Test",
             "generator_type": "concert_prep",
@@ -143,4 +213,6 @@ class TestValidateProfileInputs:
         }
         request = generators_module.CreateProfileRequest(**body)
         # Should not raise
-        generators_module.validate_profile_inputs(request)
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -423,3 +423,72 @@ class TestBackfillMbidsCommand:
         monkeypatch.setattr(cli_module, "_api_request", fake_req)
         cli_module._cmd_backfill_mbids()
         assert "entity_types=track" in captured["path"]
+
+
+class TestParsePoolSources:
+    """Tests for the layered --source / --exclude grammar (#128 T8)."""
+
+    def test_no_flags_returns_none(self) -> None:
+        # No --source/--exclude -> caller falls back to legacy --input.
+        assert cli_module._parse_pool_sources(["--input", "event_id=abc"]) is None
+
+    def test_event_source(self) -> None:
+        result = cli_module._parse_pool_sources(["--source", "event:e1"])
+        assert result == {
+            "sources": [{"kind": "event", "event_id": "e1", "enabled": True}],
+            "exclude_artist_ids": [],
+        }
+
+    def test_artist_source(self) -> None:
+        result = cli_module._parse_pool_sources(["--source", "artist:a1"])
+        assert result is not None
+        assert result["sources"] == [
+            {"kind": "artist", "artist_id": "a1", "enabled": True}
+        ]
+
+    def test_related_source_default_seed(self) -> None:
+        result = cli_module._parse_pool_sources(["--source", "related:5"])
+        assert result is not None
+        assert result["sources"] == [
+            {"kind": "related", "amount": 5, "seed": "target", "enabled": True}
+        ]
+
+    def test_related_source_explicit_seed(self) -> None:
+        result = cli_module._parse_pool_sources(["--source", "related:3:target"])
+        assert result is not None
+        assert result["sources"][0] == {
+            "kind": "related",
+            "amount": 3,
+            "seed": "target",
+            "enabled": True,
+        }
+
+    def test_multiple_sources_and_excludes(self) -> None:
+        result = cli_module._parse_pool_sources(
+            [
+                "--source",
+                "event:e1",
+                "--source",
+                "artist:a1",
+                "--exclude",
+                "x1",
+                "--exclude",
+                "x2",
+            ]
+        )
+        assert result is not None
+        assert len(result["sources"]) == 2  # type: ignore[arg-type]
+        assert result["exclude_artist_ids"] == ["x1", "x2"]
+
+    def test_exclude_only_returns_dict(self) -> None:
+        # --exclude alone still opts into the layered shape (empty sources).
+        result = cli_module._parse_pool_sources(["--exclude", "x1"])
+        assert result == {"sources": [], "exclude_artist_ids": ["x1"]}
+
+    def test_unknown_kind_exits(self) -> None:
+        with pytest.raises(SystemExit):
+            cli_module._parse_pool_sources(["--source", "bogus:1"])
+
+    def test_related_non_integer_exits(self) -> None:
+        with pytest.raises(SystemExit):
+            cli_module._parse_pool_sources(["--source", "related:lots"])

--- a/tests/test_migration_input_references.py
+++ b/tests/test_migration_input_references.py
@@ -1,0 +1,119 @@
+"""Regression tests for the {event_id} -> {sources} migration (#128 T11).
+
+These exercise the migration's pure transform helpers and the cross-check that
+matters for deploy safety: a concert_prep profile resolves to the same pool
+whether or not the migration has run, because pool.normalize_sources tolerates
+both shapes. The migration only normalizes stored data; it must never change
+which artists a profile resolves to.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import uuid
+
+import resonance.generators.pool as pool_module
+
+_MIGRATION_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "alembic"
+    / "versions"
+    / "i0j1k2l3m4n5_migrate_input_references_to_sources.py"
+)
+
+
+def _load_migration() -> object:
+    spec = importlib.util.spec_from_file_location("_mig_input_refs", _MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_mig = _load_migration()
+
+
+class TestLegacyToLayered:
+    def test_basic_event_id(self) -> None:
+        eid = str(uuid.uuid4())
+        result = _mig._legacy_to_layered({"event_id": eid})
+        assert result == {
+            "sources": [{"kind": "event", "event_id": eid, "enabled": True}],
+            "exclude_artist_ids": [],
+        }
+
+    def test_already_layered_returns_none(self) -> None:
+        # Idempotent: an already-migrated profile is skipped (re-run safe).
+        layered = {"sources": [{"kind": "event", "event_id": "x", "enabled": True}]}
+        assert _mig._legacy_to_layered(layered) is None
+
+    def test_no_event_id_returns_none(self) -> None:
+        assert _mig._legacy_to_layered({}) is None
+        assert _mig._legacy_to_layered({"event_id": ""}) is None
+
+    def test_non_dict_returns_none(self) -> None:
+        assert _mig._legacy_to_layered(None) is None
+        assert _mig._legacy_to_layered("nope") is None
+
+
+class TestLayeredToLegacy:
+    def test_reverses_clean_single_event(self) -> None:
+        eid = str(uuid.uuid4())
+        layered = {
+            "sources": [{"kind": "event", "event_id": eid, "enabled": True}],
+            "exclude_artist_ids": [],
+        }
+        assert _mig._layered_to_legacy(layered) == {"event_id": eid}
+
+    def test_skips_when_excludes_present(self) -> None:
+        layered = {
+            "sources": [{"kind": "event", "event_id": "e", "enabled": True}],
+            "exclude_artist_ids": ["a1"],
+        }
+        assert _mig._layered_to_legacy(layered) is None
+
+    def test_skips_multi_source(self) -> None:
+        layered = {
+            "sources": [
+                {"kind": "event", "event_id": "e1", "enabled": True},
+                {"kind": "artist", "artist_id": "a1", "enabled": True},
+            ],
+            "exclude_artist_ids": [],
+        }
+        assert _mig._layered_to_legacy(layered) is None
+
+    def test_skips_non_event_source(self) -> None:
+        layered = {
+            "sources": [{"kind": "artist", "artist_id": "a1", "enabled": True}],
+            "exclude_artist_ids": [],
+        }
+        assert _mig._layered_to_legacy(layered) is None
+
+
+class TestRoundTrip:
+    def test_legacy_layered_legacy_is_identity(self) -> None:
+        eid = str(uuid.uuid4())
+        layered = _mig._legacy_to_layered({"event_id": eid})
+        assert layered is not None
+        assert _mig._layered_to_legacy(layered) == {"event_id": eid}
+
+
+class TestBackCompatResolution:
+    """The deploy-safety guarantee: both shapes resolve to the same source."""
+
+    def test_migrated_and_legacy_resolve_identically(self) -> None:
+        eid = uuid.uuid4()
+        legacy = {"event_id": str(eid)}
+        migrated = _mig._legacy_to_layered(legacy)
+        assert migrated is not None
+
+        legacy_sources = pool_module.normalize_sources(legacy)
+        migrated_sources = pool_module.normalize_sources(migrated)
+
+        assert legacy_sources == migrated_sources
+        assert len(legacy_sources) == 1
+        source = legacy_sources[0]
+        assert isinstance(source, pool_module.EventSource)
+        assert source.event_id == eid
+        assert source.enabled is True

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -30,10 +30,17 @@ class TestGeneratorTypeConfig:
         assert "familiarity" in config.featured_parameters
         assert "hit_depth" in config.featured_parameters
 
-    def test_concert_prep_required_inputs(self) -> None:
+    def test_concert_prep_no_legacy_required_key(self) -> None:
+        # Pool sufficiency is structural now (#128): concert_prep no longer
+        # hard-requires the legacy "event_id" key.
         gen_type = types_module.GeneratorType.CONCERT_PREP
         config = params_module.GENERATOR_TYPE_CONFIG[gen_type]
-        assert "event_id" in config.required_inputs
+        assert config.required_inputs == frozenset()
+
+    def test_concert_prep_seeds_from_event(self) -> None:
+        gen_type = types_module.GeneratorType.CONCERT_PREP
+        config = params_module.GENERATOR_TYPE_CONFIG[gen_type]
+        assert config.default_pool_seed == "event"
 
 
 class TestApplyDefaults:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,209 @@
+"""Tests for the pure pool source spec (issue #128)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import resonance.generators.pool as pool_module
+
+
+class TestNormalizeSources:
+    def test_layered_shape_parses_all_kinds(self) -> None:
+        eid = uuid.uuid4()
+        aid = uuid.uuid4()
+        raw = {
+            "sources": [
+                {"kind": "event", "event_id": str(eid), "enabled": True},
+                {"kind": "artist", "artist_id": str(aid), "enabled": False},
+                {"kind": "related", "seed": "target", "amount": 5},
+            ]
+        }
+        sources = pool_module.normalize_sources(raw)
+        assert sources == [
+            pool_module.EventSource(event_id=eid, enabled=True),
+            pool_module.ArtistSource(artist_id=aid, enabled=False),
+            pool_module.RelatedSource(amount=5, seed="target", enabled=True),
+        ]
+
+    def test_legacy_event_id_shape(self) -> None:
+        eid = uuid.uuid4()
+        sources = pool_module.normalize_sources({"event_id": str(eid)})
+        assert sources == [pool_module.EventSource(event_id=eid, enabled=True)]
+
+    def test_sources_wins_over_legacy_event_id(self) -> None:
+        legacy = uuid.uuid4()
+        new = uuid.uuid4()
+        raw = {
+            "event_id": str(legacy),
+            "sources": [{"kind": "event", "event_id": str(new)}],
+        }
+        sources = pool_module.normalize_sources(raw)
+        assert sources == [pool_module.EventSource(event_id=new)]
+
+    def test_empty_input_yields_empty_list(self) -> None:
+        assert pool_module.normalize_sources({}) == []
+
+    def test_empty_sources_list_yields_empty_list(self) -> None:
+        assert pool_module.normalize_sources({"sources": []}) == []
+
+    def test_enabled_defaults_true(self) -> None:
+        aid = uuid.uuid4()
+        sources = pool_module.normalize_sources(
+            {"sources": [{"kind": "artist", "artist_id": str(aid)}]}
+        )
+        assert sources[0].enabled is True
+
+    def test_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown source kind"):
+            pool_module.normalize_sources({"sources": [{"kind": "genre"}]})
+
+    def test_missing_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown source kind"):
+            pool_module.normalize_sources(
+                {"sources": [{"event_id": str(uuid.uuid4())}]}
+            )
+
+    def test_bad_event_uuid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid UUID for event_id"):
+            pool_module.normalize_sources(
+                {"sources": [{"kind": "event", "event_id": "not-a-uuid"}]}
+            )
+
+    def test_sources_not_a_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="'sources' must be a list"):
+            pool_module.normalize_sources({"sources": {"kind": "event"}})
+
+    def test_source_entry_not_a_mapping_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be an object"):
+            pool_module.normalize_sources({"sources": ["event"]})
+
+    def test_related_amount_required_integer(self) -> None:
+        with pytest.raises(ValueError, match="'amount' must be an integer"):
+            pool_module.normalize_sources(
+                {"sources": [{"kind": "related", "amount": "five"}]}
+            )
+
+    def test_related_amount_rejects_bool(self) -> None:
+        # bool is an int subclass; it must not be accepted as an amount.
+        with pytest.raises(ValueError, match="'amount' must be an integer"):
+            pool_module.normalize_sources(
+                {"sources": [{"kind": "related", "amount": True}]}
+            )
+
+    def test_related_amount_non_negative(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            pool_module.normalize_sources(
+                {"sources": [{"kind": "related", "amount": -1}]}
+            )
+
+    def test_related_seed_default(self) -> None:
+        sources = pool_module.normalize_sources(
+            {"sources": [{"kind": "related", "amount": 3}]}
+        )
+        assert sources[0] == pool_module.RelatedSource(amount=3, seed="target")
+
+    def test_unsupported_seed_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported related 'seed'"):
+            pool_module.normalize_sources(
+                {"sources": [{"kind": "related", "amount": 3, "seed": "genre"}]}
+            )
+
+    def test_enabled_must_be_bool(self) -> None:
+        with pytest.raises(ValueError, match="'enabled' must be a boolean"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {"kind": "artist", "artist_id": str(uuid.uuid4()), "enabled": 1}
+                    ]
+                }
+            )
+
+
+class TestExtractExcludes:
+    def test_missing_yields_empty_set(self) -> None:
+        assert pool_module.extract_excludes({}) == set()
+
+    def test_parses_uuid_list(self) -> None:
+        a, b = uuid.uuid4(), uuid.uuid4()
+        result = pool_module.extract_excludes({"exclude_artist_ids": [str(a), str(b)]})
+        assert result == {a, b}
+
+    def test_not_a_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be a list"):
+            pool_module.extract_excludes({"exclude_artist_ids": str(uuid.uuid4())})
+
+    def test_bad_uuid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid UUID"):
+            pool_module.extract_excludes({"exclude_artist_ids": ["nope"]})
+
+
+class TestBuildPool:
+    def test_dedup_first_seen_wins(self) -> None:
+        aid = uuid.uuid4()
+        resolved = [
+            pool_module.ResolvedArtist(aid, pool_module.PoolProvenance.EVENT),
+            pool_module.ResolvedArtist(aid, pool_module.PoolProvenance.RELATED),
+        ]
+        pool = pool_module.build_pool(resolved, set())
+        assert pool == [
+            pool_module.ResolvedArtist(aid, pool_module.PoolProvenance.EVENT)
+        ]
+
+    def test_exclude_applied_last(self) -> None:
+        keep = uuid.uuid4()
+        drop = uuid.uuid4()
+        resolved = [
+            pool_module.ResolvedArtist(keep, pool_module.PoolProvenance.EVENT),
+            pool_module.ResolvedArtist(drop, pool_module.PoolProvenance.EVENT),
+        ]
+        pool = pool_module.build_pool(resolved, {drop})
+        assert [r.artist_id for r in pool] == [keep]
+
+    def test_exclude_overrides_any_provenance(self) -> None:
+        # "this event but not the opener": opener came in via event, still excluded.
+        opener = uuid.uuid4()
+        resolved = [
+            pool_module.ResolvedArtist(opener, pool_module.PoolProvenance.EVENT)
+        ]
+        assert pool_module.build_pool(resolved, {opener}) == []
+
+    def test_order_preserved(self) -> None:
+        ids = [uuid.uuid4() for _ in range(4)]
+        resolved = [
+            pool_module.ResolvedArtist(i, pool_module.PoolProvenance.ARTIST)
+            for i in ids
+        ]
+        pool = pool_module.build_pool(resolved, set())
+        assert [r.artist_id for r in pool] == ids
+
+    def test_provenance_precedence_event_over_related(self) -> None:
+        # An artist resolved both as an event act and as a related expansion keeps
+        # the event provenance (first-seen), since event sources resolve first.
+        aid = uuid.uuid4()
+        resolved = [
+            pool_module.ResolvedArtist(aid, pool_module.PoolProvenance.EVENT),
+            pool_module.ResolvedArtist(aid, pool_module.PoolProvenance.RELATED),
+        ]
+        pool = pool_module.build_pool(resolved, set())
+        assert pool[0].via is pool_module.PoolProvenance.EVENT
+
+
+class TestSerialize:
+    def test_round_trip_all_kinds(self) -> None:
+        eid = uuid.uuid4()
+        aid = uuid.uuid4()
+        sources: list[pool_module.PoolSource] = [
+            pool_module.EventSource(event_id=eid, enabled=False),
+            pool_module.ArtistSource(artist_id=aid),
+            pool_module.RelatedSource(amount=7, seed="target", enabled=True),
+        ]
+        excl = uuid.uuid4()
+        stored = pool_module.serialize_input_references(sources, [excl])
+        assert pool_module.normalize_sources(stored) == sources
+        assert pool_module.extract_excludes(stored) == {excl}
+
+    def test_serialize_input_references_empty(self) -> None:
+        stored = pool_module.serialize_input_references([])
+        assert stored == {"sources": [], "exclude_artist_ids": []}

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4121,3 +4121,137 @@ class TestImportAdjacentCandidates:
 
         assert result == [a2.id]  # one failure does not abort the rest
         log.warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# resolve_pool: shared target-resolution path (#128 T6/T14)
+# ---------------------------------------------------------------------------
+
+
+def _scalars_result(rows: list[Any]) -> MagicMock:
+    """Build a mock execute() result whose .scalars().all() returns rows."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    return result
+
+
+class TestResolvePool:
+    """resolve_pool turns input_references into a deduped, exclude-filtered pool."""
+
+    async def test_legacy_event_id_shape(self) -> None:
+        import resonance.generators.pool as pool_module
+
+        a1, a2 = uuid.uuid4(), uuid.uuid4()
+        eid = uuid.uuid4()
+        ea = MagicMock()
+        ea.artist_id = a1
+        cand = MagicMock()
+        cand.matched_artist_id = a2
+
+        session = AsyncMock()
+        session.execute.side_effect = [_scalars_result([ea]), _scalars_result([cand])]
+
+        pool = await worker_module.resolve_pool(session, {"event_id": str(eid)})
+
+        assert [r.artist_id for r in pool] == [a1, a2]
+        assert all(r.via is pool_module.PoolProvenance.EVENT for r in pool)
+
+    async def test_sources_event_shape(self) -> None:
+        a1 = uuid.uuid4()
+        eid = uuid.uuid4()
+        ea = MagicMock()
+        ea.artist_id = a1
+
+        session = AsyncMock()
+        session.execute.side_effect = [_scalars_result([ea]), _scalars_result([])]
+
+        refs = {"sources": [{"kind": "event", "event_id": str(eid), "enabled": True}]}
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert [r.artist_id for r in pool] == [a1]
+
+    async def test_artist_source_needs_no_query(self) -> None:
+        import resonance.generators.pool as pool_module
+
+        a3 = uuid.uuid4()
+        session = AsyncMock()
+
+        refs = {"sources": [{"kind": "artist", "artist_id": str(a3), "enabled": True}]}
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert [r.artist_id for r in pool] == [a3]
+        assert pool[0].via is pool_module.PoolProvenance.ARTIST
+        session.execute.assert_not_called()  # no event sources -> no DB hit
+
+    async def test_exclude_applied_last(self) -> None:
+        a1, a2 = uuid.uuid4(), uuid.uuid4()
+        eid = uuid.uuid4()
+        ea1, ea2 = MagicMock(), MagicMock()
+        ea1.artist_id, ea2.artist_id = a1, a2
+
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _scalars_result([ea1, ea2]),
+            _scalars_result([]),
+        ]
+
+        refs = {
+            "sources": [{"kind": "event", "event_id": str(eid), "enabled": True}],
+            "exclude_artist_ids": [str(a2)],
+        }
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert [r.artist_id for r in pool] == [a1]  # a2 excluded
+
+    async def test_disabled_source_skipped(self) -> None:
+        eid = uuid.uuid4()
+        session = AsyncMock()
+
+        refs = {"sources": [{"kind": "event", "event_id": str(eid), "enabled": False}]}
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert pool == []
+        session.execute.assert_not_called()  # disabled event -> no query
+
+    async def test_multiple_events_batched(self) -> None:
+        """Two event sources resolve in one query per table, not per event (T14)."""
+        a1, a2 = uuid.uuid4(), uuid.uuid4()
+        e1, e2 = uuid.uuid4(), uuid.uuid4()
+        ea1, ea2 = MagicMock(), MagicMock()
+        ea1.artist_id, ea2.artist_id = a1, a2
+
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _scalars_result([ea1, ea2]),  # both events' EventArtist rows, one query
+            _scalars_result([]),  # both events' candidates, one query
+        ]
+
+        refs = {
+            "sources": [
+                {"kind": "event", "event_id": str(e1), "enabled": True},
+                {"kind": "event", "event_id": str(e2), "enabled": True},
+            ]
+        }
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert {r.artist_id for r in pool} == {a1, a2}
+        assert session.execute.call_count == 2  # batched: not 4
+
+    async def test_dedup_across_event_and_artist(self) -> None:
+        a1 = uuid.uuid4()
+        eid = uuid.uuid4()
+        ea = MagicMock()
+        ea.artist_id = a1
+
+        session = AsyncMock()
+        session.execute.side_effect = [_scalars_result([ea]), _scalars_result([])]
+
+        refs = {
+            "sources": [
+                {"kind": "event", "event_id": str(eid), "enabled": True},
+                {"kind": "artist", "artist_id": str(a1), "enabled": True},
+            ]
+        }
+        pool = await worker_module.resolve_pool(session, refs)
+
+        assert [r.artist_id for r in pool] == [a1]  # event wins, artist dup dropped


### PR DESCRIPTION
## Summary

Generalizes a generator profile's pool from a single event to a layered list of **sources** (event / artist / related) plus a global exclude set, resolved live at generation time. Generator types become **presets** over the one generation engine, not distinct engines. Builds on PR1 (one-pool selection, already on `main`).

This is the #128 seeding work (T5–T14). The `related` source *kind* is intentionally not resolved yet — related/adjacent expansion still runs off the `similar_artist_ratio` param, pending the param-vs-count reconciliation the plan defers to the #128 UI work.

<details>
<summary>How to Review</summary>

Six commits, reviewable in order:

1. **Pure pool spec** (`9f762de`) — `generators/pool.py`: `normalize_sources` (tolerates legacy `{event_id}` and layered `{sources}`), `build_pool` (dedup + exclude-last), serializers. No DB.
2. **Shared resolver** (`24ffd93`) — `worker.resolve_pool`: single target-resolution path for event+artist sources used by both `generate_playlist` and `score_and_build_playlist`, killing the duplicated event-resolution blocks. Event lookups batched into one `IN (...)` per table (T14).
3. **API + presets** (`b9ffce5`) — `input_references` widens to `dict[str,Any]`; `validate_profile_inputs` parses via pool.py with a clear empty-pool error (no 500); `update` now validates too; `GeneratorTypeConfig` gains `default_param_values` + `default_pool_seed`.
4. **CLI grammar** (`6e75868`) — `--source event:/artist:/related:` + `--exclude`, at API parity; `--input` legacy fallback retained.
5. **Migration + back-compat** (`48bf124`) — data migration `{event_id}`→`{sources}` (portable PG+SQLite, idempotent, reversible) + regression proving legacy and migrated shapes resolve identically.
6. **Pool snapshot** (`23b5a5a`) — `GenerationRecord.pool_snapshot` records the resolved artists + provenance per run (sources re-resolve live), surfaced in the profile API.

Both the legacy `{event_id}` shape (still written by the events UI and CLI) and the new `{sources}` shape are accepted everywhere, so the migration and worker cutover need not be atomic.
</details>

<details>
<summary>Test Plan</summary>

- [x] `ruff check .` clean, `ruff format --check .` clean
- [x] `mypy src/` clean
- [x] Full suite: 1452 passing (incl. new resolve_pool, pool, CLI grammar, migration back-compat tests)
- [x] Single alembic head
- [ ] Migration applied against live Postgres (in progress)
</details>

<details>
<summary>Impact</summary>

- No breaking changes: legacy `{event_id}` profiles keep resolving and validating.
- New capability: profiles can layer multiple event/artist sources and exclude artists.
- New nullable `generation_records.pool_snapshot` column (audit/reproducibility).
- Two new migrations; run as the deploy init container.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
