### PR TITLE
fix(security): secret startup guard, Secure cookies, constant-time token compare (#141)

### DIFF
--- a/src/resonance/api/v1/auth.py
+++ b/src/resonance/api/v1/auth.py
@@ -337,6 +337,7 @@ async def auth_callback(
         max_age=86400 * 365,  # 1 year
         httponly=True,
         samesite="lax",
+        secure=not request.app.state.settings.debug,  # HTTPS-only in prod (#141, #5)
     )
     return response
 

--- a/src/resonance/app.py
+++ b/src/resonance/app.py
@@ -92,9 +92,17 @@ async def lifespan(application: fastapi.FastAPI) -> AsyncIterator[None]:
     await engine.dispose()
 
 
-def create_app() -> fastapi.FastAPI:
-    """Create and configure the FastAPI application."""
-    settings = config_module.Settings()
+def create_app(settings: config_module.Settings | None = None) -> fastapi.FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        settings: Optional settings override (tests inject a dev-mode config);
+            defaults to loading from the environment.
+    """
+    if settings is None:
+        settings = config_module.Settings()
+    # Fail fast on placeholder secrets in production (#141, finding #4).
+    settings.ensure_secure_secrets()
     logging_module.configure_logging(settings.log_level)
     application = fastapi.FastAPI(
         title=settings.app_name,
@@ -109,6 +117,7 @@ def create_app() -> fastapi.FastAPI:
         session_middleware.SessionMiddleware,
         redis=session_redis,
         secret_key=settings.session_secret_key,
+        secure=not settings.debug,
     )
 
     # Register API routes

--- a/src/resonance/config.py
+++ b/src/resonance/config.py
@@ -1,5 +1,10 @@
 import pydantic_settings
 
+# Placeholder values shipped as defaults. Safe for local dev, unsafe in
+# production — ensure_secure_secrets() refuses to start on them (#141, finding #4).
+_PLACEHOLDER_SECRET = "change-me-in-production"
+_DEFAULT_PGPASSWORD = "resonance"
+
 
 class Settings(pydantic_settings.BaseSettings):
     """Application settings loaded from environment variables."""
@@ -99,3 +104,41 @@ class Settings(pydantic_settings.BaseSettings):
         """Redis connection URL."""
         auth = f":{self.redis_password}@" if self.redis_password else ""
         return f"redis://{auth}{self.redis_host}:{self.redis_port}/0"
+
+    def ensure_secure_secrets(self) -> None:
+        """Refuse to start in production with default/empty secrets (#141, #4).
+
+        ``session_secret_key`` (session cookie signer) and
+        ``token_encryption_key`` (Fernet key for stored OAuth tokens) shipping at
+        their placeholder would mean publicly-known keys — session forgery and
+        decryption of every stored token. ``pgpassword`` left at its default is
+        the same class of slip. In ``debug`` (local dev) the defaults are
+        tolerated so setup is frictionless; outside it, an unset secret is a
+        startup error rather than a silent live exposure.
+
+        Raises:
+            RuntimeError: if any guarded secret is empty or still its default
+                and ``debug`` is False.
+        """
+        if self.debug:
+            return
+        insecure = [
+            name
+            for name, value, default in (
+                ("SESSION_SECRET_KEY", self.session_secret_key, _PLACEHOLDER_SECRET),
+                (
+                    "TOKEN_ENCRYPTION_KEY",
+                    self.token_encryption_key,
+                    _PLACEHOLDER_SECRET,
+                ),
+                ("PGPASSWORD", self.pgpassword, _DEFAULT_PGPASSWORD),
+            )
+            if not value or value == default
+        ]
+        if insecure:
+            raise RuntimeError(
+                "Refusing to start: "
+                + ", ".join(insecure)
+                + " must be overridden from the default in production "
+                "(set DEBUG=true for local development)."
+            )

--- a/src/resonance/dependencies.py
+++ b/src/resonance/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import secrets
 import uuid
 from typing import TYPE_CHECKING, Annotated
 
@@ -142,7 +143,11 @@ async def resolve_bearer_user(request: fastapi.Request) -> uuid.UUID | None:
 
     token = auth_header[7:]
     settings = request.app.state.settings
-    if not settings.admin_api_token or token != settings.admin_api_token:
+    # Constant-time compare to avoid a timing side channel on the admin token
+    # (#141, finding #7). compare_digest short-circuits safely on empty config.
+    if not settings.admin_api_token or not secrets.compare_digest(
+        token, settings.admin_api_token
+    ):
         raise fastapi.HTTPException(status_code=403, detail="Invalid API token")
 
     selector = _assume_user_selector(request)
@@ -178,7 +183,10 @@ def verify_admin_access(request: fastapi.Request) -> None:
     if auth_header.startswith("Bearer "):
         token = auth_header[7:]
         settings = request.app.state.settings
-        if settings.admin_api_token and token == settings.admin_api_token:
+        # Constant-time compare (#141, finding #7).
+        if settings.admin_api_token and secrets.compare_digest(
+            token, settings.admin_api_token
+        ):
             return
         raise fastapi.HTTPException(status_code=403, detail="Invalid API token")
 

--- a/src/resonance/middleware/session.py
+++ b/src/resonance/middleware/session.py
@@ -65,12 +65,19 @@ class SessionMiddleware(base_middleware.BaseHTTPMiddleware):
         secret_key: str,
         cookie_name: str = "session_id",
         max_age: int = 86400 * 30,
+        *,
+        secure: bool = False,
     ) -> None:
         super().__init__(app)
         self.redis = redis
         self.signer = itsdangerous.TimestampSigner(secret_key)
         self.cookie_name = cookie_name
         self.max_age = max_age
+        # When True, the session cookie carries the Secure attribute so browsers
+        # only send it over HTTPS (#141, finding #5). create_app sets this from
+        # `not settings.debug`; the default is False so local-http dev and tests
+        # work without TLS.
+        self.secure = secure
 
     async def dispatch(
         self,
@@ -136,6 +143,7 @@ class SessionMiddleware(base_middleware.BaseHTTPMiddleware):
             max_age=self.max_age,
             httponly=True,
             samesite="lax",
+            secure=self.secure,
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 import resonance.config as config_module
 
 
@@ -84,3 +86,58 @@ def test_redirect_uris_default_to_localhost() -> None:
     settings = config_module.Settings()
     assert settings.spotify_redirect_uri.startswith("http://localhost:8000")
     assert settings.musicbrainz_redirect_uri.startswith("http://localhost:8000")
+
+
+# --- production secret guard (security review #141, finding #4) ---
+
+
+def _real_secrets() -> dict[str, str]:
+    return {
+        "session_secret_key": "a-real-session-signing-key",
+        "token_encryption_key": "a-real-fernet-encryption-key",
+        "pgpassword": "a-real-db-password",
+    }
+
+
+def test_ensure_secure_secrets_rejects_placeholders_in_prod() -> None:
+    """Default placeholder secrets must fail startup when debug is off."""
+    settings = config_module.Settings(debug=False)
+    with pytest.raises(RuntimeError):
+        settings.ensure_secure_secrets()
+
+
+def test_ensure_secure_secrets_allows_placeholders_in_debug() -> None:
+    """Local dev (debug=True) tolerates the shipped defaults."""
+    settings = config_module.Settings(debug=True)
+    settings.ensure_secure_secrets()  # must not raise
+
+
+def test_ensure_secure_secrets_passes_with_real_secrets() -> None:
+    settings = config_module.Settings(debug=False, **_real_secrets())
+    settings.ensure_secure_secrets()  # must not raise
+
+
+def test_ensure_secure_secrets_rejects_empty_secret() -> None:
+    overrides = _real_secrets()
+    overrides["session_secret_key"] = ""
+    settings = config_module.Settings(debug=False, **overrides)
+    with pytest.raises(RuntimeError):
+        settings.ensure_secure_secrets()
+
+
+def test_ensure_secure_secrets_names_each_offending_field() -> None:
+    settings = config_module.Settings(debug=False)  # all three are defaults
+    with pytest.raises(RuntimeError) as exc:
+        settings.ensure_secure_secrets()
+    msg = str(exc.value)
+    assert "SESSION_SECRET_KEY" in msg
+    assert "TOKEN_ENCRYPTION_KEY" in msg
+    assert "PGPASSWORD" in msg
+
+
+def test_ensure_secure_secrets_flags_default_pgpassword() -> None:
+    overrides = _real_secrets()
+    overrides["pgpassword"] = "resonance"  # the shipped default
+    settings = config_module.Settings(debug=False, **overrides)
+    with pytest.raises(RuntimeError, match="PGPASSWORD"):
+        settings.ensure_secure_secrets()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import fastapi
 import pytest
 
@@ -38,4 +40,30 @@ class TestRequireOwner:
     def test_user_raises_403(self) -> None:
         with pytest.raises(fastapi.HTTPException) as exc_info:
             deps_module.require_owner(types_module.UserRole.USER)
+        assert exc_info.value.status_code == 403
+
+
+class TestVerifyAdminAccessTokenCompare:
+    """Admin bearer-token comparison is constant-time (#141, finding #7).
+
+    secrets.compare_digest preserves the accept/reject behavior, so these guard
+    against a regression in the comparison logic.
+    """
+
+    def _request(self, *, authorization: str, admin_token: str) -> MagicMock:
+        req = MagicMock(spec=fastapi.Request)
+        req.headers = {"authorization": authorization}
+        req.app.state.settings.admin_api_token = admin_token
+        return req
+
+    def test_correct_token_passes(self) -> None:
+        deps_module.verify_admin_access(
+            self._request(authorization="Bearer s3cret", admin_token="s3cret")
+        )
+
+    def test_wrong_token_raises_403(self) -> None:
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            deps_module.verify_admin_access(
+                self._request(authorization="Bearer wrong", admin_token="s3cret")
+            )
         assert exc_info.value.status_code == 403

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -7,11 +7,12 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 import resonance.app as app_module
+import resonance.config as config_module
 
 
 @pytest.fixture
 async def client() -> AsyncIterator[httpx.AsyncClient]:
-    application = app_module.create_app()
+    application = app_module.create_app(config_module.Settings(debug=True))
     transport = httpx.ASGITransport(app=application)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -90,3 +90,44 @@ class TestInvalidateUserSessions:
 
         assert deleted == 0
         redis.delete.assert_not_awaited()
+
+
+class TestSessionCookieSecureFlag:
+    """The session cookie's Secure attribute (security review #141, finding #5)."""
+
+    def _middleware(self, *, secure: bool) -> session_module.SessionMiddleware:
+        return session_module.SessionMiddleware(
+            app=AsyncMock(),
+            redis=AsyncMock(),
+            secret_key="test-secret-key",
+            secure=secure,
+        )
+
+    async def _save_and_capture(self, *, secure: bool) -> MagicMock:
+        mw = self._middleware(secure=secure)
+        session = session_module.SessionData(
+            session_id="sid", data={"user_id": "u1"}, is_new=True
+        )
+        response = MagicMock()
+        await mw._save_session(session, response)
+        return response
+
+    async def test_secure_cookie_when_enabled(self) -> None:
+        """secure=True (production) sets the Secure attribute on the cookie."""
+        response = await self._save_and_capture(secure=True)
+        assert response.set_cookie.call_args.kwargs["secure"] is True
+
+    async def test_insecure_cookie_when_disabled(self) -> None:
+        """secure=False (local-http dev) omits Secure so the cookie works."""
+        response = await self._save_and_capture(secure=False)
+        assert response.set_cookie.call_args.kwargs["secure"] is False
+
+    def test_secure_defaults_off(self) -> None:
+        """The middleware default is off; create_app opts in via not debug."""
+        assert self._middleware(secure=False).secure is False
+        assert (
+            session_module.SessionMiddleware(
+                app=AsyncMock(), redis=AsyncMock(), secret_key="k"
+            ).secure
+            is False
+        )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -7,11 +7,12 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 import resonance.app as app_module
+import resonance.config as config_module
 
 
 @pytest.fixture
 async def client() -> AsyncIterator[httpx.AsyncClient]:
-    application = app_module.create_app()
+    application = app_module.create_app(config_module.Settings(debug=True))
     transport = httpx.ASGITransport(app=application)
     async with httpx.AsyncClient(
         transport=transport, base_url="http://test", follow_redirects=False

--- a/tests/test_ui_candidates.py
+++ b/tests/test_ui_candidates.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 import resonance.app as app_module
+import resonance.config as config_module
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 async def client() -> AsyncIterator[httpx.AsyncClient]:
-    application = app_module.create_app()
+    application = app_module.create_app(config_module.Settings(debug=True))
     transport = httpx.ASGITransport(app=application)
     async with httpx.AsyncClient(
         transport=transport, base_url="http://test", follow_redirects=False


### PR DESCRIPTION
Three quick-hardening findings from the 2026-06-26 security review, batched into one PR. Relates to #141 (findings #4, #5, #7).

## Summary

**#4 — Secret startup guard.** `session_secret_key` and `token_encryption_key` defaulted to `change-me-in-production`, and `pgpassword` to `resonance`, with nothing failing startup if left unset. Deployed unset, the session signer key and the Fernet token-encryption key would be publicly known (session forgery + decryption of every stored OAuth token). Adds `Settings.ensure_secure_secrets()`, called from `create_app`, which refuses to start when any of the three is empty or still its default — unless `debug=True` (local dev). `create_app` now accepts an injected `Settings` so tests run in dev mode.

**#5 — Secure cookie flag.** The session cookie and the `last_auth_service` cookie set `httponly` + `samesite=lax` but not `Secure`, so a browser would send them over plain HTTP. `SessionMiddleware` gains a `secure` flag (`create_app` passes `not settings.debug`); the auth cookie gates the same way.

**#7 — Constant-time admin token compare.** The admin bearer token was compared with `==`/`!=` (timing side channel). Both sites now use `secrets.compare_digest`.

<details>
<summary>How to Review</summary>

One commit (62adaec):
- `config.py` — `ensure_secure_secrets()` + the two default sentinels.
- `app.py` — `create_app(settings=None)`, calls the guard, passes `secure=not settings.debug` to the middleware.
- `middleware/session.py` — `secure` param (default False) → `set_cookie(secure=...)`.
- `api/v1/auth.py` — `last_auth_service` cookie gets `secure=not …debug`.
- `dependencies.py` — `secrets.compare_digest` at both token-compare sites.
- Tests: the three new test classes, plus the three real-`create_app` fixtures (`test_ui`, `test_health`, `test_ui_candidates`) now inject `Settings(debug=True)`.

The `secure` middleware default is False so direct constructions (and the per-test app helpers) keep working over http; production opts in through `create_app`.
</details>

<details>
<summary>Test Plan</summary>

- [x] #4: guard matrix — placeholders rejected in prod, allowed in debug, real secrets pass, empty rejected, each offending field named, default `pgpassword` flagged
- [x] #5: `_save_session` emits `secure=True` when enabled, `False` when disabled, default off
- [x] #7: correct admin token passes, wrong token → 403
- [x] Full suite: 1619 pass (+11); ruff + ruff format + mypy strict clean
</details>

<details>
<summary>Impact</summary>

- Production deploys already set all three secrets via sealed secrets, so the guard is defense-in-depth against a deploy-time slip, not a behavior change for the live app.
- Cookies gain `Secure` in production (HTTPS only); local-http dev unaffected (`debug=True`).
- Admin token comparison behavior is unchanged — same accept/reject, just constant-time.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)