### PR TITLE
fix(security): escape lineup JSON to prevent XSS (#141, finding #6)

### DIFF
--- a/src/resonance/templates/playlists_new.html
+++ b/src/resonance/templates/playlists_new.html
@@ -93,7 +93,7 @@
 
 <button type="button" class="primary" id="generate-btn">Generate Playlist</button>
 
-<script id="lineup-data" type="application/json">{{ lineup_json | safe }}</script>
+<script id="lineup-data" type="application/json">{{ lineup | tojson }}</script>
 <script>
   window.LINEUP_PROFILE_ID = "{{ profile_id }}";
   window.LINEUP_SIMILAR_AVAILABLE = {{ 'true' if similar_available else 'false' }};

--- a/src/resonance/ui/playlists.py
+++ b/src/resonance/ui/playlists.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import uuid
 from typing import Annotated
 
@@ -489,7 +488,11 @@ async def edit_playlist_page(
     similar_available = conn_result.first() is not None
     ctx.update(
         profile_id=str(profile.id),
-        lineup_json=json.dumps(lineup),
+        # Pass the structured lineup and let the template serialize it with the
+        # markupsafe-aware `tojson` filter (escapes <, >, & inside the <script>
+        # block). Never json.dumps + | safe here — an artist/event name
+        # containing </script> would break out (security review #141, #6).
+        lineup=lineup,
         profile_name=profile.name,
         parameter_values=profile.parameter_values,
         similar_available=similar_available,

--- a/tests/test_lineup_builder.py
+++ b/tests/test_lineup_builder.py
@@ -303,3 +303,50 @@ class TestArtistSearchInLibrary:
         flags = {(i["disambiguation"], i["in_library"]) for i in items}
         assert ("heavy metal", True) in flags
         assert ("electronic", False) in flags
+
+
+# --- lineup-data XSS (security review #141, finding #6) ---
+
+
+class TestLineupDataXSS:
+    """The lineup JSON embedded in the editor page must not break out of its
+    <script> block. Artist/event names come from external APIs and manual entry,
+    so a name containing ``</script>`` must be escaped, not rendered raw."""
+
+    def test_script_breakout_is_escaped(self) -> None:
+        """``playlists_new.html`` serializes the lineup with the markupsafe-aware
+        ``tojson`` filter, so a ``</script>`` payload can't escape the tag."""
+        import resonance.ui.common as common_ui
+
+        payload = "</script><script>alert('xss')</script>"
+        lineup = {
+            "version": 0,
+            "groups": [
+                {
+                    "label": "Added artists",
+                    "rows": [{"artist_id": "x", "name": payload, "included": True}],
+                }
+            ],
+        }
+        ctx = {
+            "request": SimpleNamespace(url=SimpleNamespace(path="/playlists/x/edit")),
+            "user_id": "u",
+            "user_tz": "UTC",
+            "user_role": "owner",
+            "actual_role": "owner",
+            "viewing_as": None,
+            "profile_id": "x",
+            "profile_name": "My Playlist",
+            "parameter_values": {},
+            "similar_available": False,
+            "events": [],
+            "parameters": {},
+            "lineup": lineup,
+        }
+        html = common_ui.templates.get_template("playlists_new.html").render(ctx)
+
+        # No breakout: the raw payload must never appear verbatim in the page.
+        assert payload not in html
+        # The name is still present, escaped (tojson encodes "<" as <), which
+        # also proves the template actually serialized `lineup` (not a no-op).
+        assert "\\u003c/script\\u003e" in html


### PR DESCRIPTION
Fixes the second remote-exploit-path finding from the 2026-06-26 security review. The lineup builder embedded its data as `json.dumps(lineup)` rendered through Jinja's `| safe` filter into a `<script id="lineup-data">` block. `json.dumps` doesn't escape `<` / `>` / `&`, so an artist or event name containing `</script>` — names come from external APIs and manual entry — could break out of the tag and inject script (stored/reflected XSS).

## Summary

- `templates/playlists_new.html`: `{{ lineup_json | safe }}` → `{{ lineup | tojson }}`. Jinja's `tojson` is markupsafe-aware and escapes `<` `>` `&` (and `'`) as `<` etc. inside the script block, so a `</script>` payload can't escape. Matches the existing `account.html` pattern.
- `ui/playlists.py`: pass the structured `lineup` to the template instead of pre-serializing with `json.dumps`; drop the now-unused `json` import.

Client-side rendering already escapes names via `escapeHtml` (`static/lineup.js`), so this closes the remaining server-side hole. Relates to #141 (finding #6 of 11).

<details>
<summary>How to Review</summary>

One commit (b873529). The change is two lines of substance:
1. The template line that emits the lineup JSON now uses `tojson` (escaping) instead of `json.dumps` + `| safe` (raw).
2. The route hands the template the `lineup` object rather than a pre-dumped string.

The new test in `tests/test_lineup_builder.py::TestLineupDataXSS` renders the **real** `playlists_new.html` with an artist name of `</script><script>alert('xss')</script>` and asserts the raw payload never appears while its escaped form (`</script>`) does — which also proves the template actually serialized `lineup` (not a silent no-op).
</details>

<details>
<summary>Test Plan</summary>

- [x] New regression test renders the template with a `</script>` payload and asserts escaping
- [x] Full suite: 1608 pass (+1)
- [x] ruff check + ruff format + mypy strict: clean
</details>

<details>
<summary>Impact</summary>

- No behavior change for legitimate lineups — `tojson` produces valid JSON that `JSON.parse(dataEl.textContent)` reads exactly as before.
- A name containing HTML/script syntax is now inert in the page source instead of executable.
- No schema or API changes.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)