### PR TITLE
fix(security): block SSRF in iCal feed fetch (#141, finding #1)

### DIFF
--- a/src/resonance/concerts/url_safety.py
+++ b/src/resonance/concerts/url_safety.py
@@ -1,0 +1,171 @@
+"""SSRF guard for user-supplied feed URLs (security review #141, finding #1).
+
+An authenticated USER can register an iCal feed URL, which a background task then
+fetches. Without validation that URL could point at cloud metadata
+(``169.254.169.254``), loopback, or any cluster-internal service — a classic SSRF.
+
+``fetch_feed`` is the single safe entry point. It:
+
+- allows only ``http`` / ``https`` schemes,
+- resolves the host and rejects any private/loopback/link-local/reserved/
+  multicast/unspecified address (covering ``169.254.169.254`` and IPv4-mapped
+  IPv6 smuggling),
+- **pins** the connection to a validated IP while keeping the real hostname for
+  the ``Host`` header and TLS SNI, so a DNS-rebind between validation and connect
+  cannot redirect us to an internal address,
+- sets an explicit timeout, refuses redirects, and caps the response size.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+import httpx
+
+# Security floors. Intentionally constants, not config — these are a safety
+# baseline for fetching untrusted URLs, not per-deployment tunables.
+MAX_FEED_BYTES = 10 * 1024 * 1024  # 10 MiB
+_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0)
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+class UnsafeFeedURLError(ValueError):
+    """A feed URL uses a disallowed scheme or targets a non-public address."""
+
+
+def is_public_address(ip: IPAddress) -> bool:
+    """True only for globally routable addresses safe to fetch from a server.
+
+    Rejects loopback, private (RFC1918 / ULA), link-local (incl. the cloud
+    metadata endpoint ``169.254.169.254``), multicast, reserved, and the
+    unspecified address. IPv4-mapped IPv6 addresses are unwrapped and
+    re-checked so a private v4 target can't be smuggled inside a v6 wrapper.
+    """
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return is_public_address(ip.ipv4_mapped)
+    return not (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def resolve_safe_addresses(host: str, port: int) -> list[tuple[int, str]]:
+    """Resolve ``host`` and return ``(family, ip)`` for its public addresses.
+
+    Raises ``UnsafeFeedURLError`` if the host cannot be resolved or resolves to
+    no public address (so a host that points only at private space is blocked).
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeFeedURLError(f"cannot resolve host: {host}") from exc
+
+    safe: list[tuple[int, str]] = []
+    for family, _socktype, _proto, _canon, sockaddr in infos:
+        ip_str = str(sockaddr[0]).split("%", 1)[0]  # drop any IPv6 scope id
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if is_public_address(ip):
+            safe.append((family, ip_str))
+
+    if not safe:
+        raise UnsafeFeedURLError(f"host resolves only to non-public addresses: {host}")
+    return safe
+
+
+def _validated_target(url: httpx.URL) -> tuple[str, str | None]:
+    """Validate scheme/host and return ``(connect_ip, sni_hostname)``.
+
+    ``sni_hostname`` is ``None`` when the URL already targets a literal IP (no
+    rebinding is possible, so no host/SNI rewrite is needed); otherwise it is the
+    original hostname to preserve for the ``Host`` header and TLS verification.
+    """
+    scheme = url.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeFeedURLError(f"disallowed scheme: {scheme or '(none)'}")
+
+    host = url.host
+    if not host:
+        raise UnsafeFeedURLError("URL has no host")
+
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+
+    if literal_ip is not None:
+        if not is_public_address(literal_ip):
+            raise UnsafeFeedURLError(f"non-public address: {host}")
+        return host, None
+
+    port = url.port or _DEFAULT_PORTS[scheme]
+    safe = resolve_safe_addresses(host, port)
+    return safe[0][1], host
+
+
+async def fetch_feed(url: str, *, client: httpx.AsyncClient | None = None) -> str:
+    """Safely fetch a user-supplied feed URL and return its body as text.
+
+    Raises ``UnsafeFeedURLError`` for a disallowed scheme or non-public target
+    (before any network I/O), and ``httpx.HTTPStatusError`` on a 4xx/5xx
+    response. The response body is size-capped at ``MAX_FEED_BYTES``.
+
+    A ``client`` may be injected (tests); otherwise one is created with redirects
+    disabled and an explicit timeout. Redirects are refused regardless, since a
+    302 to an internal address would bypass the up-front validation.
+    """
+    parsed = httpx.URL(url)
+    connect_ip, sni_hostname = _validated_target(parsed)
+
+    if sni_hostname is None:
+        # Literal-IP target: already pinned, no rewrite needed.
+        request_url = parsed
+        headers: dict[str, str] = {}
+        extensions: dict[str, object] = {}
+    else:
+        # Hostname target: pin the connection to the validated IP, but keep the
+        # real hostname for routing (Host) and TLS verification (SNI).
+        request_url = parsed.copy_with(host=connect_ip)
+        host_header = sni_hostname
+        if parsed.port is not None:
+            host_header = f"{sni_hostname}:{parsed.port}"
+        headers = {"Host": host_header}
+        extensions = {"sni_hostname": sni_hostname}
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False)
+    try:
+        async with client.stream(
+            "GET",
+            request_url,
+            headers=headers,
+            extensions=extensions,
+            follow_redirects=False,
+            timeout=_TIMEOUT,
+        ) as response:
+            response.raise_for_status()
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > MAX_FEED_BYTES:
+                    raise UnsafeFeedURLError(
+                        f"feed exceeds size cap of {MAX_FEED_BYTES} bytes"
+                    )
+                chunks.append(chunk)
+            encoding = response.encoding or "utf-8"
+        return b"".join(chunks).decode(encoding, errors="replace")
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/src/resonance/concerts/worker.py
+++ b/src/resonance/concerts/worker.py
@@ -9,13 +9,13 @@ import typing
 import uuid
 from typing import Any
 
-import httpx
 import sqlalchemy as sa
 import structlog
 
 import resonance.concerts.concert_archives as concert_archives_module
 import resonance.concerts.ical as ical_module
 import resonance.concerts.sync as concert_sync
+import resonance.concerts.url_safety as url_safety_module
 import resonance.connectors.songkick as songkick_module
 import resonance.models.task as task_models
 import resonance.models.user as user_models
@@ -213,24 +213,22 @@ async def sync_calendar_feed(
             totals = EventProcessingResult()
             total_events = 0
 
-            async with httpx.AsyncClient() as client:
-                for url, feed_type in feed_items:
-                    log.info("fetching_feed", url=url, feed_type=feed_type.value)
-                    response = await client.get(url)
-                    response.raise_for_status()
+            for url, feed_type in feed_items:
+                log.info("fetching_feed", url=url, feed_type=feed_type.value)
+                # SSRF-guarded fetch: validates scheme + resolved IP and pins the
+                # connection to a public address (security review #141 / #1).
+                feed_body = await url_safety_module.fetch_feed(url)
 
-                    parsed_events = ical_module.parse_ical_feed(
-                        response.text, feed_type
-                    )
-                    total_events += len(parsed_events)
+                parsed_events = ical_module.parse_ical_feed(feed_body, feed_type)
+                total_events += len(parsed_events)
 
-                    batch = await _process_parsed_events(
-                        session, parsed_events, source_service, connection.user_id
-                    )
-                    totals.events_created += batch.events_created
-                    totals.events_updated += batch.events_updated
-                    totals.candidates_created += batch.candidates_created
-                    totals.candidates_matched += batch.candidates_matched
+                batch = await _process_parsed_events(
+                    session, parsed_events, source_service, connection.user_id
+                )
+                totals.events_created += batch.events_created
+                totals.events_updated += batch.events_updated
+                totals.candidates_created += batch.candidates_created
+                totals.candidates_matched += batch.candidates_matched
 
             # Update connection last_synced_at
             connection.last_synced_at = datetime.datetime.now(datetime.UTC)

--- a/tests/test_concert_integration.py
+++ b/tests/test_concert_integration.py
@@ -12,7 +12,6 @@ import datetime
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
 
 import resonance.concerts.worker as concert_worker
@@ -131,19 +130,9 @@ def _setup_session_queries(
     session.execute.side_effect = [task_result, conn_result]
 
 
-def _setup_http_mock(mock_client_cls: MagicMock, ical_text: str) -> MagicMock:
-    """Configure httpx.AsyncClient mock to return given iCal text."""
-    mock_response = MagicMock(spec=httpx.Response)
-    mock_response.text = ical_text
-    mock_response.raise_for_status = MagicMock()
-
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get.return_value = mock_response
-    mock_client_cls.return_value = mock_client
-
-    return mock_response
+def _setup_http_mock(mock_fetch: AsyncMock, ical_text: str) -> None:
+    """Configure the SSRF-guarded fetch_feed mock to return given iCal text."""
+    mock_fetch.return_value = ical_text
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +153,10 @@ class TestFullSongkickSyncPipeline:
         ctx = _make_ctx(session)
 
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -190,7 +182,7 @@ class TestFullSongkickSyncPipeline:
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            _setup_http_mock(mock_client_cls, SAMPLE_SONGKICK_FEED)
+            _setup_http_mock(mock_fetch, SAMPLE_SONGKICK_FEED)
 
             mock_uvc.return_value = MagicMock()
             mock_rvc.return_value = MagicMock()
@@ -262,7 +254,10 @@ class TestIdempotentSync:
         ctx = _make_ctx(session)
 
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -286,7 +281,7 @@ class TestIdempotentSync:
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            _setup_http_mock(mock_client_cls, SAMPLE_SONGKICK_FEED)
+            _setup_http_mock(mock_fetch, SAMPLE_SONGKICK_FEED)
 
             mock_uvc.return_value = MagicMock()
             mock_rvc.return_value = MagicMock()
@@ -336,7 +331,10 @@ class TestGenericIcalSync:
         ctx = _make_ctx(session)
 
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -360,7 +358,7 @@ class TestGenericIcalSync:
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            _setup_http_mock(mock_client_cls, SAMPLE_GENERIC_ICAL)
+            _setup_http_mock(mock_fetch, SAMPLE_GENERIC_ICAL)
 
             mock_uec.return_value = MagicMock()
             mock_rec.return_value = (MagicMock(), True)
@@ -404,7 +402,10 @@ class TestGenericIcalSync:
         ctx = _make_ctx(session)
 
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch("resonance.concerts.worker.concert_sync.upsert_venue_candidate"),
             patch("resonance.concerts.worker.concert_sync.resolve_venue_candidate"),
             patch(
@@ -420,7 +421,7 @@ class TestGenericIcalSync:
             ) as mock_match,
             patch("resonance.concerts.worker.lifecycle_module.complete_task"),
         ):
-            _setup_http_mock(mock_client_cls, SAMPLE_GENERIC_ICAL)
+            _setup_http_mock(mock_fetch, SAMPLE_GENERIC_ICAL)
 
             mock_uec.return_value = MagicMock()
             mock_rec.return_value = (MagicMock(), True)

--- a/tests/test_concert_worker.py
+++ b/tests/test_concert_worker.py
@@ -147,12 +147,11 @@ class TestSyncCalendarFeedSongkick:
         _setup_session_queries(session, task, connection)
         ctx = _make_ctx(session)
 
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.text = _SAMPLE_ICAL
-        mock_response.raise_for_status = MagicMock()
-
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -176,11 +175,7 @@ class TestSyncCalendarFeedSongkick:
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get.return_value = mock_response
-            mock_client_cls.return_value = mock_client
+            mock_fetch.return_value = _SAMPLE_ICAL
 
             mock_uvc.return_value = MagicMock()
             mock_rvc.return_value = MagicMock()
@@ -194,12 +189,12 @@ class TestSyncCalendarFeedSongkick:
             )
 
             # Should fetch both URLs (attendance + tracked artist)
-            assert mock_client.get.await_count == 2
+            assert mock_fetch.await_count == 2
             expected_base = (
                 f"https://www.songkick.com/users/"
                 f"{connection.external_user_id}/calendars.ics"
             )
-            calls = [call.args[0] for call in mock_client.get.call_args_list]
+            calls = [call.args[0] for call in mock_fetch.call_args_list]
             assert calls[0] == f"{expected_base}?filter=attendance"
             assert calls[1] == f"{expected_base}?filter=tracked_artist"
 
@@ -260,12 +255,11 @@ UID:generic-evt-001
 END:VEVENT
 END:VCALENDAR
 """
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.text = ical_no_venue
-        mock_response.raise_for_status = MagicMock()
-
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -286,11 +280,7 @@ END:VCALENDAR
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get.return_value = mock_response
-            mock_client_cls.return_value = mock_client
+            mock_fetch.return_value = ical_no_venue
 
             mock_uec.return_value = MagicMock()
             mock_rec.return_value = (MagicMock(), True)
@@ -302,7 +292,7 @@ END:VCALENDAR
             )
 
             # Should fetch exactly the URL from the connection
-            mock_client.get.assert_awaited_once_with(ical_url)
+            mock_fetch.assert_awaited_once_with(ical_url)
 
             # Generic iCal with no venue: no venue candidate created
             mock_uvc.assert_not_awaited()
@@ -393,18 +383,17 @@ class TestSyncCalendarFeedLifecycle:
         ctx = _make_ctx(session)
 
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch("resonance.concerts.worker.lifecycle_module.fail_task") as mock_fail,
         ):
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get.side_effect = httpx.HTTPStatusError(
+            mock_fetch.side_effect = httpx.HTTPStatusError(
                 "Server Error",
                 request=MagicMock(spec=httpx.Request),
                 response=MagicMock(spec=httpx.Response, status_code=500),
             )
-            mock_client_cls.return_value = mock_client
 
             await concert_worker.sync_calendar_feed(
                 ctx, str(connection.id), str(task.id)
@@ -425,11 +414,14 @@ class TestSyncCalendarFeedLifecycle:
         session.execute.return_value = task_result
         ctx = _make_ctx(session)
 
-        with patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls:
+        with patch(
+            "resonance.concerts.worker.url_safety_module.fetch_feed",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
             await concert_worker.sync_calendar_feed(
                 ctx, str(uuid.uuid4()), str(uuid.uuid4())
             )
-            mock_client_cls.assert_not_called()
+            mock_fetch.assert_not_called()
 
     @pytest.mark.anyio()
     async def test_empty_calendar_completes_successfully(self) -> None:
@@ -440,12 +432,11 @@ class TestSyncCalendarFeedLifecycle:
         _setup_session_queries(session, task, connection)
         ctx = _make_ctx(session)
 
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.text = _EMPTY_ICAL
-        mock_response.raise_for_status = MagicMock()
-
         with (
-            patch("resonance.concerts.worker.httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "resonance.concerts.worker.url_safety_module.fetch_feed",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
             patch(
                 "resonance.concerts.worker.concert_sync.upsert_venue_candidate"
             ) as mock_uvc,
@@ -458,11 +449,7 @@ class TestSyncCalendarFeedLifecycle:
                 "resonance.concerts.worker.lifecycle_module.complete_task"
             ) as mock_complete,
         ):
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get.return_value = mock_response
-            mock_client_cls.return_value = mock_client
+            mock_fetch.return_value = _EMPTY_ICAL
 
             await concert_worker.sync_calendar_feed(
                 ctx, str(connection.id), str(task.id)

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,240 @@
+"""Tests for the SSRF guard on user-supplied feed URLs (security review #141 / #1).
+
+The guard must block an authenticated user from pointing a feed URL at cloud
+metadata (169.254.169.254), loopback, or any private/internal address, and must
+close the DNS-rebinding window by pinning the connection to a validated IP.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import resonance.concerts.url_safety as url_safety
+
+# ---------------------------------------------------------------------------
+# is_public_address — pure classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsPublicAddress:
+    """Classification of resolved IPs into public (allowed) vs not."""
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",  # example.com
+            "2606:4700:4700::1111",  # cloudflare v6
+        ],
+    )
+    def test_public_addresses_allowed(self, ip: str) -> None:
+        assert url_safety.is_public_address(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "::1",  # loopback v6
+            "10.0.0.5",  # private
+            "172.16.0.1",  # private
+            "192.168.1.1",  # private
+            "169.254.169.254",  # link-local / cloud metadata
+            "169.254.0.1",  # link-local
+            "0.0.0.0",  # unspecified
+            "224.0.0.1",  # multicast
+            "240.0.0.1",  # reserved
+            "fc00::1",  # ULA (private v6)
+            "fe80::1",  # link-local v6
+            "::",  # unspecified v6
+        ],
+    )
+    def test_non_public_addresses_rejected(self, ip: str) -> None:
+        assert url_safety.is_public_address(ipaddress.ip_address(ip)) is False
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "::ffff:169.254.169.254",  # IPv4-mapped cloud metadata
+            "::ffff:10.0.0.1",  # IPv4-mapped private
+        ],
+    )
+    def test_ipv4_mapped_v6_is_unwrapped_and_rejected(self, ip: str) -> None:
+        """An attacker can't smuggle a private v4 address inside a v6 wrapper."""
+        assert url_safety.is_public_address(ipaddress.ip_address(ip)) is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_safe_addresses — DNS resolution + filtering
+# ---------------------------------------------------------------------------
+
+
+def _addrinfo(*ips: str) -> list[tuple]:
+    """Build a getaddrinfo-shaped return value for the given IPs."""
+    out = []
+    for ip in ips:
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        sockaddr: tuple = (ip, 443, 0, 0) if ":" in ip else (ip, 443)
+        out.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+    return out
+
+
+class TestResolveSafeAddresses:
+    def test_returns_public_ips(self) -> None:
+        with patch.object(
+            url_safety.socket, "getaddrinfo", return_value=_addrinfo("8.8.8.8")
+        ):
+            safe = url_safety.resolve_safe_addresses("dns.google", 443)
+        assert "8.8.8.8" in {ip for _fam, ip in safe}
+
+    def test_rejects_host_resolving_only_to_private(self) -> None:
+        """A hostname that resolves to a private IP (DNS rebinding setup) is blocked."""
+        with (
+            patch.object(
+                url_safety.socket, "getaddrinfo", return_value=_addrinfo("10.0.0.5")
+            ),
+            pytest.raises(url_safety.UnsafeFeedURLError),
+        ):
+            url_safety.resolve_safe_addresses("evil.example.com", 443)
+
+    def test_filters_private_keeps_public_when_dual_homed(self) -> None:
+        """Only the public IP survives; we pin to it, never the private one."""
+        with patch.object(
+            url_safety.socket,
+            "getaddrinfo",
+            return_value=_addrinfo("10.0.0.5", "93.184.216.34"),
+        ):
+            safe = url_safety.resolve_safe_addresses("dual.example.com", 443)
+        ips = {ip for _fam, ip in safe}
+        assert "93.184.216.34" in ips
+        assert "10.0.0.5" not in ips
+
+    def test_unresolvable_host_raises(self) -> None:
+        with (
+            patch.object(
+                url_safety.socket, "getaddrinfo", side_effect=socket.gaierror("nope")
+            ),
+            pytest.raises(url_safety.UnsafeFeedURLError),
+        ):
+            url_safety.resolve_safe_addresses("nx.example.com", 443)
+
+
+# ---------------------------------------------------------------------------
+# fetch_feed — end-to-end guard + pinned fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFeed:
+    @pytest.mark.anyio()
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/feed.ics",
+            "file:///etc/passwd",
+            "gopher://example.com/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://localhost:8000/admin",
+            "http://127.0.0.1/",
+            "http://10.0.0.5/internal",
+            "https://[::1]/",
+            "not-a-url",
+            "https:///no-host",
+        ],
+    )
+    async def test_blocks_unsafe_url_before_network(self, url: str) -> None:
+        """No request is ever issued for a disallowed scheme or non-public target."""
+        sent: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(request)
+            return httpx.Response(200, text="should not happen")
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        # Literal IPs/localhost are classified without DNS; for the hostname cases
+        # (none here) getaddrinfo would run, but every case above is scheme-bad or
+        # a literal non-public IP, so resolution isn't reached.
+        async with client:
+            with pytest.raises(url_safety.UnsafeFeedURLError):
+                await url_safety.fetch_feed(url, client=client)
+        assert sent == [], "a request was issued for an unsafe URL"
+
+    @pytest.mark.anyio()
+    async def test_pins_to_validated_ip_and_preserves_host(self) -> None:
+        """Connect target is the validated IP; Host + SNI keep the real hostname."""
+        captured: dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["host_in_url"] = request.url.host
+            captured["host_header"] = request.headers.get("Host")
+            captured["sni"] = request.extensions.get("sni_hostname")
+            return httpx.Response(200, text="BEGIN:VCALENDAR\nEND:VCALENDAR\n")
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(
+            url_safety.socket, "getaddrinfo", return_value=_addrinfo("93.184.216.34")
+        ):
+            async with client:
+                body = await url_safety.fetch_feed(
+                    "https://feeds.example.com/calendar.ics", client=client
+                )
+
+        assert body.startswith("BEGIN:VCALENDAR")
+        assert captured["host_in_url"] == "93.184.216.34"  # pinned to the IP
+        assert captured["host_header"] == "feeds.example.com"  # real vhost
+        assert captured["sni"] == "feeds.example.com"  # TLS verifies real host
+
+    @pytest.mark.anyio()
+    async def test_raises_for_status(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(
+            url_safety.socket, "getaddrinfo", return_value=_addrinfo("93.184.216.34")
+        ):
+            async with client:
+                with pytest.raises(httpx.HTTPStatusError):
+                    await url_safety.fetch_feed(
+                        "https://feeds.example.com/calendar.ics", client=client
+                    )
+
+    @pytest.mark.anyio()
+    async def test_caps_response_size(self) -> None:
+        """An oversized body is rejected rather than buffered without bound."""
+        big = "A" * (url_safety.MAX_FEED_BYTES + 1)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=big)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(
+            url_safety.socket, "getaddrinfo", return_value=_addrinfo("93.184.216.34")
+        ):
+            async with client:
+                with pytest.raises(url_safety.UnsafeFeedURLError):
+                    await url_safety.fetch_feed(
+                        "https://feeds.example.com/calendar.ics", client=client
+                    )
+
+    @pytest.mark.anyio()
+    async def test_returns_body_text(self) -> None:
+        ical = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR\n"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=ical)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(
+            url_safety.socket, "getaddrinfo", return_value=_addrinfo("8.8.8.8")
+        ):
+            async with client:
+                body = await url_safety.fetch_feed(
+                    "http://feeds.example.com/calendar.ics", client=client
+                )
+        assert body == ical


### PR DESCRIPTION
Fixes the High finding from the 2026-06-26 security review: a user-supplied iCal feed URL was fetched with no validation, so any authenticated USER could make the server fetch `http://169.254.169.254/` (cloud metadata), `localhost`, or cluster-internal services — a classic SSRF. There was also no timeout, redirect guard, or response-size cap.

## Summary

Adds `src/resonance/concerts/url_safety.py` as the single safe feed-fetch path and routes every calendar feed fetch (iCal + Songkick) through it. The guard:

- allows only `http` / `https` schemes
- resolves the host and rejects private / loopback / link-local / reserved / multicast / unspecified addresses — covering `169.254.169.254` and IPv4-mapped IPv6 smuggling (`::ffff:10.0.0.1`)
- **pins the connection to a validated IP** while preserving the real hostname for the `Host` header and TLS SNI, closing the DNS-rebinding window between validation and connect
- sets an explicit timeout, refuses redirects (`follow_redirects=False`), and caps the body at 10 MiB

Relates to #141 (finding #1 of 11).

<details>
<summary>How to Review</summary>

Two logical pieces in one commit (de4f5a9):

1. **`concerts/url_safety.py`** — the guard. Start with `is_public_address` (pure IP classification, incl. the IPv4-mapped-v6 unwrap), then `resolve_safe_addresses` (DNS + filter), then `_validated_target` (scheme/host check + literal-IP short-circuit), then `fetch_feed` (the pin: rewrite URL host → validated IP, set `Host` + `sni_hostname`, stream with size cap).
2. **`concerts/worker.py`** — the loop now calls `url_safety_module.fetch_feed(url)` instead of a bare `httpx.AsyncClient().get(url)`.

The key design point is the IP pin: connecting to the validated IP (no second DNS lookup) defeats DNS rebinding, while `sni_hostname` keeps TLS verifying the real hostname — confirmed by a live fetch in the test plan.
</details>

<details>
<summary>Test Plan</summary>

- [x] 38 new unit tests in `tests/test_url_safety.py` — scheme rejection, IP classification (loopback/private/link-local/metadata/multicast/reserved/unspecified + IPv4-mapped-v6), DNS filtering, the IP-pin + Host/SNI rewrite, `raise_for_status`, and the size cap
- [x] Worker + integration tests updated to mock the new `fetch_feed` path
- [x] Full suite: 1607 pass
- [x] ruff check + ruff format + mypy strict: clean
- [x] Live smoke test: real TLS fetch succeeds through the IP-pin + SNI rewrite; `169.254.169.254`, `127.0.0.1`, a private IP, `file://`, and `ftp://` are all blocked
</details>

<details>
<summary>Impact</summary>

- iCal feed sync and Songkick sync now go through the SSRF guard. Legitimate public feeds are unaffected.
- A feed URL targeting an internal/metadata address now fails the sync task with an `UnsafeFeedURLError` instead of reaching the target.
- No schema or config changes. The size/timeout limits are constants in `url_safety.py`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)