### PR TITLE
Lineup builder: web UI for layered playlist sources (#128)

### DIFF
--- a/src/resonance/api/v1/artists.py
+++ b/src/resonance/api/v1/artists.py
@@ -30,6 +30,27 @@ def _escape_ilike(q: str) -> str:
     return q.replace("%", r"\%").replace("_", r"\_")
 
 
+async def artists_in_library(
+    db: sa_async.AsyncSession, artist_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """Return the subset of ``artist_ids`` we have catalog tracks for.
+
+    Used as a lightweight "in library" signal in pickers: an artist we have
+    tracks for is far more likely to be the one the user means than a cold
+    external match of the same name. This is the disambiguation aid behind the
+    lineup builder's artist picker (#136 — ambiguous short names like "nite"
+    resolving to the wrong artist).
+    """
+    if not artist_ids:
+        return set()
+    result = await db.execute(
+        sa.select(music_models.Track.artist_id)
+        .where(music_models.Track.artist_id.in_(artist_ids))
+        .distinct()
+    )
+    return set(result.scalars().all())
+
+
 def _format_artist_summary(artist: music_models.Artist | Any) -> dict[str, Any]:
     return {
         "id": str(artist.id),
@@ -97,7 +118,13 @@ async def search_artists(
     )
     result = await db.execute(stmt)
     artists = list(result.scalars().all())
-    return {"items": [_format_artist_summary(a) for a in artists]}
+    in_library = await artists_in_library(db, [a.id for a in artists])
+    items = []
+    for a in artists:
+        summary = _format_artist_summary(a)
+        summary["in_library"] = a.id in in_library
+        items.append(summary)
+    return {"items": items}
 
 
 @router.get(

--- a/src/resonance/api/v1/events.py
+++ b/src/resonance/api/v1/events.py
@@ -12,6 +12,7 @@ import sqlalchemy.ext.asyncio as sa_async
 import sqlalchemy.orm as sa_orm
 import structlog
 
+import resonance.api.v1.artists as artists_api
 import resonance.dependencies as deps_module
 import resonance.models.concert as concert_models
 import resonance.models.music as music_models
@@ -92,6 +93,92 @@ async def list_events(
         "page_size": _PAGE_SIZE,
         "has_next": has_next,
     }
+
+
+@router.get(
+    "/{event_id}/lineup",
+    summary="Resolve an event's lineup to artists",
+    description=(
+        "Return the artists an event resolves to (confirmed lineup plus accepted"
+        " candidate matches), with disambiguation metadata and an in-library flag."
+        " Powers the playlist lineup builder's 'Add event' action so each artist"
+        " can be individually included or excluded."
+    ),
+)
+async def event_lineup(
+    event_id: uuid.UUID,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(deps_module.get_current_user_id)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, Any]:
+    """Resolve an event's lineup to displayable artists for the lineup builder.
+
+    Mirrors the event-resolution that ``worker.resolve_pool`` performs (confirmed
+    ``EventArtist`` rows plus accepted ``EventArtistCandidate`` matches), but
+    returns full artist summaries so the builder can list each artist with an
+    include/exclude toggle.
+
+    Args:
+        event_id: The event to resolve.
+        user_id: The authenticated user's ID.
+        db: The async database session.
+
+    Returns:
+        A dict with the event id and an ordered, deduplicated ``artists`` list.
+
+    Raises:
+        HTTPException: 404 if the event does not exist.
+    """
+    event = await db.get(concert_models.Event, event_id)
+    if event is None:
+        raise fastapi.HTTPException(status_code=404, detail="Event not found")
+
+    # Confirmed lineup first, then accepted candidate matches (mirrors resolve_pool).
+    ea_result = await db.execute(
+        sa.select(concert_models.EventArtist.artist_id).where(
+            concert_models.EventArtist.event_id == event_id
+        )
+    )
+    ordered_ids: list[uuid.UUID] = list(ea_result.scalars().all())
+
+    cand_result = await db.execute(
+        sa.select(concert_models.EventArtistCandidate.matched_artist_id).where(
+            concert_models.EventArtistCandidate.event_id == event_id,
+            concert_models.EventArtistCandidate.status
+            == types_module.CandidateStatus.ACCEPTED,
+            concert_models.EventArtistCandidate.matched_artist_id.isnot(None),
+        )
+    )
+    for cand_id in cand_result.scalars().all():
+        if cand_id is not None:
+            ordered_ids.append(cand_id)
+
+    # Dedup preserving first-seen order.
+    seen: set[uuid.UUID] = set()
+    unique_ids: list[uuid.UUID] = []
+    for aid in ordered_ids:
+        if aid not in seen:
+            seen.add(aid)
+            unique_ids.append(aid)
+
+    if not unique_ids:
+        return {"event_id": str(event_id), "artists": []}
+
+    artist_result = await db.execute(
+        sa.select(music_models.Artist).where(music_models.Artist.id.in_(unique_ids))
+    )
+    artist_map = {a.id: a for a in artist_result.scalars().all()}
+    in_library = await artists_api.artists_in_library(db, unique_ids)
+
+    artists: list[dict[str, Any]] = []
+    for aid in unique_ids:
+        artist = artist_map.get(aid)
+        if artist is None:
+            continue
+        summary = artists_api._format_artist_summary(artist)
+        summary["in_library"] = aid in in_library
+        artists.append(summary)
+
+    return {"event_id": str(event_id), "artists": artists}
 
 
 @router.get(

--- a/src/resonance/static/lineup.css
+++ b/src/resonance/static/lineup.css
@@ -1,0 +1,127 @@
+/* Lineup builder (New Playlist) — see DESIGN.md. Tokens from theme.css. */
+
+.lineup-hint { color: var(--text-muted); }
+
+/* Add controls row: event dropdown + artist search */
+.lineup-add {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  align-items: flex-start;
+  margin-bottom: var(--space-md);
+}
+.lineup-add > * { margin-bottom: 0; }
+.lineup-add .add-event { flex: 1 1 16rem; min-width: 12rem; }
+.lineup-add .picker { flex: 1 1 16rem; min-width: 12rem; }
+
+/* Empty state */
+.lineup-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: var(--space-md);
+  text-align: center;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+}
+
+/* Lineup groups */
+.lineup-group {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-sm);
+  overflow: hidden;
+}
+.lineup-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  background: var(--surface-alt);
+  padding: var(--space-xs) var(--space-md);
+}
+.lineup-group-head .gtitle { font-weight: 700; font-size: 0.9rem; }
+.lineup-group-head .gsub { color: var(--text-muted); font-size: 0.78rem; font-weight: 400; }
+.lineup-group-head .gremove {
+  border: none; background: none; color: var(--text-muted);
+  cursor: pointer; font-size: 1.05rem; line-height: 1; padding: 2px 6px;
+}
+.lineup-group-head .gremove:hover { color: var(--error); }
+
+/* Artist rows */
+.artist-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-md);
+  border-top: 1px solid var(--border);
+}
+.artist-row:first-of-type { border-top: none; }
+.artist-row input[type="checkbox"] {
+  width: 18px; height: 18px; flex: none; margin: 0; accent-color: var(--primary);
+}
+.artist-row .aname { flex: 1; min-width: 0; }
+.artist-row .aname .n { font-weight: 500; }
+.artist-row .aname .m { color: var(--text-muted); font-size: 0.78rem; margin-left: 6px; }
+.artist-row.excluded .aname .n { text-decoration: line-through; color: var(--text-muted); }
+.artist-row .extag {
+  font-size: 0.66rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--error); border: 1px solid var(--error); border-radius: var(--radius-full);
+  padding: 1px 8px; white-space: nowrap;
+}
+.artist-row .aremove {
+  border: none; background: none; color: var(--text-muted);
+  cursor: pointer; font-size: 1.05rem; line-height: 1; padding: 2px 6px;
+}
+.artist-row .aremove:hover { color: var(--error); }
+
+/* Artist search picker */
+.picker { position: relative; }
+.picker-dropdown {
+  position: absolute;
+  z-index: 20;
+  left: 0; right: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.10);
+  margin-top: 4px;
+  overflow: hidden;
+}
+.picker-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+}
+.picker-item:last-child { border-bottom: none; }
+.picker-item:hover, .picker-item.active { background: var(--primary-subtle); }
+.picker-item .pname { font-weight: 500; }
+.picker-item .pmeta { font-size: 0.78rem; color: var(--text-muted); }
+.picker-item .ptag {
+  font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-muted); border: 1px solid var(--border);
+  border-radius: var(--radius-full); padding: 2px 8px; white-space: nowrap;
+}
+.picker-item .ptag.lib { color: var(--success); border-color: var(--success); }
+.picker-empty { padding: var(--space-sm) var(--space-md); color: var(--text-muted); font-size: 0.85rem; }
+
+/* Parameter sliders */
+.param { margin-bottom: var(--space-lg); }
+.param .prow {
+  display: grid;
+  grid-template-columns: 8rem 1fr 2.5rem 8rem;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+.param .prow small { white-space: nowrap; }
+.param .prow .val { text-align: center; font-weight: 700; }
+
+@media (max-width: 600px) {
+  .param .prow { grid-template-columns: 1fr 2.5rem; }
+  .param .prow .lbl-lo { grid-row: 2; }
+  .param .prow .lbl-hi { grid-row: 2; text-align: right; }
+}

--- a/src/resonance/static/lineup.js
+++ b/src/resonance/static/lineup.js
@@ -1,0 +1,364 @@
+/* Lineup builder controller (New Playlist).
+ *
+ * Manages an in-memory lineup of event sources (expanded to their individual
+ * artists) and manually-added artists, each with an include/exclude checkbox.
+ * On submit it serializes the lineup into the layered input_references shape
+ * the server validates (#128):
+ *
+ *   { "sources": [ {kind:"event",event_id}, {kind:"artist",artist_id} ],
+ *     "exclude_artist_ids": [ <unchecked artist ids> ] }
+ *
+ * Reads come from the session-authenticated JSON API (/api/v1/...); the create
+ * itself is a normal form POST so the proven redirect-to-generating flow is kept.
+ */
+(function () {
+  "use strict";
+
+  var state = { events: [], manual: [] };
+
+  var groupsEl = document.getElementById("lineup-groups");
+  var emptyEl = document.getElementById("lineup-empty");
+  var eventSelect = document.getElementById("add-event-select");
+  var searchInput = document.getElementById("artist-search");
+  var resultsEl = document.getElementById("artist-results");
+  var form = document.getElementById("lineup-form");
+  var hiddenField = document.getElementById("input-references-json");
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function artistMeta(a) {
+    var bits = [];
+    if (a.disambiguation) bits.push(a.disambiguation);
+    if (a.area) bits.push(a.area);
+    if (a.begin_year) bits.push(String(a.begin_year));
+    return bits.join(" · ");
+  }
+
+  function hasArtist(id) {
+    var i, j;
+    for (i = 0; i < state.manual.length; i++) {
+      if (state.manual[i].id === id) return true;
+    }
+    for (i = 0; i < state.events.length; i++) {
+      for (j = 0; j < state.events[i].artists.length; j++) {
+        if (state.events[i].artists[j].id === id) return true;
+      }
+    }
+    return false;
+  }
+
+  function normArtist(a) {
+    return { id: a.id, name: a.name, meta: artistMeta(a), included: true };
+  }
+
+  function rowHtml(artist, scope, removable) {
+    var excluded = artist.included ? "" : " excluded";
+    var checked = artist.included ? " checked" : "";
+    var meta = artist.meta ? '<span class="m">' + esc(artist.meta) + "</span>" : "";
+    var tag = artist.included ? "" : '<span class="extag">excluded</span>';
+    var remove = removable
+      ? '<button type="button" class="aremove" data-remove-manual="' +
+        esc(artist.id) +
+        '" title="Remove" aria-label="Remove ' +
+        esc(artist.name) +
+        '">&times;</button>'
+      : "";
+    return (
+      '<div class="artist-row' +
+      excluded +
+      '">' +
+      '<input type="checkbox" data-artist-toggle data-scope="' +
+      esc(scope) +
+      '" data-artist-id="' +
+      esc(artist.id) +
+      '"' +
+      checked +
+      ' aria-label="Include ' +
+      esc(artist.name) +
+      '">' +
+      '<span class="aname"><span class="n">' +
+      esc(artist.name) +
+      "</span>" +
+      meta +
+      "</span>" +
+      tag +
+      remove +
+      "</div>"
+    );
+  }
+
+  function render() {
+    var html = "";
+    var i;
+
+    for (i = 0; i < state.events.length; i++) {
+      var ev = state.events[i];
+      var rows = "";
+      if (ev.artists.length === 0) {
+        rows =
+          '<div class="artist-row"><span class="aname"><span class="m">No artists found for this event.</span></span></div>';
+      } else {
+        for (var j = 0; j < ev.artists.length; j++) {
+          rows += rowHtml(ev.artists[j], "event:" + ev.id, false);
+        }
+      }
+      html +=
+        '<div class="lineup-group" data-event-id="' +
+        esc(ev.id) +
+        '">' +
+        '<div class="lineup-group-head">' +
+        "<span><span class=\"gtitle\">" +
+        esc(ev.title) +
+        "</span> <span class=\"gsub\">" +
+        esc(ev.sub) +
+        "</span></span>" +
+        '<button type="button" class="gremove" data-remove-event="' +
+        esc(ev.id) +
+        '" title="Remove event" aria-label="Remove event ' +
+        esc(ev.title) +
+        '">&times;</button>' +
+        "</div>" +
+        rows +
+        "</div>";
+    }
+
+    if (state.manual.length > 0) {
+      var mrows = "";
+      for (i = 0; i < state.manual.length; i++) {
+        mrows += rowHtml(state.manual[i], "manual", true);
+      }
+      html +=
+        '<div class="lineup-group">' +
+        '<div class="lineup-group-head"><span class="gtitle">Added artists</span></div>' +
+        mrows +
+        "</div>";
+    }
+
+    groupsEl.innerHTML = html;
+    var isEmpty = state.events.length === 0 && state.manual.length === 0;
+    emptyEl.hidden = !isEmpty;
+  }
+
+  function findArtist(scope, id) {
+    if (scope === "manual") {
+      return state.manual.find(function (a) {
+        return a.id === id;
+      });
+    }
+    var eid = scope.slice("event:".length);
+    var ev = state.events.find(function (e) {
+      return e.id === eid;
+    });
+    if (!ev) return undefined;
+    return ev.artists.find(function (a) {
+      return a.id === id;
+    });
+  }
+
+  function addEvent(id, title, sub) {
+    var exists = state.events.some(function (e) {
+      return e.id === id;
+    });
+    if (exists) return;
+    var ev = { id: id, title: title, sub: sub, artists: [] };
+    state.events.push(ev);
+    render();
+    fetch("/api/v1/events/" + encodeURIComponent(id) + "/lineup", {
+      credentials: "same-origin",
+    })
+      .then(function (r) {
+        return r.ok ? r.json() : { artists: [] };
+      })
+      .then(function (data) {
+        ev.artists = (data.artists || []).map(normArtist);
+        render();
+      })
+      .catch(function () {
+        render();
+      });
+  }
+
+  function renderResults(items) {
+    if (!items.length) {
+      resultsEl.innerHTML = '<div class="picker-empty">No matching artists in your library.</div>';
+      resultsEl.hidden = false;
+      return;
+    }
+    var html = "";
+    for (var i = 0; i < items.length; i++) {
+      var a = items[i];
+      var meta = artistMeta(a);
+      var disabled = hasArtist(a.id);
+      var tag = a.in_library
+        ? '<span class="ptag lib">in library</span>'
+        : '<span class="ptag">no tracks yet</span>';
+      html +=
+        '<div class="picker-item" data-add-artist="' +
+        esc(a.id) +
+        '" data-name="' +
+        esc(a.name) +
+        '" data-meta="' +
+        esc(meta) +
+        '"' +
+        (disabled ? ' style="opacity:.45;pointer-events:none;"' : "") +
+        ">" +
+        '<span><span class="pname">' +
+        esc(a.name) +
+        "</span>" +
+        (meta ? ' <span class="pmeta">— ' + esc(meta) + "</span>" : "") +
+        "</span>" +
+        (disabled ? '<span class="ptag">added</span>' : tag) +
+        "</div>";
+    }
+    resultsEl.innerHTML = html;
+    resultsEl.hidden = false;
+  }
+
+  var searchTimer = null;
+  function onSearch() {
+    var q = searchInput.value.trim();
+    if (searchTimer) clearTimeout(searchTimer);
+    if (q.length < 2) {
+      resultsEl.hidden = true;
+      resultsEl.innerHTML = "";
+      return;
+    }
+    searchTimer = setTimeout(function () {
+      fetch("/api/v1/artists/search?q=" + encodeURIComponent(q) + "&limit=8", {
+        credentials: "same-origin",
+      })
+        .then(function (r) {
+          return r.ok ? r.json() : { items: [] };
+        })
+        .then(function (data) {
+          renderResults(data.items || []);
+        })
+        .catch(function () {
+          resultsEl.hidden = true;
+        });
+    }, 250);
+  }
+
+  function serialize() {
+    var sources = [];
+    var excludes = {};
+    var i, j;
+    for (i = 0; i < state.events.length; i++) {
+      var ev = state.events[i];
+      sources.push({ kind: "event", event_id: ev.id, enabled: true });
+      for (j = 0; j < ev.artists.length; j++) {
+        if (!ev.artists[j].included) excludes[ev.artists[j].id] = true;
+      }
+    }
+    for (i = 0; i < state.manual.length; i++) {
+      var a = state.manual[i];
+      sources.push({ kind: "artist", artist_id: a.id, enabled: true });
+      if (!a.included) excludes[a.id] = true;
+    }
+    return { sources: sources, exclude_artist_ids: Object.keys(excludes) };
+  }
+
+  /* ---- wiring ---- */
+
+  eventSelect.addEventListener("change", function () {
+    var opt = eventSelect.options[eventSelect.selectedIndex];
+    var id = eventSelect.value;
+    if (!id) return;
+    var title = opt.getAttribute("data-title") || "Event";
+    var date = opt.getAttribute("data-date") || "";
+    var venue = opt.getAttribute("data-venue") || "";
+    var sub = "· " + date + (venue ? " · " + venue : "") + " · live lineup";
+    addEvent(id, title, sub);
+    eventSelect.selectedIndex = 0;
+  });
+
+  searchInput.addEventListener("input", onSearch);
+  searchInput.addEventListener("focus", onSearch);
+
+  resultsEl.addEventListener("click", function (e) {
+    var item = e.target.closest("[data-add-artist]");
+    if (!item) return;
+    var id = item.getAttribute("data-add-artist");
+    if (hasArtist(id)) return;
+    state.manual.push({
+      id: id,
+      name: item.getAttribute("data-name") || "",
+      meta: item.getAttribute("data-meta") || "",
+      included: true,
+    });
+    searchInput.value = "";
+    resultsEl.hidden = true;
+    resultsEl.innerHTML = "";
+    render();
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.closest(".picker")) {
+      resultsEl.hidden = true;
+    }
+  });
+
+  groupsEl.addEventListener("change", function (e) {
+    var cb = e.target.closest("[data-artist-toggle]");
+    if (!cb) return;
+    var artist = findArtist(cb.getAttribute("data-scope"), cb.getAttribute("data-artist-id"));
+    if (artist) {
+      artist.included = cb.checked;
+      render();
+    }
+  });
+
+  groupsEl.addEventListener("click", function (e) {
+    var rmEvent = e.target.closest("[data-remove-event]");
+    if (rmEvent) {
+      var eid = rmEvent.getAttribute("data-remove-event");
+      state.events = state.events.filter(function (ev) {
+        return ev.id !== eid;
+      });
+      render();
+      return;
+    }
+    var rmManual = e.target.closest("[data-remove-manual]");
+    if (rmManual) {
+      var aid = rmManual.getAttribute("data-remove-manual");
+      state.manual = state.manual.filter(function (a) {
+        return a.id !== aid;
+      });
+      render();
+    }
+  });
+
+  form.addEventListener("submit", function (e) {
+    var payload = serialize();
+    if (payload.sources.length === 0) {
+      e.preventDefault();
+      emptyEl.textContent = "Add at least one event or artist before generating.";
+      emptyEl.style.color = "var(--error)";
+      emptyEl.style.borderColor = "var(--error)";
+      emptyEl.hidden = false;
+      return;
+    }
+    hiddenField.value = JSON.stringify(payload);
+  });
+
+  /* Pre-seed from ?event_id= */
+  if (window.LINEUP_PRESEED_EVENT) {
+    var presEl = eventSelect.querySelector(
+      'option[value="' + window.LINEUP_PRESEED_EVENT + '"]'
+    );
+    if (presEl) {
+      var t = presEl.getAttribute("data-title") || "Event";
+      var d = presEl.getAttribute("data-date") || "";
+      var v = presEl.getAttribute("data-venue") || "";
+      addEvent(window.LINEUP_PRESEED_EVENT, t, "· " + d + (v ? " · " + v : "") + " · live lineup");
+    }
+  }
+
+  render();
+})();

--- a/src/resonance/templates/playlists_new.html
+++ b/src/resonance/templates/playlists_new.html
@@ -1,48 +1,64 @@
 {% extends "base.html" %}
 {% block title %}New Playlist — resonance{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="/static/lineup.css">
+{% endblock %}
 {% block content %}
 <p><a href="/playlists">&larr; Back to Playlists</a></p>
 <h2>New Playlist</h2>
 
-<form method="post" action="/playlists/new">
-    <article>
-        <label for="generator_type">
-            Type
-            <select id="generator_type" name="generator_type" required>
-                {% for gt, config in generator_types.items() %}
-                <option value="{{ gt.value }}"{% if selected_type == gt.value %} selected{% endif %}>
-                    {{ gt.value | replace('_', ' ') | title }} — {{ config.description }}
-                </option>
-                {% endfor %}
-            </select>
-        </label>
+{% if error %}
+<div role="alert" style="padding: 0.5em 1em; margin-bottom: 1em; border-left: 3px solid var(--error); background: var(--surface);">
+    <small style="color: var(--error)">{{ error }}</small>
+</div>
+{% endif %}
 
-        <label for="event_id">
-            Event
-            <select id="event_id" name="event_id" required>
-                <option value="">Select an event...</option>
+<form method="post" action="/playlists/new" id="lineup-form">
+    <input type="hidden" name="generator_type" value="{{ selected_type or 'concert_prep' }}">
+    <input type="hidden" name="input_references_json" id="input-references-json" value="">
+
+    <!-- Lineup -->
+    <article>
+        <header>Lineup <small class="lineup-hint">— who's in this playlist. Uncheck an artist to leave them out.</small></header>
+
+        <div class="lineup-add">
+            <select class="add-event" id="add-event-select" aria-label="Add an event">
+                <option value="">+ Add event…</option>
                 {% for event in events %}
-                <option value="{{ event.id }}"{% if selected_event_id == event.id | string %} selected{% endif %}>
+                <option value="{{ event.id }}"
+                        data-title="{{ event.title }}"
+                        data-date="{{ event.event_date }}"
+                        data-venue="{% if event.venue %}{{ event.venue.name }}{% endif %}">
                     {{ event.title }} — {{ event.event_date }}{% if event.venue %} @ {{ event.venue.name }}{% endif %}
                 </option>
                 {% endfor %}
             </select>
-        </label>
+
+            <div class="picker">
+                <input type="search" id="artist-search" autocomplete="off"
+                       placeholder="+ Add artist…" aria-label="Search artists to add">
+                <div class="picker-dropdown" id="artist-results" hidden></div>
+            </div>
+        </div>
+
+        <div class="lineup-empty" id="lineup-empty">No artists yet — add an event or artist above.</div>
+        <div id="lineup-groups"></div>
     </article>
 
+    <!-- Parameters -->
     <article>
         <header>Parameters</header>
         {% for name, param in parameters.items() %}
-        <div style="margin-bottom: 1.5rem;">
+        <div class="param">
             <strong>{{ param.display_name }}</strong>
-            <small style="margin-left: 0.5rem; opacity: 0.7;">{{ param.description }}</small>
-            <div style="display: grid; grid-template-columns: 8rem 1fr 3rem 8rem; align-items: center; gap: 0.5rem; margin-top: 0.25rem;">
-                <small style="text-align: right; white-space: nowrap;">{{ param.labels[0] }}</small>
+            <small class="lineup-hint" style="margin-left: 0.5rem;">{{ param.description }}</small>
+            <div class="prow">
+                <small class="lbl-lo" style="text-align: right;">{{ param.labels[0] }}</small>
                 <input type="range" name="param_{{ name }}" min="0" max="100"
                        value="{{ param.default_value }}" style="margin: 0;"
-                       oninput="this.nextElementSibling.textContent = this.value">
-                <small style="text-align: center; font-weight: bold;">{{ param.default_value }}</small>
-                <small style="white-space: nowrap;">{{ param.labels[1] }}</small>
+                       oninput="this.parentElement.querySelector('.val').textContent = this.value">
+                <small class="val">{{ param.default_value }}</small>
+                <small class="lbl-hi">{{ param.labels[1] }}</small>
             </div>
         </div>
         {% endfor %}
@@ -55,6 +71,7 @@
         </div>
     </article>
 
+    <!-- Name -->
     <article>
         <label for="name">
             Playlist Name
@@ -62,6 +79,11 @@
         </label>
     </article>
 
-    <button type="submit">Generate Playlist</button>
+    <button type="submit" id="lineup-submit">Generate Playlist</button>
 </form>
+
+<script>
+  window.LINEUP_PRESEED_EVENT = "{{ selected_event_id or '' }}";
+</script>
+<script src="/static/lineup.js" defer></script>
 {% endblock %}

--- a/src/resonance/ui/playlists.py
+++ b/src/resonance/ui/playlists.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import uuid
 from typing import Annotated
 
@@ -12,6 +13,7 @@ import sqlalchemy as sa
 import sqlalchemy.ext.asyncio as sa_async
 import sqlalchemy.orm as sa_orm
 
+import resonance.api.v1.generators as generators_api
 import resonance.dependencies as deps_module
 import resonance.models.concert as concert_models
 import resonance.models.generator as generator_models
@@ -141,15 +143,20 @@ async def playlists_page(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/playlists/new", response_model=None)
-async def new_playlist_page(
+async def _new_playlist_context(
     request: fastapi.Request,
-    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
-    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
-    event_id: str = "",
-    type: str = "",
-) -> fastapi.responses.HTMLResponse:
-    """Render the New Playlist form."""
+    db: sa_async.AsyncSession,
+    *,
+    selected_event_id: str = "",
+    selected_type: str = "",
+    error: str | None = None,
+) -> dict[str, object]:
+    """Build the template context for the lineup builder (GET and error re-render).
+
+    The builder fetches an event's artists and searches artists live via the API,
+    so the page only needs the upcoming-events list for the "Add event" dropdown
+    plus the parameter and generator-type registries.
+    """
     import resonance.generators.parameters as params_module
 
     events_result = await db.execute(
@@ -169,10 +176,61 @@ async def new_playlist_page(
         events=events,
         generator_types=params_module.GENERATOR_TYPE_CONFIG,
         parameters=params_module.PARAMETER_REGISTRY,
-        selected_event_id=event_id,
-        selected_type=type or "",
+        selected_event_id=selected_event_id,
+        selected_type=selected_type or "",
+        error=error,
     )
+    return ctx
 
+
+async def _default_playlist_name(
+    db: sa_async.AsyncSession, input_references: dict[str, object]
+) -> str:
+    """Derive a playlist name when the user leaves it blank.
+
+    Names from the first event source's event (the common concert-prep case),
+    otherwise falls back to a timestamped label.
+    """
+    sources = input_references.get("sources")
+    first_event_id: str | None = None
+    if isinstance(sources, list):
+        for source in sources:
+            if isinstance(source, dict) and source.get("kind") == "event":
+                event_id = source.get("event_id")
+                if event_id:
+                    first_event_id = str(event_id)
+                    break
+
+    if first_event_id is not None:
+        try:
+            event = await db.get(concert_models.Event, uuid.UUID(first_event_id))
+        except ValueError:
+            event = None
+        if event is not None:
+            venue = (
+                await db.get(concert_models.Venue, event.venue_id)
+                if (event.venue_id)
+                else None
+            )
+            venue_str = f" @ {venue.name}" if venue else ""
+            return f"Concert Prep: {event.title}{venue_str}"
+
+    now_str = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
+    return f"Playlist {now_str}"
+
+
+@router.get("/playlists/new", response_model=None)
+async def new_playlist_page(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    event_id: str = "",
+    type: str = "",
+) -> fastapi.responses.HTMLResponse:
+    """Render the lineup builder (New Playlist) page."""
+    ctx = await _new_playlist_context(
+        request, db, selected_event_id=event_id, selected_type=type
+    )
     return common.templates.TemplateResponse(request, "playlists_new.html", ctx)
 
 
@@ -181,40 +239,57 @@ async def create_playlist(
     request: fastapi.Request,
     user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
     db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
-) -> fastapi.responses.RedirectResponse:
-    """Handle New Playlist form submission."""
+) -> fastapi.responses.Response:
+    """Handle lineup builder submission.
+
+    The builder serializes the lineup into a single ``input_references_json``
+    hidden field carrying the layered source spec
+    (``{"sources": [...], "exclude_artist_ids": [...]}``). This replaces the old
+    single-event ``{"event_id": ...}`` shape (#128). Validation reuses the same
+    ``validate_profile_inputs`` path as the JSON API so the UI and CLI/API agree
+    on what a valid pool is.
+    """
     form = await request.form()
 
-    gen_type = str(form.get("generator_type", ""))
-    event_id_str = str(form.get("event_id", ""))
-    max_tracks = int(str(form.get("max_tracks", "30")))
+    gen_type = str(form.get("generator_type", "") or "concert_prep")
+    max_tracks = int(str(form.get("max_tracks", "30")) or "30")
     name = str(form.get("name", "")).strip()
+    raw_json = str(form.get("input_references_json", "")).strip()
 
     param_values: dict[str, int] = {}
     for key, val in form.items():
         if key.startswith("param_"):
-            param_name = key[6:]
-            param_values[param_name] = int(str(val))
+            param_values[key[6:]] = int(str(val))
+
+    try:
+        gen_type_enum = types_module.GeneratorType(gen_type)
+    except ValueError:
+        gen_type_enum = types_module.GeneratorType.CONCERT_PREP
+
+    try:
+        parsed = json.loads(raw_json) if raw_json else {}
+    except json.JSONDecodeError:
+        parsed = None
+    input_references: dict[str, object] = parsed if isinstance(parsed, dict) else {}
+
+    try:
+        generators_api.validate_profile_inputs(input_references, gen_type_enum)
+    except ValueError as exc:
+        ctx = await _new_playlist_context(
+            request, db, selected_type=gen_type, error=str(exc)
+        )
+        return common.templates.TemplateResponse(
+            request, "playlists_new.html", ctx, status_code=400
+        )
 
     if not name:
-        event_result = await db.execute(
-            sa.select(concert_models.Event)
-            .where(concert_models.Event.id == uuid.UUID(event_id_str))
-            .options(sa_orm.joinedload(concert_models.Event.venue))
-        )
-        event = event_result.unique().scalar_one_or_none()
-        if event:
-            venue_str = f" @ {event.venue.name}" if event.venue else ""
-            name = f"Concert Prep: {event.title}{venue_str}"
-        else:
-            now_str = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
-            name = f"Playlist {now_str}"
+        name = await _default_playlist_name(db, input_references)
 
     profile = generator_models.GeneratorProfile(
         user_id=user_id,
         name=name,
-        generator_type=types_module.GeneratorType(gen_type),
-        input_references={"event_id": event_id_str},
+        generator_type=gen_type_enum,
+        input_references=input_references,
         parameter_values=param_values,
     )
     db.add(profile)

--- a/tests/test_lineup_builder.py
+++ b/tests/test_lineup_builder.py
@@ -1,0 +1,338 @@
+"""Tests for the lineup builder: create_playlist POST, event lineup + search.
+
+Covers the #128 UI cutover from the legacy single-event ``{"event_id": ...}``
+shape to the layered ``{"sources": [...], "exclude_artist_ids": [...]}`` spec.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fastapi
+import httpx
+import pytest
+
+import resonance.config as config_module
+import resonance.middleware.session as session_middleware
+import resonance.types as types_module
+import resonance.ui.playlists as playlists_ui
+
+# --- shared fakes (self-contained, mirrors test_api_artist_search) ---
+
+
+def _make_settings() -> config_module.Settings:
+    return config_module.Settings(
+        spotify_client_id="test-id",
+        spotify_client_secret="test-secret",
+        token_encryption_key="y4s2fMagCz79NWhqQfaAPbTBl9vnamqcvlGM6GRH2cQ=",
+    )
+
+
+class FakeResult:
+    def __init__(self, items: list[Any] | None = None) -> None:
+        self._items = items or []
+
+    def unique(self) -> FakeResult:
+        return self
+
+    def scalars(self) -> FakeResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return self._items
+
+    def scalar_one_or_none(self) -> Any:
+        return self._items[0] if self._items else None
+
+
+class FakeAsyncSession:
+    def __init__(self) -> None:
+        self._results: list[Any] = []
+        self._call_count = 0
+        self.added: list[Any] = []
+        self._committed = False
+        self._get_returns: list[Any] = []
+        self._get_count = 0
+
+    def set_results(self, results: list[Any]) -> None:
+        self._results = results
+
+    def set_get_returns(self, values: list[Any]) -> None:
+        self._get_returns = values
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        if self._call_count < len(self._results):
+            result = self._results[self._call_count]
+            self._call_count += 1
+            return result
+        return FakeResult()
+
+    async def get(self, *args: Any, **kwargs: Any) -> Any:
+        if self._get_count < len(self._get_returns):
+            value = self._get_returns[self._get_count]
+            self._get_count += 1
+            return value
+        return None
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def flush(self) -> None:
+        pass
+
+    async def commit(self) -> None:
+        self._committed = True
+
+    async def __aenter__(self) -> FakeAsyncSession:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+class FakeSessionFactory:
+    def __init__(self, session: FakeAsyncSession) -> None:
+        self._session = session
+
+    def __call__(self) -> FakeAsyncSession:
+        return self._session
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    async def setex(self, key: str, ttl: int, value: str) -> None:
+        self._store[key] = value
+
+    async def aclose(self) -> None:
+        pass
+
+    def inject_session(self, session_id: str, data: dict[str, Any]) -> None:
+        self._store[f"session:{session_id}"] = json.dumps(data)
+
+
+def _session_cookie(secret_key: str) -> str:
+    import itsdangerous
+
+    return itsdangerous.TimestampSigner(secret_key).sign("test-session-id").decode()
+
+
+def _api_app(user_id: uuid.UUID, db: FakeAsyncSession) -> Any:
+    import resonance.api.v1 as api_v1_module
+
+    settings = _make_settings()
+    fake_redis = FakeRedis()
+    fake_redis.inject_session(
+        "test-session-id", {"user_id": str(user_id), "user_role": "owner"}
+    )
+    app = fastapi.FastAPI(title="test", lifespan=None)
+    app.state.settings = settings
+    app.state.session_factory = FakeSessionFactory(db)
+    app.add_middleware(
+        session_middleware.SessionMiddleware,
+        redis=fake_redis,  # type: ignore[arg-type]
+        secret_key=settings.session_secret_key,
+    )
+    app.include_router(api_v1_module.router)
+    return app
+
+
+def _artist(name: str, **over: Any) -> SimpleNamespace:
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "name": name,
+        "origin": None,
+        "disambiguation": "",
+        "artist_type": "Group",
+        "area": "US",
+        "begin_year": 2010,
+        "end_year": None,
+        "service_links": {},
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+# --- create_playlist POST (direct call) ---
+
+
+class TestCreatePlaylistLayeredReferences:
+    async def test_builds_layered_input_references(self, user_id: uuid.UUID) -> None:
+        event_id = str(uuid.uuid4())
+        artist_a = str(uuid.uuid4())
+        artist_b = str(uuid.uuid4())
+        payload = {
+            "sources": [
+                {"kind": "event", "event_id": event_id, "enabled": True},
+                {"kind": "artist", "artist_id": artist_a, "enabled": True},
+                {"kind": "artist", "artist_id": artist_b, "enabled": True},
+            ],
+            "exclude_artist_ids": [artist_b],
+        }
+        form = {
+            "generator_type": "concert_prep",
+            "max_tracks": "40",
+            "name": "My Mix",
+            "input_references_json": json.dumps(payload),
+            "param_familiarity": "70",
+            "param_hit_depth": "30",
+        }
+        request = MagicMock(spec=fastapi.Request)
+        request.form = AsyncMock(return_value=form)
+        request.app.state.arq_redis.enqueue_job = AsyncMock()
+        db = FakeAsyncSession()
+
+        resp = await playlists_ui.create_playlist(request, user_id, db)
+
+        assert resp.status_code == 303
+        assert "/playlists/generating/" in resp.headers["location"]
+
+        profiles = [a for a in db.added if hasattr(a, "input_references")]
+        assert len(profiles) == 1
+        profile = profiles[0]
+        assert profile.input_references == payload
+        assert profile.parameter_values == {"familiarity": 70, "hit_depth": 30}
+        assert profile.name == "My Mix"
+        assert profile.generator_type == types_module.GeneratorType.CONCERT_PREP
+
+        tasks = [a for a in db.added if hasattr(a, "task_type")]
+        assert len(tasks) == 1
+        assert tasks[0].params["profile_id"] == str(profile.id)
+        assert tasks[0].params["max_tracks"] == 40
+        request.app.state.arq_redis.enqueue_job.assert_awaited_once()
+
+    async def test_excludes_carry_through(self, user_id: uuid.UUID) -> None:
+        """An unchecked event artist is stored in exclude_artist_ids."""
+        event_id = str(uuid.uuid4())
+        opener = str(uuid.uuid4())
+        payload = {
+            "sources": [{"kind": "event", "event_id": event_id, "enabled": True}],
+            "exclude_artist_ids": [opener],
+        }
+        form = {
+            "generator_type": "concert_prep",
+            "max_tracks": "30",
+            "name": "Concert",
+            "input_references_json": json.dumps(payload),
+        }
+        request = MagicMock(spec=fastapi.Request)
+        request.form = AsyncMock(return_value=form)
+        request.app.state.arq_redis.enqueue_job = AsyncMock()
+        db = FakeAsyncSession()
+
+        resp = await playlists_ui.create_playlist(request, user_id, db)
+
+        assert resp.status_code == 303
+        profile = next(a for a in db.added if hasattr(a, "input_references"))
+        assert profile.input_references["exclude_artist_ids"] == [opener]
+
+    async def test_empty_pool_is_rejected(self, user_id: uuid.UUID) -> None:
+        """A lineup with no enabled sources must not create a profile."""
+        form = {
+            "generator_type": "concert_prep",
+            "max_tracks": "30",
+            "name": "Empty",
+            "input_references_json": json.dumps({"sources": []}),
+        }
+        request = MagicMock(spec=fastapi.Request)
+        request.form = AsyncMock(return_value=form)
+        request.app.state.arq_redis.enqueue_job = AsyncMock()
+        # Error path re-renders the form, which queries upcoming events.
+        db = FakeAsyncSession()
+        db.set_results([FakeResult([])])
+
+        resp = await playlists_ui.create_playlist(request, user_id, db)
+
+        assert resp.status_code == 400
+        assert not any(hasattr(a, "input_references") for a in db.added)
+        request.app.state.arq_redis.enqueue_job.assert_not_called()
+
+
+# --- event lineup endpoint ---
+
+
+class TestEventLineup:
+    async def test_resolves_lineup_with_in_library(self, user_id: uuid.UUID) -> None:
+        event_id = uuid.uuid4()
+        headliner = _artist("Wolves in the Throne Room")
+        opener = _artist("Opening DJ")
+        db = FakeAsyncSession()
+        db.set_get_returns([SimpleNamespace(id=event_id, title="WITTR")])
+        db.set_results(
+            [
+                FakeResult([headliner.id, opener.id]),  # EventArtist ids
+                FakeResult([]),  # accepted candidates
+                FakeResult([headliner, opener]),  # Artist objects
+                FakeResult([headliner.id]),  # in-library subset (only headliner)
+            ]
+        )
+
+        app = _api_app(user_id, db)
+        cookie = _session_cookie(_make_settings().session_secret_key)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", cookies={"session_id": cookie}
+        ) as c:
+            resp = await c.get(f"/api/v1/events/{event_id}/lineup")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["artists"]) == 2
+        by_name = {a["name"]: a for a in data["artists"]}
+        assert by_name["Wolves in the Throne Room"]["in_library"] is True
+        assert by_name["Opening DJ"]["in_library"] is False
+
+    async def test_missing_event_returns_404(self, user_id: uuid.UUID) -> None:
+        db = FakeAsyncSession()
+        db.set_get_returns([None])
+        app = _api_app(user_id, db)
+        cookie = _session_cookie(_make_settings().session_secret_key)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", cookies={"session_id": cookie}
+        ) as c:
+            resp = await c.get(f"/api/v1/events/{uuid.uuid4()}/lineup")
+        assert resp.status_code == 404
+
+
+# --- artist search in_library flag ---
+
+
+class TestArtistSearchInLibrary:
+    async def test_search_includes_in_library_flag(self, user_id: uuid.UUID) -> None:
+        nite_metal = _artist("Nite", disambiguation="heavy metal")
+        nite_electronic = _artist("Nite", disambiguation="electronic")
+        db = FakeAsyncSession()
+        db.set_results(
+            [
+                FakeResult([nite_metal, nite_electronic]),  # name search
+                FakeResult([nite_metal.id]),  # in-library subset
+            ]
+        )
+        app = _api_app(user_id, db)
+        cookie = _session_cookie(_make_settings().session_secret_key)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", cookies={"session_id": cookie}
+        ) as c:
+            resp = await c.get("/api/v1/artists/search?q=nite")
+
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 2
+        flags = {(i["disambiguation"], i["in_library"]) for i in items}
+        assert ("heavy metal", True) in flags
+        assert ("electronic", False) in flags


### PR DESCRIPTION
## Summary

Replaces the single-event New Playlist form with a **Lineup builder** that produces the layered `input_references` the worker already understands (`{sources:[...], exclude_artist_ids:[...]}`). PR1/PR2 of #128 shipped the layered pool model on the API/CLI, but the web UI still wrote the legacy `{event_id}` shape, so arbitrary artist seeding and excludes had no UI. This closes that gap.

The lineup lists individual artists grouped by source:
- **Add event** expands the event into per-artist rows. The event stays a live source (re-resolves each generation), and unchecking any artist excludes it (e.g. the opener) via `exclude_artist_ids`.
- **Add artist** searches the local catalog and adds a manual artist row.
- Each artist has an include checkbox; unchecking = excluded. No separate exclude UI.

The picker shows disambiguation metadata + an "in library" flag so ambiguous short names resolve to the intended artist (mitigates the wrong-genre matching in #136).

<details>
<summary>How to Review</summary>

Single feature commit. Suggested reading order:

1. **API** (`api/v1/events.py`, `api/v1/artists.py`) — `GET /events/{id}/lineup` resolves an event to its artists (mirrors `worker.resolve_pool`'s event resolution); artist search gains an `in_library` flag via a shared `artists_in_library` helper.
2. **POST handler** (`ui/playlists.py`) — `create_playlist` parses the hidden `input_references_json`, validates via the same `validate_profile_inputs` path as the JSON API, builds the profile/task. `_default_playlist_name` names from the first event source.
3. **Template + assets** (`templates/playlists_new.html`, `static/lineup.css`, `static/lineup.js`) — the builder shell + client controller that manages lineup state and serializes on submit. Reads use the session-authenticated `/api/v1/` endpoints; the create stays a form POST so the redirect-to-generating flow is unchanged.
4. **Tests** (`tests/test_lineup_builder.py`).
</details>

<details>
<summary>Test Plan</summary>

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean (91 files)
- [x] `pytest` — 1470 passed (+6 new)
- [x] Jinja template compiles
- [x] New tests: layered reference mapping, exclude carry-through, empty-pool rejection (400), event lineup endpoint (resolve + in_library + 404), artist search in_library flag
- [ ] Live dogfood in dev (not yet run — happy to spin up `make dev` or you can test in a deploy)
</details>

<details>
<summary>Impact</summary>

- New Playlist UI now supports multi-event lineups, arbitrary artist seeding, and per-artist excludes — the headline #128 capabilities.
- No data migration: writes the same layered shape PR2 added; legacy profiles still resolve (worker tolerates both).
- Similar Artists slider stays the related-composition control this phase; the related-source-as-count reshape is the fast-follow (#133).
- Follow-ups: #136 (matching disambiguation — picker metadata is a first step), #133 (reshape).
</details>

Relates to #128. Mitigates #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)