### PR TITLE
fix(ui): mobile-safe slider labels in the lineup builder

### DIFF
--- a/src/resonance/static/lineup.css
+++ b/src/resonance/static/lineup.css
@@ -108,20 +108,31 @@
 .picker-item .ptag.lib { color: var(--success); border-color: var(--success); }
 .picker-empty { padding: var(--space-sm) var(--space-md); color: var(--text-muted); font-size: 0.85rem; }
 
-/* Parameter sliders */
+/* Parameter sliders — mobile-first stacked layout that never overflows.
+ * Label row (name + description) → full-width slider → low/value/high scale row. */
 .param { margin-bottom: var(--space-lg); }
-.param .prow {
-  display: grid;
-  grid-template-columns: 8rem 1fr 2.5rem 8rem;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+.param-head { margin-bottom: var(--space-2xs); }
+.param-head strong { font-weight: 700; }
+.param input[type="range"] {
+  display: block;
+  width: 100%;
+  margin: 0;
 }
-.param .prow small { white-space: nowrap; }
-.param .prow .val { text-align: center; font-weight: 700; }
-
-@media (max-width: 600px) {
-  .param .prow { grid-template-columns: 1fr 2.5rem; }
-  .param .prow .lbl-lo { grid-row: 2; }
-  .param .prow .lbl-hi { grid-row: 2; text-align: right; }
+.slider-scale {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2xs) var(--space-sm);
+  margin-top: var(--space-2xs);
+  font-size: 0.78rem;
+}
+.slider-scale small { color: var(--text-muted); }
+.slider-scale .lbl-lo { text-align: left; }
+.slider-scale .lbl-hi { text-align: right; }
+.slider-scale .val {
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  flex: none;
 }

--- a/src/resonance/templates/playlists_new.html
+++ b/src/resonance/templates/playlists_new.html
@@ -50,13 +50,15 @@
         <header>Parameters</header>
         {% for name, param in parameters.items() %}
         <div class="param">
-            <strong>{{ param.display_name }}</strong>
-            <small class="lineup-hint" style="margin-left: 0.5rem;">{{ param.description }}</small>
-            <div class="prow">
-                <small class="lbl-lo" style="text-align: right;">{{ param.labels[0] }}</small>
-                <input type="range" name="param_{{ name }}" min="0" max="100"
-                       value="{{ param.default_value }}" style="margin: 0;"
-                       oninput="this.parentElement.querySelector('.val').textContent = this.value">
+            <div class="param-head">
+                <strong>{{ param.display_name }}</strong>
+                <small class="lineup-hint">{{ param.description }}</small>
+            </div>
+            <input type="range" name="param_{{ name }}" min="0" max="100"
+                   value="{{ param.default_value }}"
+                   oninput="this.parentElement.querySelector('.val').textContent = this.value">
+            <div class="slider-scale">
+                <small class="lbl-lo">{{ param.labels[0] }}</small>
                 <small class="val">{{ param.default_value }}</small>
                 <small class="lbl-hi">{{ param.labels[1] }}</small>
             </div>


### PR DESCRIPTION
## Summary

The parameter sliders in the new lineup builder used a fixed 4-column grid (`8rem 1fr 2.5rem 8rem`) that overflowed narrow viewports — on mobile the high label ran off the right edge (reported from prod testing). Replaces it with a stacked, wrap-safe layout: label row (name + description) → full-width slider → a low/value/high scale row using flex `space-between` with `flex-wrap`.

Touches only `lineup.css` + `playlists_new.html` (no Python). Follow-up to #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)