### PR TITLE
Playlist round-robin selection + recipe-level refine (exclude tracks, regenerate, Spotify sync visibility)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,9 @@ uv run alembic revision --autogenerate -m "description"  # create new
 # Generator profiles and playlists
 uv run resonance-api profile list
 uv run resonance-api profile create --type concert_prep --event <id> --name "name"
-uv run resonance-api generate <profile-id> [--freshness 50]
-uv run resonance-api enrich <profile-id> --lineup [--n 5]          # add related artists
+uv run resonance-api generate <profile-id> [--freshness 50]       # regenerates in place
+uv run resonance-api profile exclude-track <profile-id> <track-id>... [--regenerate]
+uv run resonance-api enrich <profile-id> --lineup [--n 5]          # top up related artists
 uv run resonance-api enrich <profile-id> --seed <artist-id> [--n 5]
 uv run resonance-api playlists
 uv run resonance-api playlist <playlist-id>
@@ -150,7 +151,8 @@ uv run resonance-api task <task_id>             # Check bulk task status
 uv run resonance-api track <query>              # Search tracks by title
 uv run resonance-api profile list               # List generator profiles
 uv run resonance-api profile create ...         # Create a generator profile
-uv run resonance-api generate <profile-id>      # Generate playlist from profile
+uv run resonance-api generate <profile-id>      # Generate (regenerates in place)
+uv run resonance-api profile exclude-track <profile-id> <track-id>... [--regenerate]  # Exclude tracks from the recipe
 uv run resonance-api enrich <profile-id> --lineup | --seed <id>  # Add related artists
 uv run resonance-api playlists                  # List playlists
 uv run resonance-api playlist <playlist-id>     # Show playlist details
@@ -195,9 +197,13 @@ uv run resonance-api --as-user <user_id> api POST /api/v1/generator-profiles/ -d
 - Generator types declared in `generators/parameters.py` via `GENERATOR_TYPE_CONFIG`
 - Scoring logic in `generators/scoring.py`
 - Generator-specific logic in `generators/<type>.py` (e.g., `concert_prep.py`)
+- **Track selection is weighted round-robin (reverses #128)**: `concert_prep._select_one_pool` deals each pool artist's tracks round by round until `max_tracks`, so every artist on the bill gets an even share and a heavy-rotation neighbor can't monopolize the playlist. `composite_score` (familiarity/hit_depth) decides WHICH of an artist's tracks fill its slots, round-robin decides HOW MANY. A short band's slack redistributes to the others; `max_tracks < n_artists` keeps the top by score. `weights` (artist_id → tracks per round, default 1 = even) is a real plumbed seam for future seed/headliner emphasis. This reverses #128's round-0 + pure-score fill, which buried the seed band.
 - **Lineup builder is a server-backed profile editor (#133)**: `/playlists/new` eagerly creates a `draft` `GeneratorProfile` and redirects to `/playlists/{id}/edit`; the same editor edits existing profiles. Every edit PATCHes `input_references` (and parameters/name) via `/api/v1/generator-profiles/{id}`; "Generate" is a separate action that flips a draft `active`. The profile list shows only `active` profiles. Client state logic is the pure ES module `static/lineup.core.js` (unit-tested with **vitest** under `tests/js/`); `static/lineup.js` is the DOM/network controller. `ui/playlists._hydrate_lineup` turns stored `input_references` into named, grouped rows for the editor.
-- **Related-artist enrichment (#133)**: `POST /api/v1/generator-profiles/{id}/enrich {seed_artist_ids: [...] | "lineup", n}` resolves related artists and persists them into the pool as concrete `artist` sources tagged with `via_seed` (`"<seed_id>"` per-seed, `"lineup"` global). It runs as a `RELATED_ARTIST_ENRICHMENT` worker task; re-running a scope replaces only that scope's prior discoveries. There is NO generation-time related expansion anymore (the old `similar_artist_ratio` slider is gone).
+- **Related-artist enrichment (#133)**: `POST /api/v1/generator-profiles/{id}/enrich {seed_artist_ids: [...] | "lineup", n}` resolves related artists and persists them into the pool as concrete `artist` sources tagged with `via_seed` (`"<seed_id>"` per-seed, `"lineup"` global). It runs as a `RELATED_ARTIST_ENRICHMENT` worker task; re-running a scope **tops up to N active** (counts the non-excluded discoveries already in the scope, fetches only the difference, appends rather than replaces, never re-suggests a globally-excluded artist). A scope already at/over N is a no-op (curated discoveries are never trimmed); connectors running dry is a partial success. There is NO generation-time related expansion anymore (the old `similar_artist_ratio` slider is gone).
 - **Profile concurrency (#133)**: `GeneratorProfile.version` is the SQLAlchemy `version_id_col`. The editor sends `expected_version` on PATCH (409 + conflict banner on mismatch); the enrich worker reloads and re-applies on a version conflict so concurrent edits merge instead of clobbering. Generation and enrichment are mutually exclusive per profile (409).
+- **Regenerate is in place on the same Playlist row**: `worker.score_and_build_playlist` reuses the profile's current `Playlist` (via the latest `GenerationRecord`) instead of creating a new one, so the row identity — and the Spotify export anchor in `service_links` — survives. Old `PlaylistTrack` rows are replaced; only the first generation (or a deleted playlist) creates a fresh row. UI: a "Regenerate" button on the playlist detail page; API: re-POST `/{id}/generate`. `max_tracks`/`freshness_target` live on the `PLAYLIST_GENERATION` task, so a regenerate must re-pass them.
+- **Version history is data-only (#versions, D6)**: each generation records its ordered track list on `GenerationRecord.track_snapshot` (`list[str]` of track uuids). This is the durable per-version history AND the freshness baseline for the next regenerate — `score_and_build` reads the **latest snapshot** for `previous_track_ids`, NOT the live `PlaylistTrack` rows (reading the rows it's about to overwrite would self-poison the freshness target). Browse/restore UI is deferred; the data is captured so it's recoverable later.
+- **Track exclusions live on the recipe (#track-exclude)**: `input_references.exclude_track_ids` (parse/serialize via `pool.extract_track_excludes` / `with_track_excludes`; validated on profile PATCH). `pool.py` is artist-only/pre-track, so the exclude is applied as a **candidate filter** in `score_and_build` (an excluded track never becomes a candidate; its band deals its next-best on regenerate). UI: per-row ✕ on the detail page writes it (mark-then-regenerate). CLI: `resonance-api profile exclude-track <id> <track-id>... [--regenerate]`.
 - **Artist similarity is durable data, not a cache**: `models.taste.ArtistSimilarity` stores connector-reported artist→neighbor edges (`source_artist_id`, `connector`, `neighbor_name`/`mbid`, `rank`, `fetched_at`). The enrich worker reads stored edges first and falls back to a live fetch, recording the result; `fetched_at` drives refresh-if-old, never eviction.
 - SQLAlchemy models use UUID primary keys
 - OAuth tokens encrypted at rest via Fernet
@@ -207,6 +213,7 @@ uv run resonance-api --as-user <user_id> api POST /api/v1/generator-profiles/ -d
 - Playlist export uses `PLAYLIST_WRITE` capability — connectors declare it to enable export. Export creates a background `PLAYLIST_EXPORT` task per connection, tracked via `playlist.service_links`
 - Track matching: export uses two-pass resolution. First, tracks with MusicBrainz recording MBIDs are resolved via MB URL relations (authoritative, community-curated). Second, unresolved tracks fall back to Spotify text search. Matches from both passes are persisted in `service_links["spotify"]` for future reuse.
 - Sync staleness: compare `playlist.updated_at` vs `service_links[connection].exported_at` — no external API calls needed
+- **Per-track Spotify sync visibility (#spotify-sync-visibility)**: `export_playlist` stamps `PlaylistTrack.spotify_synced_at` after the push — matched tracks get the timestamp, unmatched are cleared (re-match is not monotone). Drives the per-row SP badge on the detail page and the "N of M synced · Exclude unsynced & regenerate" affordance (excludes every unsynced track, then regenerates). A regenerated track starts unsynced (correct — a new version hasn't been exported).
 - No deployment manifests in this repo — all K8s config lives in `megadoomer-config`
 
 ## Environment Variables

--- a/alembic/versions/q8r9s0t1u2v3_track_snapshot_and_sync_status.py
+++ b/alembic/versions/q8r9s0t1u2v3_track_snapshot_and_sync_status.py
@@ -1,0 +1,46 @@
+"""add generation_records.track_snapshot and playlist_tracks.spotify_synced_at
+
+Two additive, nullable columns for the round-robin + refine cluster:
+
+- ``generation_records.track_snapshot`` (JSON): the ordered track-id list a
+  generation produced. Persists per-version track history (the live PlaylistTrack
+  rows are replaced in place on regenerate) and is the freshness baseline for the
+  next regenerate. Browse/restore UI is deferred -- this is the data model only.
+- ``playlist_tracks.spotify_synced_at`` (timestamptz): when the track was last
+  confirmed on Spotify by an export; null = not synced. Drives the per-track sync
+  badge and the "exclude unsynced" action.
+
+Both nullable with no backfill: existing generations have no track snapshot, and
+existing playlist tracks are treated as not-yet-synced until the next export.
+
+Revision ID: q8r9s0t1u2v3
+Revises: p7q8r9s0t1u2
+Create Date: 2026-06-26
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "q8r9s0t1u2v3"
+down_revision: str = "p7q8r9s0t1u2"
+branch_labels: None = None
+depends_on: None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generation_records",
+        sa.Column("track_snapshot", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "playlist_tracks",
+        sa.Column("spotify_synced_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("playlist_tracks", "spotify_synced_at")
+    op.drop_column("generation_records", "track_snapshot")

--- a/src/resonance/api/v1/generators.py
+++ b/src/resonance/api/v1/generators.py
@@ -202,6 +202,11 @@ def validate_profile_inputs(
     """
     try:
         sources = pool_module.normalize_sources(input_references)
+        # Parse the exclude sets too so a malformed exclude_artist_ids /
+        # exclude_track_ids is rejected at write time (422), not persisted and
+        # only discovered when the worker tries to apply it (#track-exclude).
+        pool_module.extract_excludes(input_references)
+        pool_module.extract_track_excludes(input_references)
     except ValueError as exc:
         msg = f"Invalid input_references: {exc}"
         raise ValueError(msg) from exc

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -463,6 +463,10 @@ Subcommands:
            [--name <n>]
            [--param key=val ...]
            [--source ... | --exclude ... | --input key=val ...]
+  exclude-track <profile-id> <track-id> [<track-id> ...] [--regenerate]
+                                    Add tracks to the recipe's exclude list
+                                    (an excluded track is skipped at selection;
+                                    --regenerate refills the freed slots)
   delete <profile-id>               Delete a profile
 
 Sources and --input are mutually exclusive: if any --source/--exclude is given,
@@ -698,6 +702,51 @@ def _cmd_profile() -> None:
         data = resp.json()
         print(f"Updated profile: {data['name']} ({data['generator_type']})")
         print(f"  id: {data['id']}")
+
+    elif subcmd == "exclude-track":
+        if len(sys.argv) < 5:
+            print(
+                "Usage: resonance-api profile exclude-track <profile-id> "
+                "<track-id> [<track-id> ...] [--regenerate]"
+            )
+            sys.exit(1)
+        profile_id = sys.argv[3]
+        rest = sys.argv[4:]
+        regenerate = "--regenerate" in rest
+        track_ids = [a for a in rest if a != "--regenerate"]
+        if not track_ids:
+            print("Provide at least one track id to exclude.")
+            sys.exit(1)
+        # Read the current recipe, append to exclude_track_ids (dedup, preserve
+        # order), and PATCH the whole input_references back. The excluded track is
+        # skipped at selection time; regenerate refills the freed slot.
+        resp = _api_request("GET", f"/api/v1/generator-profiles/{profile_id}")
+        refs = dict(resp.json().get("input_references") or {})
+        excluded = [str(t) for t in (refs.get("exclude_track_ids") or [])]
+        excluded_set = set(excluded)
+        for tid in track_ids:
+            if tid not in excluded_set:
+                excluded.append(tid)
+                excluded_set.add(tid)
+        refs["exclude_track_ids"] = excluded
+        _api_request(
+            "PATCH",
+            f"/api/v1/generator-profiles/{profile_id}",
+            json={"input_references": refs},
+        )
+        print(
+            f"Excluded {len(track_ids)} track(s); {len(excluded)} total on the recipe."
+        )
+        if regenerate:
+            print(f"Triggering regeneration for profile {profile_id}...")
+            gen = _api_request(
+                "POST",
+                f"/api/v1/generator-profiles/{profile_id}/generate",
+                json=None,
+            )
+            task_id = gen.json().get("task_id", "")
+            result = _poll_task(task_id, "Regenerating playlist")
+            print(f"Playlist regenerated: {result.get('playlist_id', 'unknown')}")
 
     elif subcmd == "delete":
         if len(sys.argv) < 4:

--- a/src/resonance/generators/concert_prep.py
+++ b/src/resonance/generators/concert_prep.py
@@ -8,7 +8,7 @@ tracks for playlist inclusion.
 from __future__ import annotations
 
 import dataclasses
-from collections import Counter
+from collections import Counter, deque
 from typing import TYPE_CHECKING
 
 import resonance.generators.scoring as scoring_module
@@ -79,47 +79,67 @@ def _score_candidate(
 def _select_one_pool(
     scored: list[tuple[CandidateTrack, float]],
     max_tracks: int,
+    weights: dict[uuid.UUID, int] | None = None,
 ) -> list[tuple[CandidateTrack, float]]:
-    """Select ``max_tracks`` from a single scored pool with a per-artist floor.
+    """Select ``max_tracks`` by **weighted round-robin** across the pool's artists.
 
     Provenance (event / manual / related) never touches selection -- there is one
-    pool, ranked by ``composite_score``. The input must already be sorted by score
-    descending. Selection is two phases:
+    pool. ``composite_score`` (familiarity + hit_depth) decides WHICH of an artist's
+    tracks fill its slots; round-robin decides HOW MANY each artist gets, so every
+    artist on the bill is represented (not buried by a heavy-rotation neighbor).
+    This restores the per-artist spread that #128 dropped (round-0 + global fill),
+    which let well-listened artists monopolize every post-round-0 slot.
 
-    Round 0 -- per-artist guarantee: each artist in the pool contributes its single
-    highest-scoring track. Because ``scored`` is score-desc, the first time an
-    artist is seen is its best track, so round 0 is the set of those firsts, itself
-    in score-desc order. This guarantees every pool artist is represented by at
-    least one track and is never silently absent.
+    ``scored`` must already be sorted by score descending. Tracks are grouped by
+    artist (each group stays score-desc); artists are dealt in best-track-score
+    order. Each round, every artist with tracks left contributes its next-best
+    track -- ``weights[artist_id]`` of them per round (default 1 = even). Dealing
+    stops at ``max_tracks`` or when every artist is exhausted; an artist that runs
+    out simply drops from later rounds, so its unused share redistributes to the
+    others automatically (a 6-track band among five gives 6; the rest absorb the
+    slack).
 
-    Fill: the remaining ``max_tracks - num_artists`` slots are filled by pure score
-    across all not-yet-selected tracks. A prolific, high-scoring artist *can* take
-    several fill slots here -- that is the intended "heard artists get depth"
-    behavior, replacing the old forced round-robin spread.
+    ``weights`` is the plumbed seam for a future seed/headliner emphasis (and
+    jitter): a higher weight = more tracks per round. Today it is unset (all 1), so
+    the deal is even -- the behavior the owner asked for (#round-robin, D7).
 
-    Edge case: when the pool has more distinct artists than ``max_tracks``, round 0
-    cannot seat everyone. The highest-scoring artist groups keep their guaranteed
-    slot; the lowest are dropped (graceful best-effort), since round 0 is already
-    in score-desc order.
+    Edge cases, all handled by the deal order (best-track-score desc):
+    - ``max_tracks < n_artists``: only the highest-scoring artists get a slot in
+      round 1; the lowest never get dealt (graceful, keeps the top of the bill).
+    - ``max_tracks`` not divisible by artist count: the partial final round deals
+      to the highest-scoring artists first, so they get the extra slots.
+    - one artist: deals its top ``max_tracks`` by score.
+    - empty pool: returns empty (handled by the caller's no-candidates guard).
     """
-    round_zero: list[tuple[CandidateTrack, float]] = []
-    remaining: list[tuple[CandidateTrack, float]] = []
-    seen_artists: set[uuid.UUID] = set()
+    weights = weights or {}
+    # Group tracks by artist, preserving score-desc order within each group.
+    # First-seen order == best-track-score order (``scored`` is score-desc), so the
+    # artist deal order is best-score desc without a separate sort.
+    groups: dict[uuid.UUID, deque[tuple[CandidateTrack, float]]] = {}
+    order: list[uuid.UUID] = []
     for pair in scored:
         artist_id = pair[0].artist_id
-        if artist_id not in seen_artists:
-            seen_artists.add(artist_id)
-            round_zero.append(pair)
-        else:
-            remaining.append(pair)
+        if artist_id not in groups:
+            groups[artist_id] = deque()
+            order.append(artist_id)
+        groups[artist_id].append(pair)
 
-    # More artists than slots: keep the highest-scoring guaranteed tracks, drop
-    # the rest. round_zero is score-desc, so a head slice is the graceful choice.
-    if len(round_zero) >= max_tracks:
-        return round_zero[:max_tracks]
-
-    fill_slots = max_tracks - len(round_zero)
-    return round_zero + remaining[:fill_slots]
+    selected: list[tuple[CandidateTrack, float]] = []
+    while len(selected) < max_tracks:
+        dealt_this_round = False
+        for artist_id in order:
+            if len(selected) >= max_tracks:
+                break
+            group = groups[artist_id]
+            # weight = tracks this artist deals per round (>=1); default even.
+            for _ in range(max(1, weights.get(artist_id, 1))):
+                if not group or len(selected) >= max_tracks:
+                    break
+                selected.append(group.popleft())
+                dealt_this_round = True
+        if not dealt_this_round:
+            break  # every artist exhausted before reaching max_tracks
+    return selected
 
 
 def _apply_freshness_filter(
@@ -162,6 +182,7 @@ def score_and_select(
     max_tracks: int,
     previous_track_ids: set[uuid.UUID],
     freshness_target: int | None,
+    weights: dict[uuid.UUID, int] | None = None,
 ) -> SelectionResult:
     """Score candidates, apply freshness filtering, and select top tracks.
 
@@ -171,6 +192,9 @@ def score_and_select(
         max_tracks: Maximum number of tracks to include in the result.
         previous_track_ids: Track IDs from a previous generation (for freshness).
         freshness_target: Target freshness percentage (0-100), or None to skip.
+        weights: Optional per-artist deal weight for the round-robin selection
+            (artist_id -> tracks per round, default 1 = even). The plumbed seam for
+            a future seed/headliner emphasis; unset today.
 
     Returns:
         A SelectionResult with scored, positioned tracks and metadata.
@@ -193,11 +217,12 @@ def score_and_select(
         scored, previous_track_ids, freshness_target, max_tracks
     )
 
-    # 4. Select from one pool: round-0 per-artist guarantee, then fill by score.
-    #    Provenance (target vs adjacent) is metadata only -- it does not affect
-    #    selection. Pool composition (which related artists are present) is decided
-    #    upstream by enrichment (#133), not here.
-    selected = _select_one_pool(scored, max_tracks)
+    # 4. Select by weighted round-robin across the pool's artists: every artist on
+    #    the bill is represented; composite_score decides which of each artist's
+    #    tracks fill its slots. Provenance (target vs adjacent) is metadata only.
+    #    Pool composition (which related artists are present) is decided upstream by
+    #    enrichment (#133), not here.
+    selected = _select_one_pool(scored, max_tracks, weights)
 
     # 5. Re-sort the merged selection by score for final ordering, then assign
     #    1-indexed positions and build the ScoredTrack list.

--- a/src/resonance/generators/pool.py
+++ b/src/resonance/generators/pool.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 
 class PoolSourceKind(enum.StrEnum):
@@ -216,6 +216,27 @@ def extract_track_excludes(raw: Mapping[str, object]) -> set[uuid.UUID]:
         msg = f"'exclude_track_ids' must be a list, got {type(raw_excludes).__name__}"
         raise ValueError(msg)
     return {_parse_uuid(item, "exclude_track_ids[]") for item in raw_excludes}
+
+
+def with_track_excludes(
+    input_references: Mapping[str, object],
+    track_ids: Iterable[uuid.UUID],
+) -> dict[str, object]:
+    """Return a copy of ``input_references`` with ``exclude_track_ids`` set to
+    ``track_ids`` (deduped, order-preserving), leaving every other key intact.
+
+    Used by the playlist-detail refine actions (#track-exclude) to mark/unmark a
+    track on the recipe. The key is omitted when the set is empty so a profile
+    that excludes nothing keeps its lean shape (matching
+    :func:`serialize_input_references`).
+    """
+    refs = dict(input_references)
+    ids = list(dict.fromkeys(str(t) for t in track_ids))
+    if ids:
+        refs["exclude_track_ids"] = ids
+    else:
+        refs.pop("exclude_track_ids", None)
+    return refs
 
 
 def build_pool(

--- a/src/resonance/generators/pool.py
+++ b/src/resonance/generators/pool.py
@@ -11,8 +11,13 @@ applied last to the union (issue #128). The stored shape is::
         {"kind": "artist",  "artist_id": "<uuid>", "enabled": true,
          "via_seed": "lineup"}
       ],
-      "exclude_artist_ids": ["<uuid>"]
+      "exclude_artist_ids": ["<uuid>"],
+      "exclude_track_ids": ["<uuid>"]
     }
+
+``exclude_track_ids`` (optional, #track-exclude) is applied at track-selection time
+as a candidate filter in the worker -- this module only parses it; it never sees
+tracks. ``exclude_artist_ids`` is applied here at pool build (artist level).
 
 Related artists are no longer a live source kind: enrichment (#133) resolves them
 up front and persists them as concrete ``artist`` sources tagged with ``via_seed``.
@@ -193,6 +198,26 @@ def extract_excludes(raw: Mapping[str, object]) -> set[uuid.UUID]:
     return {_parse_uuid(item, "exclude_artist_ids[]") for item in raw_excludes}
 
 
+def extract_track_excludes(raw: Mapping[str, object]) -> set[uuid.UUID]:
+    """Parse the ``exclude_track_ids`` set from ``input_references`` (#track-exclude).
+
+    Track exclusions are applied at track-selection time (a candidate filter in the
+    scoring path), NOT at pool build time -- this module never sees tracks. This
+    helper only parses the stored ids; the worker applies them.
+
+    Raises:
+        ValueError: If ``exclude_track_ids`` is present but not a list, or any
+            entry is not a valid UUID.
+    """
+    raw_excludes = raw.get("exclude_track_ids")
+    if raw_excludes is None:
+        return set()
+    if not isinstance(raw_excludes, Sequence) or isinstance(raw_excludes, (str, bytes)):
+        msg = f"'exclude_track_ids' must be a list, got {type(raw_excludes).__name__}"
+        raise ValueError(msg)
+    return {_parse_uuid(item, "exclude_track_ids[]") for item in raw_excludes}
+
+
 def build_pool(
     resolved: Sequence[ResolvedArtist],
     exclude_ids: set[uuid.UUID],
@@ -244,12 +269,21 @@ def serialize_source(source: PoolSource) -> dict[str, object]:
 def serialize_input_references(
     sources: Sequence[PoolSource],
     exclude_ids: Sequence[uuid.UUID] = (),
+    exclude_track_ids: Sequence[uuid.UUID] = (),
 ) -> dict[str, object]:
-    """Build a stored ``input_references`` dict from typed sources + excludes."""
-    return {
+    """Build a stored ``input_references`` dict from typed sources + excludes.
+
+    ``exclude_track_ids`` is emitted only when non-empty, so profiles that never
+    exclude a track keep their existing lean shape (and existing round-trips are
+    unchanged).
+    """
+    refs: dict[str, object] = {
         "sources": [serialize_source(s) for s in sources],
         "exclude_artist_ids": [str(aid) for aid in exclude_ids],
     }
+    if exclude_track_ids:
+        refs["exclude_track_ids"] = [str(tid) for tid in exclude_track_ids]
+    return refs
 
 
 def scope_artist_ids(
@@ -293,4 +327,9 @@ def replace_via_seed_sources(
         ArtistSource(artist_id=aid, enabled=True, via_seed=scope) for aid in artist_ids
     )
     excludes = extract_excludes(input_references)
-    return serialize_input_references(kept, sorted(excludes, key=str))
+    track_excludes = extract_track_excludes(input_references)
+    return serialize_input_references(
+        kept,
+        sorted(excludes, key=str),
+        sorted(track_excludes, key=str),
+    )

--- a/src/resonance/models/generator.py
+++ b/src/resonance/models/generator.py
@@ -131,6 +131,16 @@ class GenerationRecord(base_module.TimestampMixin, base_module.Base):
     pool_snapshot: orm.Mapped[list[dict[str, str]] | None] = orm.mapped_column(
         sa.JSON, nullable=True
     )
+    # Resolved track snapshot (#versions): the ordered track ids this generation
+    # produced, captured so prior versions stay recoverable even though the live
+    # PlaylistTrack rows are replaced in place on regenerate (the Playlist row is
+    # reused so the Spotify export link survives). Also the freshness baseline for
+    # the NEXT regenerate (read this, not the live rows, to avoid self-comparison).
+    # Shape: ["<track_uuid>", ...] in playlist order. Nullable: pre-snapshot rows
+    # have none. UI to browse/restore versions is deferred -- this is data only.
+    track_snapshot: orm.Mapped[list[str] | None] = orm.mapped_column(
+        sa.JSON, nullable=True
+    )
 
     profile: orm.Mapped[GeneratorProfile] = orm.relationship(
         back_populates="generations"

--- a/src/resonance/models/playlist.py
+++ b/src/resonance/models/playlist.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -82,6 +83,15 @@ class PlaylistTrack(base_module.TimestampMixin, base_module.Base):
     score: orm.Mapped[float | None] = orm.mapped_column(sa.Float, nullable=True)
     source: orm.Mapped[types_module.TrackSource] = orm.mapped_column(
         sa.Enum(types_module.TrackSource, native_enum=False), nullable=False
+    )
+    # When this track was last confirmed present on Spotify by an export
+    # (#spotify-sync-visibility). Null = not synced (no Spotify match, or never
+    # exported). Drives the per-track sync badge and the "exclude unsynced" bulk
+    # action. Per-playlist-per-track grain (scalar column, no JSON write-race);
+    # a regenerated playlist's fresh rows start null, which is correct -- a new
+    # version has not been exported yet.
+    spotify_synced_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        sa.DateTime(timezone=True), nullable=True, default=None
     )
 
     playlist: orm.Mapped[Playlist] = orm.relationship(back_populates="tracks")

--- a/src/resonance/static/filters.css
+++ b/src/resonance/static/filters.css
@@ -177,6 +177,25 @@
 .service-badge-lastfm   { background: var(--color-lastfm); }
 .service-badge-lb       { background: var(--color-listenbrainz); }
 
+/* Playlist-detail refine controls (#track-exclude). Reuses the lineup builder's
+   visual vocabulary (.aremove / .extag) but scoped to the tracks table so it
+   does not collide with the flex-based .artist-row selectors. */
+#playlist-tracks .trk-actions { text-align: right; white-space: nowrap; }
+#playlist-tracks .aremove {
+  border: none; background: none; color: var(--text-muted); cursor: pointer;
+  font-size: 1.05rem; line-height: 1; min-width: 44px; min-height: 44px;
+  padding: 2px 6px;
+}
+#playlist-tracks .aremove:hover { color: var(--error); }
+#playlist-tracks .extag {
+  font-size: 0.66rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.05em; color: var(--error); border: 1px solid var(--error);
+  border-radius: var(--radius-full); padding: 1px 8px; white-space: nowrap;
+}
+#playlist-tracks tr.excluded td:not(.trk-actions) {
+  text-decoration: line-through; color: var(--text-muted);
+}
+
 /* Truncation utility — click to expand/collapse long values in list views */
 .truncate {
   max-width: 30ch;

--- a/src/resonance/templates/partials/playlist_detail_tracks.html
+++ b/src/resonance/templates/partials/playlist_detail_tracks.html
@@ -9,17 +9,46 @@
         {"label": "Artist"},
         {"label": "Score"},
         {"label": "Source"},
+        {"label": "Spotify"},
+        {"label": "", "style": "width: 4rem;"},
     ],
     empty_message="No tracks in this playlist.",
     page=page,
     has_next=has_next,
     has_prev=has_prev
 ) %}
-<tr>
+{% set is_excluded = (pt.track_id | string) in (excluded_track_ids or []) %}
+<tr{% if is_excluded %} class="excluded"{% endif %}>
     <td>{{ pt.position }}</td>
     <td>{{ pt.track.title }}</td>
     <td>{{ pt.track.artist.name }}</td>
     <td>{{ "%.2f" | format(pt.score) if pt.score is not none else "" }}</td>
     <td>{{ pt.source }}</td>
+    <td>
+        {% if pt.spotify_synced_at %}
+        <span class="service-badge service-badge-spotify"
+              title="On Spotify — synced {{ pt.spotify_synced_at | localtime(user_tz) }}">SP</span>
+        {% else %}
+        <span class="text-muted" title="Not synced to Spotify" aria-label="Not synced to Spotify">—</span>
+        {% endif %}
+    </td>
+    <td class="trk-actions">
+        {% if profile_id %}
+        {% if is_excluded %}
+        <span class="extag">excluded</span>
+        <button type="button" class="aremove"
+                title="Undo exclude"
+                aria-label="Undo excluding {{ pt.track.title }}"
+                hx-post="/playlists/{{ playlist_id }}/tracks/{{ pt.track_id }}/toggle-exclude"
+                hx-target="#playlist-tracks" hx-swap="innerHTML">&#8634;</button>
+        {% else %}
+        <button type="button" class="aremove"
+                title="Exclude this track"
+                aria-label="Exclude {{ pt.track.title }}"
+                hx-post="/playlists/{{ playlist_id }}/tracks/{{ pt.track_id }}/toggle-exclude"
+                hx-target="#playlist-tracks" hx-swap="innerHTML">&times;</button>
+        {% endif %}
+        {% endif %}
+    </td>
 </tr>
 {% endcall %}

--- a/src/resonance/templates/playlist_detail.html
+++ b/src/resonance/templates/playlist_detail.html
@@ -18,6 +18,15 @@
         class="outline btn-sm"
         style="margin-left: 1rem;"
     >Edit</a>
+    {# Regenerate in place: re-runs selection (refilling any excluded slots) and
+       re-passes the size/freshness this playlist was built with. #}
+    <form method="post" action="/playlists/{{ playlist.id }}/regenerate" class="inline-form" style="margin-left: 0.5rem;">
+        <input type="hidden" name="max_tracks" value="{{ playlist.track_count }}">
+        {% if generation.freshness_target is not none %}
+        <input type="hidden" name="freshness_target" value="{{ generation.freshness_target }}">
+        {% endif %}
+        <button type="submit" class="outline btn-sm">Regenerate</button>
+    </form>
     {% endif %}
     <button
         hx-delete="/api/v1/playlists/{{ playlist.id }}"
@@ -110,6 +119,24 @@
         {% endif %}
     </div>
     {% endfor %}
+    {% endif %}
+    {% if generation and synced_count is defined %}
+    {# Per-track sync visibility: how many tracks are confirmed on Spotify, plus
+       the convergence affordance. Copy is action-descriptive, not a promise --
+       a refill can pull in another unmatched track (re-match is not monotone). #}
+    <p style="margin-top: 0.75rem; font-size: 0.85rem;">
+        <span class="text-muted">{{ synced_count }} of {{ playlist.track_count }} tracks synced</span>
+        {% if synced_count < playlist.track_count %}
+        &middot;
+        <form method="post" action="/playlists/{{ playlist.id }}/exclude-unsynced-and-regenerate" class="inline-form">
+            <input type="hidden" name="max_tracks" value="{{ playlist.track_count }}">
+            {% if generation.freshness_target is not none %}
+            <input type="hidden" name="freshness_target" value="{{ generation.freshness_target }}">
+            {% endif %}
+            <button type="submit" class="outline secondary btn-sm">Exclude unsynced &amp; regenerate</button>
+        </form>
+        {% endif %}
+    </p>
     {% endif %}
 </article>
 {% elif not spotify_connections and spotify_connections is defined %}

--- a/src/resonance/templates/playlist_detail.html
+++ b/src/resonance/templates/playlist_detail.html
@@ -9,6 +9,16 @@
 {% endif %}
 <p>
     <small>{{ playlist.track_count }} tracks &middot; {{ playlist.created_at | localtime(user_tz) }}</small>
+    {% if generation %}
+    {# Edit the recipe this playlist was generated from. The profile is the
+       durable "playlist"; the editor regenerates this same row in place. #}
+    <a
+        href="/playlists/{{ generation.profile.id }}/edit"
+        role="button"
+        class="outline btn-sm"
+        style="margin-left: 1rem;"
+    >Edit</a>
+    {% endif %}
     <button
         hx-delete="/api/v1/playlists/{{ playlist.id }}"
         hx-swap="none"

--- a/src/resonance/ui/playlists.py
+++ b/src/resonance/ui/playlists.py
@@ -14,6 +14,7 @@ import sqlalchemy.ext.asyncio as sa_async
 import sqlalchemy.orm as sa_orm
 
 import resonance.api.v1.artists as artists_api
+import resonance.api.v1.generators as generators_api
 import resonance.dependencies as deps_module
 import resonance.generators.pool as pool_module
 import resonance.models.concert as concert_models
@@ -813,10 +814,31 @@ async def playlist_detail_page(
     gen_result = await db.execute(
         sa.select(generator_models.GenerationRecord)
         .where(generator_models.GenerationRecord.playlist_id == playlist_id)
+        .order_by(generator_models.GenerationRecord.created_at.desc())
         .options(sa_orm.joinedload(generator_models.GenerationRecord.profile))
         .limit(1)
     )
     generation = gen_result.scalar_one_or_none()
+
+    # Refine context (#track-exclude, #spotify-sync-visibility): the profile is the
+    # editable recipe; its exclude_track_ids drives which rows render struck-through.
+    profile = generation.profile if generation is not None else None
+    profile_id = profile.id if profile is not None else None
+    excluded_track_ids: set[str] = (
+        {str(t) for t in pool_module.extract_track_excludes(profile.input_references)}
+        if profile is not None
+        else set()
+    )
+    # How many of this playlist's tracks are confirmed on Spotify (drives the
+    # "N of M synced" line and the exclude-unsynced affordance). Counts the whole
+    # playlist, not just the current page.
+    synced_count_result = await db.execute(
+        sa.select(sa.func.count()).where(
+            playlist_models.PlaylistTrack.playlist_id == playlist_id,
+            playlist_models.PlaylistTrack.spotify_synced_at.isnot(None),
+        )
+    )
+    synced_count = synced_count_result.scalar_one()
 
     spotify_conn_result = await db.execute(
         sa.select(user_models.ServiceConnection).where(
@@ -840,6 +862,9 @@ async def playlist_detail_page(
         playlist_id=playlist_id,
         tracks=tracks,
         generation=generation,
+        profile_id=profile_id,
+        excluded_track_ids=excluded_track_ids,
+        synced_count=synced_count,
         spotify_connections=spotify_connections,
         export_in_progress=bool(active_export_tasks),
         export_task_ids=export_task_ids,
@@ -854,4 +879,208 @@ async def playlist_detail_page(
         partial_template="partials/playlist_detail_tracks.html",
         full_template="playlist_detail.html",
         context=ctx,
+    )
+
+
+async def _playlist_and_profile(
+    db: sa_async.AsyncSession,
+    user_id: uuid.UUID,
+    playlist_id: uuid.UUID,
+) -> tuple[playlist_models.Playlist, generator_models.GeneratorProfile]:
+    """Load a user's playlist and the recipe (profile) it was generated from.
+
+    Resolves the profile via the latest GenerationRecord. Raises 404 if the
+    playlist is not the user's, or if it has no generating profile (e.g. a
+    manually-built playlist that can't be refined/regenerated).
+    """
+    playlist = (
+        await db.execute(
+            sa.select(playlist_models.Playlist).where(
+                playlist_models.Playlist.id == playlist_id,
+                playlist_models.Playlist.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if playlist is None:
+        raise fastapi.HTTPException(status_code=404, detail="Playlist not found")
+
+    generation = (
+        await db.execute(
+            sa.select(generator_models.GenerationRecord)
+            .where(generator_models.GenerationRecord.playlist_id == playlist_id)
+            .order_by(generator_models.GenerationRecord.created_at.desc())
+            .options(sa_orm.joinedload(generator_models.GenerationRecord.profile))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if generation is None or generation.profile is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail="This playlist has no editable recipe"
+        )
+    return playlist, generation.profile
+
+
+async def _render_tracks_fragment(
+    request: fastapi.Request,
+    db: sa_async.AsyncSession,
+    playlist_id: uuid.UUID,
+    profile: generator_models.GeneratorProfile,
+    page: int,
+) -> fastapi.responses.HTMLResponse:
+    """Re-render just the playlist tracks partial after a refine mutation."""
+    offset = common.page_offset(page)
+    tracks = list(
+        (
+            await db.execute(
+                sa.select(playlist_models.PlaylistTrack)
+                .where(playlist_models.PlaylistTrack.playlist_id == playlist_id)
+                .order_by(playlist_models.PlaylistTrack.position)
+                .options(
+                    sa_orm.joinedload(playlist_models.PlaylistTrack.track).joinedload(
+                        music_models.Track.artist
+                    )
+                )
+                .offset(offset)
+                .limit(common.PAGE_SIZE + 1)
+            )
+        )
+        .scalars()
+        .unique()
+        .all()
+    )
+    has_next = len(tracks) > common.PAGE_SIZE
+    tracks = tracks[: common.PAGE_SIZE]
+    excluded_track_ids = {
+        str(t) for t in pool_module.extract_track_excludes(profile.input_references)
+    }
+    ctx = common.base_context(request)
+    ctx.update(
+        playlist_id=playlist_id,
+        tracks=tracks,
+        page=page,
+        has_next=has_next,
+        has_prev=page > 1,
+        excluded_track_ids=excluded_track_ids,
+        profile_id=profile.id,
+    )
+    return common.templates.TemplateResponse(
+        request, "partials/playlist_detail_tracks.html", ctx
+    )
+
+
+@router.post("/playlists/{playlist_id}/tracks/{track_id}/toggle-exclude")
+async def toggle_track_exclude(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    playlist_id: uuid.UUID,
+    track_id: uuid.UUID,
+    page: int = 1,
+) -> fastapi.responses.HTMLResponse:
+    """Toggle a track in the recipe's exclude_track_ids (mark/unmark for refill).
+
+    Marking does NOT remove the track from the current playlist -- it is struck
+    through until the user regenerates, which refills the freed slot
+    (mark-then-regenerate, #track-exclude). Returns the re-rendered tracks partial.
+    """
+    _playlist, profile = await _playlist_and_profile(db, user_id, playlist_id)
+    excluded = pool_module.extract_track_excludes(profile.input_references)
+    if track_id in excluded:
+        excluded.discard(track_id)
+    else:
+        excluded.add(track_id)
+    profile.input_references = pool_module.with_track_excludes(
+        profile.input_references, excluded
+    )
+    await db.commit()
+    return await _render_tracks_fragment(request, db, playlist_id, profile, page)
+
+
+@router.post("/playlists/{playlist_id}/regenerate", response_model=None)
+async def regenerate_playlist(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    playlist_id: uuid.UUID,
+    max_tracks: Annotated[int, fastapi.Form()] = 50,
+    freshness_target: Annotated[str, fastapi.Form()] = "",
+) -> fastapi.responses.RedirectResponse:
+    """Regenerate this playlist in place from its recipe (refills excluded slots).
+
+    Re-passes max_tracks/freshness_target (they live on the generation task, not
+    the profile) and lands on the generation-progress page.
+    """
+    _playlist, profile = await _playlist_and_profile(db, user_id, playlist_id)
+    fresh = int(freshness_target) if freshness_target.strip() else None
+    task_id = await generators_api._trigger_profile_task(
+        db=db,
+        arq_redis=request.app.state.arq_redis,
+        profile_id=profile.id,
+        user_id=user_id,
+        task_type=types_module.TaskType.PLAYLIST_GENERATION,
+        params={
+            "profile_id": str(profile.id),
+            "freshness_target": fresh,
+            "max_tracks": max_tracks,
+        },
+        job_name="generate_playlist",
+    )
+    return fastapi.responses.RedirectResponse(
+        url=f"/playlists/generating/{task_id}", status_code=303
+    )
+
+
+@router.post(
+    "/playlists/{playlist_id}/exclude-unsynced-and-regenerate", response_model=None
+)
+async def exclude_unsynced_and_regenerate(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    playlist_id: uuid.UUID,
+    max_tracks: Annotated[int, fastapi.Form()] = 50,
+    freshness_target: Annotated[str, fastapi.Form()] = "",
+) -> fastapi.responses.RedirectResponse:
+    """Exclude every not-yet-synced track from the recipe, then regenerate.
+
+    The convergence affordance for partial Spotify exports: drop the tracks that
+    failed to match, refill from the same pool, and land on the progress page so
+    a re-export can sync the new selection. Convergence is best-effort, not
+    monotone (a refill can pull in another unmatched track).
+    """
+    _playlist, profile = await _playlist_and_profile(db, user_id, playlist_id)
+    unsynced = (
+        (
+            await db.execute(
+                sa.select(playlist_models.PlaylistTrack.track_id).where(
+                    playlist_models.PlaylistTrack.playlist_id == playlist_id,
+                    playlist_models.PlaylistTrack.spotify_synced_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    excluded = pool_module.extract_track_excludes(profile.input_references)
+    excluded.update(unsynced)
+    profile.input_references = pool_module.with_track_excludes(
+        profile.input_references, excluded
+    )
+    await db.commit()
+    fresh = int(freshness_target) if freshness_target.strip() else None
+    task_id = await generators_api._trigger_profile_task(
+        db=db,
+        arq_redis=request.app.state.arq_redis,
+        profile_id=profile.id,
+        user_id=user_id,
+        task_type=types_module.TaskType.PLAYLIST_GENERATION,
+        params={
+            "profile_id": str(profile.id),
+            "freshness_target": fresh,
+            "max_tracks": max_tracks,
+        },
+        job_name="generate_playlist",
+    )
+    return fastapi.responses.RedirectResponse(
+        url=f"/playlists/generating/{task_id}", status_code=303
     )

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -1506,10 +1506,14 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
 
     Loads the RELATED_ARTIST_ENRICHMENT task and its profile, resolves similar
     artists for the requested scope (a single seed, several seeds, or the whole
-    lineup), imports the new ones, and replaces that scope's prior discovered
-    artist sources in ``profile.input_references`` with the fresh batch. The
-    discovered artists become concrete, curatable ``artist`` sources tagged with
-    ``via_seed``; a later generate re-scores tracks against this fixed pool.
+    lineup), imports the new ones, and **tops up** that scope to ``n`` active
+    discoveries in ``profile.input_references`` -- counting the non-excluded
+    discoveries already present and appending only the difference, never
+    re-suggesting a globally-excluded artist. A scope already at or over ``n``
+    active is a no-op (curated discoveries are never trimmed); if the connectors
+    return fewer than needed, it is a partial success. The discovered artists
+    become concrete, curatable ``artist`` sources tagged with ``via_seed``; a
+    later generate re-scores tracks against this fixed pool.
 
     Args:
         ctx: arq worker context dict.
@@ -1607,10 +1611,39 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
                     for sid in seed_id_list
                 ]
 
+            # Plan per-scope top-up: count the active (non-excluded) discoveries
+            # already in each scope and fetch only the difference up to the
+            # requested N. A scope at or over N is a no-op -- we never trim the
+            # user's curated discoveries; we only add. Globally-excluded artists do
+            # not count toward "active" and are never re-suggested below.
+            excluded_ids = pool_module.extract_excludes(refs)
+            scope_plans: list[tuple[str, list[music_models.Artist], int]] = []
+            for scope, seed_artists, target_n in scopes:
+                active = set(pool_module.scope_artist_ids(refs, scope)) - excluded_ids
+                needed = max(0, target_n - len(active))
+                scope_plans.append((scope, seed_artists, needed))
+            target_total = sum(needed for _, _, needed in scope_plans)
+
+            # Every scope already at its target: nothing to fetch, success no-op.
+            if target_total == 0:
+                task.progress_total = 0
+                task.progress_current = 0
+                await lifecycle_module.complete_task(
+                    session,
+                    task,
+                    {
+                        "found": 0,
+                        "requested": 0,
+                        "message": "scopes already at target",
+                    },
+                )
+                await session.commit()
+                log.info("enrich_related_artists_already_full")
+                return
+
             similar_connectors = wctx["connector_registry"].get_by_capability(
                 base_module.ConnectorCapability.SIMILAR_ARTISTS
             )
-            target_total = requested_n * len(scopes)
             if not similar_connectors:
                 task.progress_total = target_total
                 task.progress_current = 0
@@ -1645,26 +1678,28 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
             scope_results: list[tuple[str, list[uuid.UUID]]] = []
             running_pool_ids = set(current_pool_ids)
             total_found = 0
-            for scope, seed_artists, target_n in scopes:
-                scope_prior = set(pool_module.scope_artist_ids(refs, scope))
-                # Exclude everything currently in the pool EXCEPT this scope's
-                # own prior discoveries (so they can be re-found on replace), plus
-                # the seeds themselves (an artist is never its own neighbor).
-                exclude = (running_pool_ids - scope_prior) | {
-                    a.id for a in seed_artists
-                }
+            for scope, seed_artists, needed in scope_plans:
+                if needed == 0:
+                    scope_results.append((scope, []))
+                    continue
+                # Never re-find anything already in the pool, the seeds themselves
+                # (an artist is not its own neighbor), or a globally-excluded artist
+                # (we must not re-suggest one the user removed). Because we APPEND
+                # (top-up) rather than replace, this scope's existing discoveries
+                # stay put and are excluded from re-discovery too.
+                exclude = running_pool_ids | {a.id for a in seed_artists} | excluded_ids
                 new_ids = await _collect_related(
                     session,
                     similar_connectors,
                     lb_connector,
                     seed_artists,
                     exclude,
-                    target_n,
+                    needed,
                     _store_fetch,
                     log,
                 )
                 scope_results.append((scope, new_ids))
-                running_pool_ids = (running_pool_ids - scope_prior) | set(new_ids)
+                running_pool_ids |= set(new_ids)
                 total_found += len(new_ids)
             await session.commit()
 
@@ -1676,16 +1711,37 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
             for attempt in range(_MAX_VERSION_RETRIES):
                 merged: dict[str, object] = dict(profile.input_references)
                 for scope, new_ids in scope_results:
+                    if not new_ids:
+                        continue  # no-op top-up: leave the scope's discoveries
+                    # Top-up (append), not replace: recompute the scope's current
+                    # discoveries from the (possibly reloaded) refs and append only
+                    # the genuinely-new ids, so a concurrent writer's additions to
+                    # this scope are preserved rather than clobbered.
+                    existing = list(pool_module.scope_artist_ids(merged, scope))
+                    existing_set = set(existing)
+                    appended = existing + [
+                        nid for nid in new_ids if nid not in existing_set
+                    ]
                     merged = pool_module.replace_via_seed_sources(
-                        merged, scope, new_ids
+                        merged, scope, appended
                     )
                 profile.input_references = merged
                 task.progress_total = target_total
                 task.progress_current = total_found
+                result_payload: dict[str, object] = {
+                    "found": total_found,
+                    "requested": target_total,
+                }
+                if total_found < target_total:
+                    # Partial success: the connectors had fewer fresh neighbors than
+                    # the top-up needed (neighbors exhausted).
+                    result_payload["message"] = (
+                        f"found {total_found} of {target_total} (neighbors exhausted)"
+                    )
                 await lifecycle_module.complete_task(
                     session,
                     task,
-                    {"found": total_found, "requested": target_total},
+                    result_payload,
                 )
                 try:
                     await session.commit()

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -1844,7 +1844,14 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 r.track_id for r in utr_result.scalars().all()
             }
 
-            # Get previous playlist track IDs for freshness
+            # Freshness baseline + in-place target: load the latest GenerationRecord.
+            # CRITICAL (#versions): read the baseline from its track_snapshot, NOT the
+            # live PlaylistTrack rows. On an in-place regenerate the "previous"
+            # playlist IS the row we are about to overwrite, so reading its live rows
+            # would compare the new selection against itself and silently break the
+            # freshness target. The snapshot is captured at generation time and never
+            # mutated, so it is the correct previous-track set. Read here, before any
+            # row replacement below.
             prev_gen_result = await session.execute(
                 sa.select(generator_models.GenerationRecord)
                 .where(
@@ -1857,18 +1864,35 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
             prev_gen = prev_gen_result.scalar_one_or_none()
             previous_track_ids: set[uuid.UUID] = set()
             if prev_gen is not None:
-                # Load previous playlist tracks
-                prev_pt_result = await session.execute(
-                    sa.select(playlist_models.PlaylistTrack.track_id).where(
-                        playlist_models.PlaylistTrack.playlist_id
-                        == prev_gen.playlist_id
+                if prev_gen.track_snapshot is not None:
+                    previous_track_ids = {
+                        uuid.UUID(tid) for tid in prev_gen.track_snapshot
+                    }
+                else:
+                    # Backwards-compat: records written before track_snapshot existed
+                    # have no snapshot. Fall back to that generation's live rows --
+                    # safe because this read happens before any replacement below.
+                    prev_pt_result = await session.execute(
+                        sa.select(playlist_models.PlaylistTrack.track_id).where(
+                            playlist_models.PlaylistTrack.playlist_id
+                            == prev_gen.playlist_id
+                        )
                     )
-                )
-                previous_track_ids = {row[0] for row in prev_pt_result.all()}
+                    previous_track_ids = {row[0] for row in prev_pt_result.all()}
+
+            # Recipe-level track exclusions (#track-exclude): an excluded track never
+            # becomes a candidate, so its band deals its next-best track on the next
+            # round-robin pass and the freed slot refills. pool.py is artist-only /
+            # pre-track, so this filter lives here, not in build_pool.
+            exclude_track_ids = pool_module.extract_track_excludes(
+                profile.input_references
+            )
 
             # Build CandidateTrack objects
             candidates: list[concert_prep_module.CandidateTrack] = []
             for track in all_tracks:
+                if track.id in exclude_track_ids:
+                    continue
                 lc = listen_counts.get(track.id, 0)
                 in_library = lc > 0 or track.id in liked_track_ids
                 candidates.append(
@@ -1908,17 +1932,44 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 freshness_target=freshness_target,
             )
 
-            # Create Playlist
-            playlist = playlist_models.Playlist(
-                id=uuid.uuid4(),
-                user_id=task.user_id,
-                name=str(profile.name),
-                description=f"Generated from profile: {profile.name}",
-                track_count=len(selection.tracks),
-            )
-            session.add(playlist)
+            # Regenerate in place (#versions): reuse the current Playlist row when one
+            # exists, so its identity -- and the Spotify export anchor in
+            # service_links -- survives the regenerate. Replace its PlaylistTrack rows
+            # with the new selection; the prior version's tracks live on in the
+            # GenerationRecord.track_snapshot history, not in this row. Only when there
+            # is no prior playlist (first generation, or it was deleted) do we create a
+            # fresh one.
+            existing_playlist: playlist_models.Playlist | None = None
+            if prev_gen is not None:
+                existing_playlist = await session.get(
+                    playlist_models.Playlist, prev_gen.playlist_id
+                )
 
-            # Create PlaylistTrack rows
+            if existing_playlist is not None:
+                playlist = existing_playlist
+                # Drop the old rows first (Core delete executes immediately within the
+                # transaction, before the new inserts below). Keep id, service_links
+                # (Spotify anchor), and is_pinned untouched.
+                await session.execute(
+                    sa.delete(playlist_models.PlaylistTrack).where(
+                        playlist_models.PlaylistTrack.playlist_id == playlist.id
+                    )
+                )
+                playlist.name = str(profile.name)
+                playlist.description = f"Generated from profile: {profile.name}"
+                playlist.track_count = len(selection.tracks)
+            else:
+                playlist = playlist_models.Playlist(
+                    id=uuid.uuid4(),
+                    user_id=task.user_id,
+                    name=str(profile.name),
+                    description=f"Generated from profile: {profile.name}",
+                    track_count=len(selection.tracks),
+                )
+                session.add(playlist)
+
+            # Create PlaylistTrack rows (fresh rows start unsynced -- a regenerated
+            # version has not been exported yet).
             for scored in selection.tracks:
                 pt = playlist_models.PlaylistTrack(
                     id=uuid.uuid4(),
@@ -1951,6 +2002,10 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 track_sources_summary=selection.sources_summary,
                 generation_duration_ms=generation_duration_ms,
                 pool_snapshot=pool_snapshot,
+                # Ordered track ids this generation produced (#versions): the durable
+                # history of this version AND the freshness baseline for the next
+                # regenerate (read above, never the live rows).
+                track_snapshot=[str(scored.track_id) for scored in selection.tracks],
             )
             session.add(gen_record)
 

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -2254,8 +2254,13 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
             )
 
             # Match tracks to Spotify IDs (two-pass: MB URL relations, then text search)
+            export_now = datetime.datetime.now(datetime.UTC)
             spotify_uris: list[str] = []
             skipped_tracks: list[str] = []
+            # Per-track sync status (#spotify-sync-visibility): which PlaylistTrack
+            # rows matched vs not, so we can stamp spotify_synced_at after the push.
+            matched_pts: list[playlist_models.PlaylistTrack] = []
+            unmatched_pts: list[playlist_models.PlaylistTrack] = []
             mb_matched = 0
             search_matched = 0
 
@@ -2290,9 +2295,11 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
                         search_matched += 1
                     else:
                         skipped_tracks.append(track.title)
+                        unmatched_pts.append(pt)
                         continue
 
                 spotify_uris.append(f"spotify:track:{spotify_id}")
+                matched_pts.append(pt)
 
             log.info(
                 "export_track_matching_summary",
@@ -2359,6 +2366,16 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
             updated_playlist_links["spotify"] = spotify_section
             playlist.service_links = updated_playlist_links
 
+            # Persist per-track Spotify sync status (#spotify-sync-visibility): the
+            # push succeeded, so every matched track is now confirmed on Spotify;
+            # an unmatched one is cleared (re-match is not monotone -- a track can
+            # stop matching on a re-export). Drives the per-row badge and the
+            # "exclude unsynced & regenerate" affordance.
+            for matched_pt in matched_pts:
+                matched_pt.spotify_synced_at = export_now
+            for unmatched_pt in unmatched_pts:
+                unmatched_pt.spotify_synced_at = None
+
             await lifecycle_module.complete_task(
                 session,
                 task,
@@ -2367,6 +2384,7 @@ async def export_playlist(ctx: dict[str, Any], task_id: str) -> None:
                     "exported": len(spotify_uris),
                     "skipped": len(skipped_tracks),
                     "skipped_tracks": skipped_tracks,
+                    "synced_track_ids": [str(pt.track_id) for pt in matched_pts],
                 },
             )
             await session.commit()

--- a/tests/test_api_generators.py
+++ b/tests/test_api_generators.py
@@ -221,6 +221,43 @@ class TestValidateProfileInputs:
             request.input_references, request.generator_type
         )
 
+    def test_valid_exclude_track_ids_pass_validation(self) -> None:
+        """A well-formed exclude_track_ids list round-trips through validation."""
+        body = {
+            "name": "Test",
+            "generator_type": "concert_prep",
+            "input_references": {
+                "sources": [
+                    {"kind": "artist", "artist_id": str(uuid.uuid4()), "enabled": True}
+                ],
+                "exclude_track_ids": [str(uuid.uuid4()), str(uuid.uuid4())],
+            },
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )
+
+    def test_malformed_exclude_track_ids_raise(self) -> None:
+        """A non-UUID in exclude_track_ids is rejected at write time, not later."""
+        body = {
+            "name": "Test",
+            "generator_type": "concert_prep",
+            "input_references": {
+                "sources": [
+                    {"kind": "artist", "artist_id": str(uuid.uuid4()), "enabled": True}
+                ],
+                "exclude_track_ids": ["not-a-uuid"],
+            },
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        with pytest.raises(ValueError, match="Invalid input_references"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
+
 
 # --- enrich endpoint (#133) ---
 

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -637,3 +637,131 @@ class TestEnrichCommand:
         )
         with pytest.raises(SystemExit):
             cli_module._cmd_enrich()
+
+
+class TestProfileExcludeTrack:
+    """`profile exclude-track`: append to exclude_track_ids and PATCH."""
+
+    @pytest.mark.usefixtures("_mock_config")
+    def test_appends_to_existing_excludes_and_preserves_refs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing_track = "11111111-1111-1111-1111-111111111111"
+        new_track = "22222222-2222-2222-2222-222222222222"
+        source = {"kind": "artist", "artist_id": "a1", "enabled": True}
+        calls: list[dict[str, Any]] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+            calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+            if method == "GET":
+                return _fake_response(
+                    json_body={
+                        "id": "p1",
+                        "name": "P",
+                        "generator_type": "concert_prep",
+                        "input_references": {
+                            "sources": [source],
+                            "exclude_track_ids": [existing_track],
+                        },
+                    }
+                )
+            # PATCH
+            return _fake_response(
+                json_body={"id": "p1", "name": "P", "generator_type": "concert_prep"}
+            )
+
+        monkeypatch.setattr(httpx, "request", fake_request)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["resonance-api", "profile", "exclude-track", "p1", new_track],
+        )
+        cli_module._cmd_profile()
+
+        # A GET then a PATCH, no generate (no --regenerate).
+        assert [c["method"] for c in calls] == ["GET", "PATCH"]
+        patched_refs = calls[1]["json"]["input_references"]
+        # New track appended; existing exclude preserved; sources untouched.
+        assert patched_refs["exclude_track_ids"] == [existing_track, new_track]
+        assert patched_refs["sources"] == [source]
+
+    @pytest.mark.usefixtures("_mock_config")
+    def test_dedupes_already_excluded_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        track = "11111111-1111-1111-1111-111111111111"
+        calls: list[dict[str, Any]] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+            calls.append({"method": method, "json": kwargs.get("json")})
+            if method == "GET":
+                return _fake_response(
+                    json_body={
+                        "id": "p1",
+                        "name": "P",
+                        "generator_type": "concert_prep",
+                        "input_references": {"exclude_track_ids": [track]},
+                    }
+                )
+            return _fake_response(
+                json_body={"id": "p1", "name": "P", "generator_type": "concert_prep"}
+            )
+
+        monkeypatch.setattr(httpx, "request", fake_request)
+        monkeypatch.setattr(
+            sys, "argv", ["resonance-api", "profile", "exclude-track", "p1", track]
+        )
+        cli_module._cmd_profile()
+
+        # Re-excluding the same track does not duplicate it.
+        assert calls[1]["json"]["input_references"]["exclude_track_ids"] == [track]
+
+    @pytest.mark.usefixtures("_mock_config")
+    def test_regenerate_flag_triggers_generate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        track = "22222222-2222-2222-2222-222222222222"
+        calls: list[dict[str, Any]] = []
+
+        def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+            calls.append({"method": method, "url": url})
+            if method == "GET" and url.endswith("/p1"):
+                return _fake_response(
+                    json_body={
+                        "id": "p1",
+                        "name": "P",
+                        "generator_type": "concert_prep",
+                        "input_references": {},
+                    }
+                )
+            if method == "POST":
+                return _fake_response(json_body={"task_id": "t1"})
+            if method == "GET":  # _poll_task status poll
+                return _fake_response(
+                    json_body={
+                        "status": "completed",
+                        "result": {"playlist_id": "pl1"},
+                    }
+                )
+            return _fake_response(json_body={"id": "p1"})  # PATCH
+
+        monkeypatch.setattr(httpx, "request", fake_request)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "resonance-api",
+                "profile",
+                "exclude-track",
+                "p1",
+                track,
+                "--regenerate",
+            ],
+        )
+        cli_module._cmd_profile()
+
+        methods = [c["method"] for c in calls]
+        # GET profile -> PATCH excludes -> POST generate -> GET poll(s).
+        assert methods[0] == "GET"
+        assert "PATCH" in methods
+        assert "POST" in methods

--- a/tests/test_concert_prep_generator.py
+++ b/tests/test_concert_prep_generator.py
@@ -402,16 +402,19 @@ def _artist_count(
 
 
 class TestOnePoolSelection:
-    """One ranked pool: round-0 per-artist guarantee, then fill by pure score.
+    """One ranked pool, **weighted round-robin** deal across the pool's artists.
 
-    Provenance (target vs adjacent) is metadata only and never affects selection.
-    This replaces the #122 forced target/adjacent quota and full round-robin
-    spread (issue #128 / #111).
+    Every artist on the bill is represented (no heavy-rotation neighbor can
+    monopolize the slots); ``composite_score`` decides WHICH of an artist's tracks
+    fill its share, round-robin decides HOW MANY. This restores the per-artist
+    spread #128 dropped (round-0 + pure-score fill let well-listened artists take
+    every post-round-0 slot). Provenance (target vs adjacent) is metadata only and
+    never affects selection.
     """
 
-    def test_round_zero_guarantees_each_artist(self) -> None:
-        # Six artists, each with several tracks; plenty of room. Every artist must
-        # appear at least once -- never silently absent.
+    def test_every_artist_present_with_room(self) -> None:
+        # Six artists, five tracks each, exactly enough room (30 slots). Round-robin
+        # deals an even share: every artist contributes all five, none is buried.
         artists = [uuid.uuid4() for _ in range(6)]
         candidates: list[concert_prep_module.CandidateTrack] = []
         for rank, aid in enumerate(artists):
@@ -428,40 +431,119 @@ class TestOnePoolSelection:
         )
         per_artist = _artist_count(result, candidates)
         for aid in artists:
-            assert per_artist.get(aid, 0) >= 1, per_artist
+            assert per_artist.get(aid, 0) == 5, per_artist
 
-    def test_high_score_artist_gets_depth_in_fill(self) -> None:
-        # A prolific, high-scoring artist SHOULD take many fill slots beyond its
-        # round-0 token -- "heard artists get depth". This is the deliberate
-        # reversal of the old anti-flooding round-robin.
-        deep = uuid.uuid4()
-        others = [uuid.uuid4() for _ in range(3)]
-        candidates: list[concert_prep_module.CandidateTrack] = [
-            _artist_candidate(artist_id=deep, listen_count=90 + i) for i in range(15)
-        ]
-        for other in others:
+    def test_even_share_with_comparable_catalogs(self) -> None:
+        # The reversal of #128: a prolific, heavily-listened artist no longer
+        # monopolizes the fill. Five artists each have 20 tracks and there are 50
+        # slots, so round-robin deals ~10 to every artist regardless of how much
+        # more one is listened to than the others.
+        artists = [uuid.uuid4() for _ in range(5)]
+        candidates: list[concert_prep_module.CandidateTrack] = []
+        for rank, aid in enumerate(artists):
+            # Wildly different listen counts (rank 0 ~ obscure, rank 4 ~ heavy
+            # rotation) -- round-robin must still give an even share.
             candidates += [
-                _artist_candidate(artist_id=other, listen_count=5 + i) for i in range(2)
+                _artist_candidate(artist_id=aid, listen_count=1 + rank * 50 + i)
+                for i in range(20)
             ]
         result = concert_prep_module.score_and_select(
             candidates=candidates,
             params=_FAMILIARITY_DRIVEN,
-            max_tracks=20,
+            max_tracks=50,
             previous_track_ids=set(),
             freshness_target=None,
         )
         per_artist = _artist_count(result, candidates)
-        # Each of the 3 others is guaranteed exactly its catalog (1-2 each); the
-        # deep artist takes the rest of the 20 slots. Round 0 = 4 tracks (one per
-        # artist), fill 16 by score -> the deep artist's 14 remaining all outrank
-        # the others, so it gets 1 + 14 = 15.
-        assert per_artist[deep] == 15, per_artist
-        for other in others:
-            assert per_artist.get(other, 0) >= 1, per_artist
+        assert len(result.tracks) == 50
+        for aid in artists:
+            assert per_artist[aid] == 10, per_artist
+
+    def test_short_band_redistributes_its_slack(self) -> None:
+        # One band has only 6 tracks; the other four have plenty. With 50 slots the
+        # short band contributes all 6 and drops out, and its unused share is
+        # absorbed by the remaining bands (no empty slots).
+        full = [uuid.uuid4() for _ in range(4)]
+        short = uuid.uuid4()
+        candidates: list[concert_prep_module.CandidateTrack] = []
+        for rank, aid in enumerate(full):
+            candidates += [
+                _artist_candidate(artist_id=aid, listen_count=10 + rank * 10 + i)
+                for i in range(20)
+            ]
+        candidates += [
+            _artist_candidate(artist_id=short, listen_count=5 + i) for i in range(6)
+        ]
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=_FAMILIARITY_DRIVEN,
+            max_tracks=50,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        per_artist = _artist_count(result, candidates)
+        assert len(result.tracks) == 50
+        # Short band gives everything it has; nothing more is invented for it.
+        assert per_artist[short] == 6, per_artist
+        # The 44 remaining slots are absorbed by the four full bands (11 each).
+        for aid in full:
+            assert per_artist[aid] == 11, per_artist
+
+    def test_weight_increases_a_bands_share(self) -> None:
+        # The plumbed per-band weight is a real seam: a band with weight 3 is dealt
+        # three tracks per round instead of one, so it takes ~3x the share of an
+        # even band -- without changing the algorithm (default weight stays 1).
+        heavy = uuid.uuid4()
+        evens = [uuid.uuid4() for _ in range(3)]
+        candidates: list[concert_prep_module.CandidateTrack] = [
+            _artist_candidate(artist_id=heavy, listen_count=50 + i) for i in range(30)
+        ]
+        for rank, aid in enumerate(evens):
+            candidates += [
+                _artist_candidate(artist_id=aid, listen_count=10 + rank + i)
+                for i in range(30)
+            ]
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=_FAMILIARITY_DRIVEN,
+            max_tracks=24,
+            previous_track_ids=set(),
+            freshness_target=None,
+            weights={heavy: 3},
+        )
+        per_artist = _artist_count(result, candidates)
+        assert len(result.tracks) == 24
+        # Per round: heavy deals 3, each of the 3 evens deals 1 => 6 per round.
+        # 24 / 6 = 4 rounds => heavy = 12, each even = 4.
+        assert per_artist[heavy] == 12, per_artist
+        for aid in evens:
+            assert per_artist[aid] == 4, per_artist
+
+    def test_single_artist_returns_top_n_by_score(self) -> None:
+        # One artist degenerates to "that artist's top max_tracks by score" -- no
+        # special-case needed.
+        artist = uuid.uuid4()
+        candidates = [
+            _artist_candidate(artist_id=artist, listen_count=i) for i in range(30)
+        ]
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=_FAMILIARITY_DRIVEN,
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        assert len(result.tracks) == 10
+        # All ten are the highest listen_counts (29..20) from the one artist.
+        listen_by_track = {c.track_id: c.listen_count for c in candidates}
+        selected_listens = sorted(
+            (listen_by_track[t.track_id] for t in result.tracks), reverse=True
+        )
+        assert selected_listens == list(range(29, 19, -1)), selected_listens
 
     def test_pool_larger_than_max_tracks_graceful_drop(self) -> None:
-        # More distinct artists than slots: round 0 cannot seat everyone. The
-        # highest-scoring artist groups keep their guaranteed slot; lowest drop.
+        # More distinct artists than slots: round 1 cannot seat everyone. The
+        # highest-scoring artists are dealt first; the lowest never get a slot.
         artists = [uuid.uuid4() for _ in range(20)]
         candidates = [
             _artist_candidate(artist_id=aid, listen_count=rank + 1)
@@ -551,9 +633,11 @@ class TestOnePoolSelection:
         assert artist_by_track[result.tracks[0].track_id] == strong
 
 
-class TestKnownVsDiscoveryDistribution:
-    """Familiarity shifts depth between heard and unheard artists, but the
-    round-0 guarantee keeps every artist present at both extremes (issue #128)."""
+class TestFamiliarityWithinArtist:
+    """The #128 reversal: under round-robin the familiarity slider no longer
+    changes how MANY tracks an artist gets (that is even by deal) -- a heard artist
+    can't out-fill an unheard one. Familiarity instead chooses WHICH of an artist's
+    tracks are picked."""
 
     def _mixed_pool(self) -> list[concert_prep_module.CandidateTrack]:
         heard = uuid.uuid4()
@@ -573,44 +657,66 @@ class TestKnownVsDiscoveryDistribution:
         ]
         return candidates
 
-    def test_mostly_known_keeps_unheard_present_but_light(self) -> None:
+    def test_even_share_when_favoring_known(self) -> None:
         candidates = self._mixed_pool()
         heard = candidates[0].artist_id
         unheard = candidates[-1].artist_id
         result = concert_prep_module.score_and_select(
             candidates=candidates,
-            # Favor known tracks: heard artist wins the fill, unheard stays at its
-            # one guaranteed token.
+            # Favoring known tracks does NOT let the heard artist take more slots:
+            # round-robin gives two artists four each out of eight.
             params={"familiarity": 100, "hit_depth": 50},
             max_tracks=8,
             previous_track_ids=set(),
             freshness_target=None,
         )
         per_artist = _artist_count(result, candidates)
-        assert per_artist.get(unheard, 0) >= 1, per_artist
-        assert per_artist[heard] > per_artist[unheard], per_artist
+        assert per_artist[heard] == 4, per_artist
+        assert per_artist[unheard] == 4, per_artist
 
-    def test_mostly_discovery_lets_unheard_fill(self) -> None:
+    def test_even_share_when_favoring_discovery(self) -> None:
         candidates = self._mixed_pool()
         heard = candidates[0].artist_id
         unheard = candidates[-1].artist_id
         result = concert_prep_module.score_and_select(
             candidates=candidates,
-            # Favor discovery: unheard tracks win the fill slots.
+            # The opposite extreme is symmetric: still four each.
             params={"familiarity": 0, "hit_depth": 50},
             max_tracks=8,
             previous_track_ids=set(),
             freshness_target=None,
         )
         per_artist = _artist_count(result, candidates)
-        assert per_artist.get(heard, 0) >= 1, per_artist
-        assert per_artist[unheard] > per_artist[heard], per_artist
+        assert per_artist[heard] == 4, per_artist
+        assert per_artist[unheard] == 4, per_artist
+
+    def test_familiarity_picks_most_played_within_artist(self) -> None:
+        # WHICH tracks: one artist with varied listen_counts. High familiarity ranks
+        # the most-played tracks first, so with a tight max they are the ones kept.
+        artist = uuid.uuid4()
+        candidates = [
+            _artist_candidate(artist_id=artist, listen_count=lc)
+            for lc in (1, 5, 40, 90)
+        ]
+        result = concert_prep_module.score_and_select(
+            candidates=candidates,
+            params=_FAMILIARITY_DRIVEN,
+            max_tracks=2,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        listen_by_track = {c.track_id: c.listen_count for c in candidates}
+        picked = sorted(
+            (listen_by_track[t.track_id] for t in result.tracks), reverse=True
+        )
+        # The two most-played tracks (90, 40) are chosen.
+        assert picked == [90, 40], picked
 
 
 class TestHitDepthReorders:
     """#114: hit_depth re-ranks the pool by external popularity_score.
 
-    A single artist (so the round-0 guarantee doesn't interfere) with tracks of
+    A single artist (so the round-robin deal doesn't interfere) with tracks of
     varying popularity. With familiarity neutral, hit_depth alone drives order.
     """
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -403,3 +403,29 @@ class TestExtractTrackExcludes:
         # Empty stays lean (no key) — preserves existing profile shape.
         without = pool_module.serialize_input_references([])
         assert "exclude_track_ids" not in without
+
+
+class TestWithTrackExcludes:
+    """with_track_excludes (#track-exclude refine actions)."""
+
+    def test_sets_excludes_preserving_other_keys(self) -> None:
+        t1, t2 = uuid.uuid4(), uuid.uuid4()
+        refs = {"sources": [{"kind": "artist"}], "exclude_artist_ids": ["a"]}
+        out = pool_module.with_track_excludes(refs, [t1, t2])
+        assert pool_module.extract_track_excludes(out) == {t1, t2}
+        # Untouched keys survive.
+        assert out["sources"] == [{"kind": "artist"}]
+        assert out["exclude_artist_ids"] == ["a"]
+        # Input not mutated.
+        assert "exclude_track_ids" not in refs
+
+    def test_empty_drops_the_key(self) -> None:
+        refs = {"exclude_track_ids": [str(uuid.uuid4())], "sources": []}
+        out = pool_module.with_track_excludes(refs, [])
+        assert "exclude_track_ids" not in out
+        assert out["sources"] == []
+
+    def test_dedups(self) -> None:
+        t1 = uuid.uuid4()
+        out = pool_module.with_track_excludes({}, [t1, t1])
+        assert out["exclude_track_ids"] == [str(t1)]

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -361,3 +361,45 @@ class TestReplaceViaSeedSources:
         }
         pool_module.replace_via_seed_sources(refs, "lineup", [uuid.uuid4()])
         assert refs == snapshot
+
+    def test_preserves_track_excludes(self) -> None:
+        """Re-running a scope keeps the global exclude_track_ids set."""
+        core = uuid.uuid4()
+        t1, t2 = uuid.uuid4(), uuid.uuid4()
+        refs = pool_module.serialize_input_references(
+            [pool_module.ArtistSource(artist_id=core)],
+            exclude_track_ids=[t1, t2],
+        )
+        out = pool_module.replace_via_seed_sources(refs, "lineup", [uuid.uuid4()])
+        assert pool_module.extract_track_excludes(out) == {t1, t2}
+
+
+class TestExtractTrackExcludes:
+    """extract_track_excludes (#track-exclude)."""
+
+    def test_missing_yields_empty_set(self) -> None:
+        assert pool_module.extract_track_excludes({}) == set()
+
+    def test_parses_uuid_list(self) -> None:
+        a, b = uuid.uuid4(), uuid.uuid4()
+        result = pool_module.extract_track_excludes(
+            {"exclude_track_ids": [str(a), str(b)]}
+        )
+        assert result == {a, b}
+
+    def test_not_a_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="exclude_track_ids"):
+            pool_module.extract_track_excludes({"exclude_track_ids": str(uuid.uuid4())})
+
+    def test_bad_uuid_raises(self) -> None:
+        with pytest.raises(ValueError, match="exclude_track_ids"):
+            pool_module.extract_track_excludes({"exclude_track_ids": ["nope"]})
+
+    def test_serialize_round_trip(self) -> None:
+        """serialize emits exclude_track_ids only when non-empty, round-trips."""
+        t1 = uuid.uuid4()
+        with_excl = pool_module.serialize_input_references([], exclude_track_ids=[t1])
+        assert pool_module.extract_track_excludes(with_excl) == {t1}
+        # Empty stays lean (no key) — preserves existing profile shape.
+        without = pool_module.serialize_input_references([])
+        assert "exclude_track_ids" not in without

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -228,3 +228,37 @@ class TestComponentPlayground:
         response = await client.get("/dev/components", follow_redirects=False)
         assert response.status_code == 307
         assert response.headers["location"] == "/login"
+
+
+class TestPlaylistRefineRoutes:
+    """The track-exclude / regenerate refine actions require auth (#track-exclude)."""
+
+    async def test_toggle_exclude_requires_auth(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.post(
+            "/playlists/00000000-0000-0000-0000-000000000001/tracks/"
+            "00000000-0000-0000-0000-000000000002/toggle-exclude",
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        assert response.headers["location"] == "/login"
+
+    async def test_regenerate_requires_auth(self, client: httpx.AsyncClient) -> None:
+        response = await client.post(
+            "/playlists/00000000-0000-0000-0000-000000000001/regenerate",
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        assert response.headers["location"] == "/login"
+
+    async def test_exclude_unsynced_requires_auth(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.post(
+            "/playlists/00000000-0000-0000-0000-000000000001/"
+            "exclude-unsynced-and-regenerate",
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        assert response.headers["location"] == "/login"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2929,6 +2929,372 @@ class TestScoreAndBuildPlaylist:
         assert parent_task.status == types_module.SyncStatus.COMPLETED
         assert parent_task.completed_at is not None
 
+    @pytest.mark.asyncio
+    async def test_regenerate_in_place_uses_snapshot_baseline(self) -> None:
+        """CRITICAL (#versions): a regenerate reuses the current Playlist row in
+        place and reads its freshness baseline from the latest
+        GenerationRecord.track_snapshot -- NOT the live PlaylistTrack rows it is
+        about to overwrite. Reading the live rows would compare the new selection
+        against itself (self-poison) and silently break the freshness target.
+
+        Also asserts the in-place contract: the existing Playlist is reused (no new
+        row), its old tracks are deleted, and a fresh track_snapshot is recorded.
+        """
+        import resonance.generators.concert_prep as concert_prep_module
+        import resonance.models.generator as generator_models
+        import resonance.models.music as music_models
+        import resonance.models.playlist as playlist_models
+
+        task_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        profile_id = uuid.uuid4()
+        event_id = uuid.uuid4()
+        artist_id = uuid.uuid4()
+        track_id = uuid.uuid4()
+        existing_pl_id = uuid.uuid4()
+        snap_a = uuid.uuid4()
+        snap_b = uuid.uuid4()
+
+        task = task_module.Task(
+            id=task_id,
+            user_id=user_id,
+            parent_id=parent_id,
+            task_type=types_module.TaskType.TRACK_SCORING,
+            status=types_module.SyncStatus.PENDING,
+            params={"profile_id": str(profile_id), "event_id": str(event_id)},
+        )
+        parent_task = task_module.Task(
+            id=parent_id,
+            user_id=user_id,
+            task_type=types_module.TaskType.PLAYLIST_GENERATION,
+            status=types_module.SyncStatus.RUNNING,
+            params={
+                "profile_id": str(profile_id),
+                "max_tracks": 30,
+                "freshness_target": 100,
+            },
+        )
+
+        session = AsyncMock()
+        arq_redis = AsyncMock()
+
+        task_result_mock = MagicMock()
+        task_result_mock.scalar_one_or_none.return_value = task
+
+        profile = MagicMock(spec=generator_models.GeneratorProfile)
+        profile.id = profile_id
+        profile.user_id = user_id
+        profile.name = "Concert"
+        profile.parameter_values = {"familiarity": 70, "hit_depth": 40}
+        profile.input_references = {"event_id": str(event_id)}
+        profile_result = MagicMock()
+        profile_result.scalar_one_or_none.return_value = profile
+
+        import resonance.models.concert as concert_models
+
+        ea = MagicMock(spec=concert_models.EventArtist)
+        ea.artist_id = artist_id
+        ea_scalars = MagicMock()
+        ea_scalars.all.return_value = [ea]
+        ea_result = MagicMock()
+        ea_result.scalars.return_value = ea_scalars
+        eac_scalars = MagicMock()
+        eac_scalars.all.return_value = []
+        eac_result = MagicMock()
+        eac_result.scalars.return_value = eac_scalars
+
+        parent_for_params_result = MagicMock()
+        parent_for_params_result.scalar_one_or_none.return_value = parent_task
+
+        mock_track = MagicMock(spec=music_models.Track)
+        mock_track.id = track_id
+        mock_track.title = "Song"
+        mock_track.artist_id = artist_id
+        mock_track.popularity_score = None
+        mock_artist = MagicMock(spec=music_models.Artist)
+        mock_artist.id = artist_id
+        mock_artist.name = "Artist"
+        mock_track.artist = mock_artist
+        track_scalars = MagicMock()
+        track_scalars.all.return_value = [mock_track]
+        track_result = MagicMock()
+        track_result.scalars.return_value = track_scalars
+
+        listen_result = MagicMock()
+        listen_result.all.return_value = [(track_id, 10)]
+        utr_scalars = MagicMock()
+        utr_scalars.all.return_value = []
+        utr_result = MagicMock()
+        utr_result.scalars.return_value = utr_scalars
+
+        # Latest GenerationRecord carries a track_snapshot -> the freshness baseline.
+        # If the code wrongly read live PlaylistTrack rows instead, no mock is
+        # provided for that query and the side_effect would misalign -- the test
+        # would fail rather than pass on a self-poisoned baseline.
+        prev_gen = MagicMock(spec=generator_models.GenerationRecord)
+        prev_gen.playlist_id = existing_pl_id
+        prev_gen.track_snapshot = [str(snap_a), str(snap_b)]
+        prev_gen_result = MagicMock()
+        prev_gen_result.scalar_one_or_none.return_value = prev_gen
+
+        existing_playlist = playlist_models.Playlist(
+            id=existing_pl_id,
+            user_id=user_id,
+            name="old name",
+            description="old",
+            track_count=2,
+        )
+        session.get = AsyncMock(return_value=existing_playlist)
+
+        delete_result = MagicMock()
+        pending_count_mock = MagicMock()
+        pending_count_mock.scalar_one.return_value = 0
+        parent_result_mock = MagicMock()
+        parent_result_mock.scalar_one_or_none.return_value = parent_task
+        failed_count_mock = MagicMock()
+        failed_count_mock.scalar_one.return_value = 0
+        children_scalars_mock = MagicMock()
+        children_scalars_mock.all.return_value = [task]
+        children_result_mock = MagicMock()
+        children_result_mock.scalars.return_value = children_scalars_mock
+
+        session.execute.side_effect = [
+            task_result_mock,
+            _not_cancelled_result(parent_id),
+            profile_result,
+            ea_result,
+            eac_result,
+            parent_for_params_result,
+            track_result,
+            listen_result,
+            utr_result,
+            prev_gen_result,
+            delete_result,  # in-place PlaylistTrack delete
+            pending_count_mock,
+            parent_result_mock,
+            failed_count_mock,
+            children_result_mock,
+        ]
+
+        captured: dict[str, Any] = {}
+
+        def _fake_select(**kwargs: Any) -> concert_prep_module.SelectionResult:
+            captured.update(kwargs)
+            return concert_prep_module.SelectionResult(
+                tracks=[
+                    concert_prep_module.ScoredTrack(
+                        track_id=track_id,
+                        title="Song",
+                        artist_name="Artist",
+                        position=1,
+                        score=1.0,
+                        source=types_module.TrackSource.LIBRARY,
+                    )
+                ],
+                sources_summary={types_module.TrackSource.LIBRARY: 1},
+                freshness_actual=100.0,
+            )
+
+        ctx: dict[str, Any] = {
+            "session_factory": _mock_session_factory(session),
+            "connector_registry": MagicMock(),
+            "redis": arq_redis,
+        }
+
+        with patch.object(
+            worker_module.concert_prep_module, "score_and_select", _fake_select
+        ):
+            await worker_module.score_and_build_playlist(ctx, str(task_id))
+
+        # 1. Freshness baseline is the snapshot, not the (overwritten) live rows.
+        assert captured["previous_track_ids"] == {snap_a, snap_b}
+
+        added_objects = [c.args[0] for c in session.add.call_args_list]
+        # 2. In place: no NEW Playlist row was added (the existing one is reused).
+        playlists_added = [
+            o for o in added_objects if isinstance(o, playlist_models.Playlist)
+        ]
+        assert playlists_added == []
+        # 3. The existing playlist was updated in place.
+        assert existing_playlist.track_count == 1
+        assert existing_playlist.name == "Concert"
+        # 4. Its old tracks were deleted (Core delete against playlist_tracks).
+        assert any(
+            c.args and type(c.args[0]).__name__ == "Delete"
+            for c in session.execute.call_args_list
+        )
+        # 5. A fresh track_snapshot was recorded for the new version.
+        gen_records = [
+            o for o in added_objects if isinstance(o, generator_models.GenerationRecord)
+        ]
+        assert len(gen_records) == 1
+        assert gen_records[0].track_snapshot == [str(track_id)]
+
+    @pytest.mark.asyncio
+    async def test_excluded_tracks_filtered_from_candidates(self) -> None:
+        """#track-exclude: a track listed in exclude_track_ids never becomes a
+        candidate, so its band deals its next-best and the freed slot refills."""
+        import resonance.generators.concert_prep as concert_prep_module
+        import resonance.models.generator as generator_models
+        import resonance.models.music as music_models
+
+        task_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        profile_id = uuid.uuid4()
+        event_id = uuid.uuid4()
+        artist_id = uuid.uuid4()
+        excluded_id = uuid.uuid4()
+        kept_id = uuid.uuid4()
+
+        task = task_module.Task(
+            id=task_id,
+            user_id=user_id,
+            parent_id=parent_id,
+            task_type=types_module.TaskType.TRACK_SCORING,
+            status=types_module.SyncStatus.PENDING,
+            params={"profile_id": str(profile_id), "event_id": str(event_id)},
+        )
+        parent_task = task_module.Task(
+            id=parent_id,
+            user_id=user_id,
+            task_type=types_module.TaskType.PLAYLIST_GENERATION,
+            status=types_module.SyncStatus.RUNNING,
+            params={
+                "profile_id": str(profile_id),
+                "max_tracks": 30,
+                "freshness_target": None,
+            },
+        )
+
+        session = AsyncMock()
+        arq_redis = AsyncMock()
+
+        task_result_mock = MagicMock()
+        task_result_mock.scalar_one_or_none.return_value = task
+
+        profile = MagicMock(spec=generator_models.GeneratorProfile)
+        profile.id = profile_id
+        profile.user_id = user_id
+        profile.name = "Concert"
+        profile.parameter_values = {"familiarity": 70, "hit_depth": 40}
+        # The recipe excludes one track.
+        profile.input_references = {
+            "event_id": str(event_id),
+            "exclude_track_ids": [str(excluded_id)],
+        }
+        profile_result = MagicMock()
+        profile_result.scalar_one_or_none.return_value = profile
+
+        import resonance.models.concert as concert_models
+
+        ea = MagicMock(spec=concert_models.EventArtist)
+        ea.artist_id = artist_id
+        ea_scalars = MagicMock()
+        ea_scalars.all.return_value = [ea]
+        ea_result = MagicMock()
+        ea_result.scalars.return_value = ea_scalars
+        eac_scalars = MagicMock()
+        eac_scalars.all.return_value = []
+        eac_result = MagicMock()
+        eac_result.scalars.return_value = eac_scalars
+
+        parent_for_params_result = MagicMock()
+        parent_for_params_result.scalar_one_or_none.return_value = parent_task
+
+        def _mk_track(tid: uuid.UUID, title: str) -> MagicMock:
+            t = MagicMock(spec=music_models.Track)
+            t.id = tid
+            t.title = title
+            t.artist_id = artist_id
+            t.popularity_score = None
+            a = MagicMock(spec=music_models.Artist)
+            a.id = artist_id
+            a.name = "Artist"
+            t.artist = a
+            return t
+
+        track_scalars = MagicMock()
+        track_scalars.all.return_value = [
+            _mk_track(excluded_id, "Excluded"),
+            _mk_track(kept_id, "Kept"),
+        ]
+        track_result = MagicMock()
+        track_result.scalars.return_value = track_scalars
+
+        listen_result = MagicMock()
+        listen_result.all.return_value = [(excluded_id, 5), (kept_id, 5)]
+        utr_scalars = MagicMock()
+        utr_scalars.all.return_value = []
+        utr_result = MagicMock()
+        utr_result.scalars.return_value = utr_scalars
+
+        prev_gen_result = MagicMock()
+        prev_gen_result.scalar_one_or_none.return_value = None
+
+        pending_count_mock = MagicMock()
+        pending_count_mock.scalar_one.return_value = 0
+        parent_result_mock = MagicMock()
+        parent_result_mock.scalar_one_or_none.return_value = parent_task
+        failed_count_mock = MagicMock()
+        failed_count_mock.scalar_one.return_value = 0
+        children_scalars_mock = MagicMock()
+        children_scalars_mock.all.return_value = [task]
+        children_result_mock = MagicMock()
+        children_result_mock.scalars.return_value = children_scalars_mock
+
+        session.execute.side_effect = [
+            task_result_mock,
+            _not_cancelled_result(parent_id),
+            profile_result,
+            ea_result,
+            eac_result,
+            parent_for_params_result,
+            track_result,
+            listen_result,
+            utr_result,
+            prev_gen_result,
+            pending_count_mock,
+            parent_result_mock,
+            failed_count_mock,
+            children_result_mock,
+        ]
+
+        captured: dict[str, Any] = {}
+
+        def _fake_select(**kwargs: Any) -> concert_prep_module.SelectionResult:
+            captured.update(kwargs)
+            return concert_prep_module.SelectionResult(
+                tracks=[
+                    concert_prep_module.ScoredTrack(
+                        track_id=kept_id,
+                        title="Kept",
+                        artist_name="Artist",
+                        position=1,
+                        score=1.0,
+                        source=types_module.TrackSource.LIBRARY,
+                    )
+                ],
+                sources_summary={types_module.TrackSource.LIBRARY: 1},
+                freshness_actual=None,
+            )
+
+        ctx: dict[str, Any] = {
+            "session_factory": _mock_session_factory(session),
+            "connector_registry": MagicMock(),
+            "redis": arq_redis,
+        }
+
+        with patch.object(
+            worker_module.concert_prep_module, "score_and_select", _fake_select
+        ):
+            await worker_module.score_and_build_playlist(ctx, str(task_id))
+
+        candidate_ids = {c.track_id for c in captured["candidates"]}
+        assert excluded_id not in candidate_ids
+        assert kept_id in candidate_ids
+
 
 # ---------------------------------------------------------------------------
 # ExportPlaylist tests

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4016,7 +4016,8 @@ class TestEnrichRelatedArtists:
         assert task.result["message"] == "no connector connected"
 
     @pytest.mark.asyncio
-    async def test_lineup_success_replaces_scope(self) -> None:
+    async def test_lineup_tops_up_empty_scope(self) -> None:
+        # Empty discovery scope: top-up from 0 fills it with the full batch.
         core_id = uuid.uuid4()
         new1, new2 = uuid.uuid4(), uuid.uuid4()
         profile = generator_models.GeneratorProfile(
@@ -4208,3 +4209,191 @@ class TestEnrichRelatedArtists:
         assert by_id[editor_id] is None  # concurrent edit NOT clobbered
         assert by_id[new_id] == "lineup"  # enrichment applied
         session.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_top_up_fetches_only_the_difference_and_appends(self) -> None:
+        """A scope with prior discoveries tops up to N: fetch only N - active and
+        append (keep the priors), never replace them."""
+        seed_id = uuid.uuid4()
+        prior1, prior2 = uuid.uuid4(), uuid.uuid4()
+        new1, new2 = uuid.uuid4(), uuid.uuid4()
+        profile = generator_models.GeneratorProfile(
+            user_id=uuid.uuid4(),
+            name="P",
+            generator_type=types_module.GeneratorType.CONCERT_PREP,
+            input_references=pool_module.serialize_input_references(
+                [
+                    pool_module.ArtistSource(artist_id=seed_id),
+                    pool_module.ArtistSource(artist_id=prior1, via_seed=str(seed_id)),
+                    pool_module.ArtistSource(artist_id=prior2, via_seed=str(seed_id)),
+                ]
+            ),
+        )
+        task = _enrich_task(
+            {"profile_id": str(uuid.uuid4()), "seed_artist_ids": [str(seed_id)], "n": 4}
+        )
+        seed_artist = _artist_ns("Seed", id=seed_id)
+        session = AsyncMock()
+        task_res = MagicMock()
+        task_res.scalar_one_or_none.return_value = task
+        profile_res = MagicMock()
+        profile_res.scalar_one_or_none.return_value = profile
+        artists_res = MagicMock()
+        artists_res.scalars.return_value.all.return_value = [seed_artist]
+        session.execute.side_effect = [task_res, profile_res, artists_res]
+
+        collect = AsyncMock(return_value=[new1, new2])
+        with (
+            patch.object(
+                worker_module,
+                "resolve_pool",
+                AsyncMock(
+                    return_value=[
+                        pool_module.ResolvedArtist(
+                            artist_id=aid, via=pool_module.PoolProvenance.ARTIST
+                        )
+                        for aid in (seed_id, prior1, prior2)
+                    ]
+                ),
+            ),
+            patch.object(worker_module, "_collect_related", collect),
+        ):
+            await worker_module.enrich_related_artists(
+                _enrich_ctx(session), str(task.id or uuid.uuid4())
+            )
+
+        assert task.status == types_module.SyncStatus.COMPLETED
+        # 4 wanted, 2 active already -> only 2 fetched (the difference).
+        assert collect.await_args.args[5] == 2
+        assert task.result["found"] == 2
+        assert task.progress_total == 2
+        # Priors are re-excluded from re-discovery (top-up appends, never re-finds).
+        exclude_arg = collect.await_args.args[4]
+        assert prior1 in exclude_arg
+        assert prior2 in exclude_arg
+        # Scope now holds priors AND new -- appended, not replaced.
+        scope_ids = set(
+            pool_module.scope_artist_ids(profile.input_references, str(seed_id))
+        )
+        assert scope_ids == {prior1, prior2, new1, new2}
+
+    @pytest.mark.asyncio
+    async def test_over_count_scope_is_noop(self) -> None:
+        """A scope already at or over N active is a no-op: no fetch, no trim."""
+        seed_id = uuid.uuid4()
+        p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        profile = generator_models.GeneratorProfile(
+            user_id=uuid.uuid4(),
+            name="P",
+            generator_type=types_module.GeneratorType.CONCERT_PREP,
+            input_references=pool_module.serialize_input_references(
+                [
+                    pool_module.ArtistSource(artist_id=seed_id),
+                    pool_module.ArtistSource(artist_id=p1, via_seed=str(seed_id)),
+                    pool_module.ArtistSource(artist_id=p2, via_seed=str(seed_id)),
+                    pool_module.ArtistSource(artist_id=p3, via_seed=str(seed_id)),
+                ]
+            ),
+        )
+        task = _enrich_task(
+            {"profile_id": str(uuid.uuid4()), "seed_artist_ids": [str(seed_id)], "n": 2}
+        )
+        seed_artist = _artist_ns("Seed", id=seed_id)
+        session = AsyncMock()
+        task_res = MagicMock()
+        task_res.scalar_one_or_none.return_value = task
+        profile_res = MagicMock()
+        profile_res.scalar_one_or_none.return_value = profile
+        artists_res = MagicMock()
+        artists_res.scalars.return_value.all.return_value = [seed_artist]
+        session.execute.side_effect = [task_res, profile_res, artists_res]
+
+        collect = AsyncMock(return_value=[uuid.uuid4()])
+        with (
+            patch.object(
+                worker_module,
+                "resolve_pool",
+                AsyncMock(
+                    return_value=[
+                        pool_module.ResolvedArtist(
+                            artist_id=aid, via=pool_module.PoolProvenance.ARTIST
+                        )
+                        for aid in (seed_id, p1, p2, p3)
+                    ]
+                ),
+            ),
+            patch.object(worker_module, "_collect_related", collect),
+        ):
+            await worker_module.enrich_related_artists(
+                _enrich_ctx(session), str(task.id or uuid.uuid4())
+            )
+
+        assert task.status == types_module.SyncStatus.COMPLETED
+        collect.assert_not_awaited()  # nothing fetched
+        assert task.result["found"] == 0
+        assert task.result["message"] == "scopes already at target"
+        # Discoveries are untouched -- never trimmed.
+        scope_ids = set(
+            pool_module.scope_artist_ids(profile.input_references, str(seed_id))
+        )
+        assert scope_ids == {p1, p2, p3}
+
+    @pytest.mark.asyncio
+    async def test_excluded_artist_not_counted_or_resuggested(self) -> None:
+        """An excluded discovery does not count toward active and is never
+        re-suggested: it is passed in the exclude set and the top-up refetches to
+        replace its missing slot."""
+        seed_id = uuid.uuid4()
+        disc1, disc2 = uuid.uuid4(), uuid.uuid4()  # disc2 is excluded
+        new1 = uuid.uuid4()
+        profile = generator_models.GeneratorProfile(
+            user_id=uuid.uuid4(),
+            name="P",
+            generator_type=types_module.GeneratorType.CONCERT_PREP,
+            input_references=pool_module.serialize_input_references(
+                [
+                    pool_module.ArtistSource(artist_id=seed_id),
+                    pool_module.ArtistSource(artist_id=disc1, via_seed=str(seed_id)),
+                    pool_module.ArtistSource(artist_id=disc2, via_seed=str(seed_id)),
+                ],
+                exclude_ids=[disc2],
+            ),
+        )
+        task = _enrich_task(
+            {"profile_id": str(uuid.uuid4()), "seed_artist_ids": [str(seed_id)], "n": 2}
+        )
+        seed_artist = _artist_ns("Seed", id=seed_id)
+        session = AsyncMock()
+        task_res = MagicMock()
+        task_res.scalar_one_or_none.return_value = task
+        profile_res = MagicMock()
+        profile_res.scalar_one_or_none.return_value = profile
+        artists_res = MagicMock()
+        artists_res.scalars.return_value.all.return_value = [seed_artist]
+        session.execute.side_effect = [task_res, profile_res, artists_res]
+
+        collect = AsyncMock(return_value=[new1])
+        with (
+            patch.object(
+                worker_module,
+                "resolve_pool",
+                AsyncMock(
+                    return_value=[
+                        pool_module.ResolvedArtist(
+                            artist_id=aid, via=pool_module.PoolProvenance.ARTIST
+                        )
+                        for aid in (seed_id, disc1, disc2)
+                    ]
+                ),
+            ),
+            patch.object(worker_module, "_collect_related", collect),
+        ):
+            await worker_module.enrich_related_artists(
+                _enrich_ctx(session), str(task.id or uuid.uuid4())
+            )
+
+        assert task.status == types_module.SyncStatus.COMPLETED
+        # 2 wanted, only disc1 active (disc2 excluded) -> 1 fetched.
+        assert collect.await_args.args[5] == 1
+        # The excluded artist is in the exclude set -> never re-suggested.
+        assert disc2 in collect.await_args.args[4]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3318,6 +3318,102 @@ class TestExportPlaylist:
         ]
         assert job_name == "export_playlist"
 
+    @pytest.mark.asyncio
+    async def test_export_stamps_per_track_sync_status(self) -> None:
+        """A successful export stamps spotify_synced_at on matched tracks and
+        clears it on unmatched ones (#spotify-sync-visibility)."""
+        import resonance.connectors.spotify as spotify_module
+        import resonance.models.playlist as playlist_models
+        import resonance.models.user as user_models
+
+        task_id = uuid.uuid4()
+        playlist_id = uuid.uuid4()
+        connection_id = uuid.uuid4()
+
+        task = task_module.Task(
+            id=task_id,
+            user_id=uuid.uuid4(),
+            parent_id=None,  # no parent -> skips is_cancelled query + parent check
+            task_type=types_module.TaskType.PLAYLIST_EXPORT,
+            status=types_module.SyncStatus.PENDING,
+            params={
+                "playlist_id": str(playlist_id),
+                "connection_id": str(connection_id),
+            },
+        )
+
+        # Two tracks: one already has a cached Spotify id (matches), one has no id
+        # and search will fail (skipped).
+        def _pt(spotify_id: str | None) -> MagicMock:
+            track = MagicMock()
+            track.title = "Song"
+            track.service_links = {"spotify": spotify_id} if spotify_id else {}
+            track.artist = MagicMock()
+            track.artist.name = "Artist"
+            pt = MagicMock(spec=playlist_models.PlaylistTrack)
+            pt.track = track
+            pt.track_id = uuid.uuid4()
+            pt.spotify_synced_at = None
+            return pt
+
+        matched_pt = _pt("abc123")
+        unmatched_pt = _pt(None)
+
+        playlist = MagicMock(spec=playlist_models.Playlist)
+        playlist.id = playlist_id
+        playlist.name = "PL"
+        playlist.description = ""
+        playlist.service_links = None
+        playlist.tracks = [matched_pt, unmatched_pt]
+
+        connection = MagicMock(spec=user_models.ServiceConnection)
+        connection.encrypted_access_token = b"enc"
+        connection.encrypted_refresh_token = None
+        connection.token_expires_at = None
+
+        session = AsyncMock()
+        task_res = MagicMock()
+        task_res.scalar_one_or_none.return_value = task
+        playlist_res = MagicMock()
+        playlist_res.scalar_one_or_none.return_value = playlist
+        conn_res = MagicMock()
+        conn_res.scalar_one_or_none.return_value = connection
+        session.execute.side_effect = [task_res, playlist_res, conn_res]
+
+        spotify_conn = MagicMock(spec=spotify_module.SpotifyConnector)
+        spotify_conn.search_track = AsyncMock(return_value=None)  # unmatched fails
+        spotify_conn.create_playlist = AsyncMock(return_value="sp_playlist")
+        spotify_conn.add_tracks_to_playlist = AsyncMock()
+        spotify_conn.replace_playlist_tracks = AsyncMock()
+
+        registry = MagicMock()
+
+        def _get_base(stype: Any) -> Any:
+            if stype == types_module.ServiceType.SPOTIFY:
+                return spotify_conn
+            return None  # no ListenBrainz -> skip the MB pass
+
+        registry.get_base_connector.side_effect = _get_base
+
+        ctx: dict[str, Any] = {
+            "session_factory": _mock_session_factory(session),
+            "connector_registry": registry,
+            "settings": MagicMock(),
+            "redis": AsyncMock(),
+        }
+
+        with patch.object(
+            worker_module.crypto_module, "decrypt_token", lambda *_a, **_k: "access"
+        ):
+            await worker_module.export_playlist(ctx, str(task_id))
+
+        assert task.status == types_module.SyncStatus.COMPLETED
+        # Matched track stamped; unmatched cleared.
+        assert matched_pt.spotify_synced_at is not None
+        assert unmatched_pt.spotify_synced_at is None
+        # The completion payload reports which track ids synced.
+        assert task.result["synced_track_ids"] == [str(matched_pt.track_id)]
+
 
 class TestArtistsNeedingDiscovery:
     """Gating for which target artists get an external catalog fetch (#110)."""


### PR DESCRIPTION
## Summary

Two linked fixes surfaced while dogfooding concert-prep playlists.

1. **The seed band was buried.** Seeding Slipknot + 10 discovered neighbors at high familiarity produced a 50-track playlist with **49 neighbor tracks and 1 Slipknot track** — the old selection (round-0 + pure-score fill) let heavy-rotation neighbors monopolize every slot. Selection is now **weighted round-robin**: every artist on the bill gets an even share; `composite_score` (familiarity/hit_depth) decides WHICH of an artist's tracks fill its slots, round-robin decides HOW MANY. A short band's slack redistributes; `weight` is a real plumbed seam (default 1 = even) for future seed/headliner emphasis. (Reverses the no-quota decision from #128.)

2. **No refinement loop.** A generated playlist is now a living recipe: edit it from the playlist itself, exclude a dud track and have the slot refill on regenerate, top up related artists after excluding some, and see/repair which tracks failed to sync to Spotify.

Regenerate is **in place on the same Playlist row** (the Spotify export anchor survives); each generation's track list is snapshotted on `GenerationRecord.track_snapshot` as durable version history, which is also the freshness baseline for the next run (reading the live rows it's about to overwrite would self-poison freshness).

<details>
<summary>How to Review</summary>

9 logical commits, build it commit-by-commit:

1. **Data model** (`18fc2ac`) — `GenerationRecord.track_snapshot`, `PlaylistTrack.spotify_synced_at`, `exclude_track_ids` parse/serialize, migration `q8r9s0t1u2v3`.
2. **Round-robin selection** (`9d1ec86`) — `concert_prep._select_one_pool` rewritten; reverses #128. Tests cover even split, short-band redistribution, the weights seam, `max_tracks<n`, single-artist, familiarity-within-artist.
3. **Regenerate-in-place + snapshot + freshness fix** (`36582f7`) — the critical self-poison fix has a dedicated regression test.
4. **Enrich top-up-to-N-active** (`666b7a6`) — replace → top-up; counts active, fetches the difference, appends, skips excluded.
5. **API + CLI** (`a10b3de`) — exclude_track_ids validation; `resonance-api profile exclude-track ... [--regenerate]`.
6. **Edit button** (`3274a28`) — playlist → recipe editor.
7. **Export sync persistence** (`4a4b77d`) — stamps `spotify_synced_at` per track.
8. **Refine UI** (`d5c353f`) — per-row ✕ exclude, sync badges, Regenerate + "exclude unsynced & regenerate".
9. **Docs** (`333938a`) — CLAUDE.md conventions.

Suggested order: 1 → 2 → 3 are the core; 4–9 build the refine loop on top.
</details>

<details>
<summary>Test Plan</summary>

- [x] Full suite green (1569 passed), ruff + mypy strict clean
- [x] Round-robin selection: even split, short-band redistribution, weights seam, edge cases (unit)
- [x] CRITICAL freshness-ordering regression (reads snapshot, not the row being overwritten)
- [x] Exclude-then-regenerate filters candidates; enrich top-up / over-count / excluded-skip
- [x] Export stamps per-track sync status; `with_track_excludes` set/clear/dedup
- [x] New refine routes auth-gated; app boots against dev DB, migration at head, templates compile
- [ ] Post-deploy live QA against the Slipknot repro profile (round-robin distribution, exclude+regenerate, sync badges)
</details>

<details>
<summary>Impact</summary>

- Reverses #128's no-quota fill; depends on #133 (enrich, optimistic versioning) and #137 (lineup builder).
- Migration `q8r9s0t1u2v3` runs as the deploy init container (additive columns; rollback-safe).
- Version browse/restore UI, seed/headliner weight values, and auto-converging Spotify sync are deferred (data + seams shipped).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)