### PR TITLE
fix(security): CSP headers, OAuth-state CSRF, docs + playground gating (#141)

### DIFF
--- a/src/resonance/api/v1/auth.py
+++ b/src/resonance/api/v1/auth.py
@@ -120,14 +120,22 @@ async def auth_callback(
             status_code=400, detail="Missing code or token parameter"
         )
 
-    # Verify state matches.  When state is non-empty (standard OAuth2) we
-    # require it to match the stored value.  When state is empty the service
-    # does not echo it back (e.g. Last.fm), so we skip the check.
-    stored_state = session.get("oauth_state")
-    if state and (stored_state is None or stored_state != state):
-        raise fastapi.HTTPException(
-            status_code=400, detail="Invalid or missing OAuth state"
-        )
+    # Verify the OAuth state (CSRF protection). Standard OAuth2 services echo
+    # `state` back, so we REQUIRE a match. Last.fm is the one exception: it does
+    # not return state, so it (and only it) skips the check. Previously the skip
+    # triggered whenever `state` was empty, which let an attacker defeat the
+    # check for ANY service by simply omitting it (#141, finding #2).
+    skip_state_check = service_type == types_module.ServiceType.LASTFM
+    if not skip_state_check:
+        stored_state = session.get("oauth_state")
+        if (
+            not state
+            or stored_state is None
+            or not secrets.compare_digest(stored_state, state)
+        ):
+            raise fastapi.HTTPException(
+                status_code=400, detail="Invalid or missing OAuth state"
+            )
 
     # Exchange code for tokens
     try:

--- a/src/resonance/app.py
+++ b/src/resonance/app.py
@@ -26,6 +26,7 @@ import resonance.connectors.spotify as spotify_module
 import resonance.connectors.test as test_connector_module
 import resonance.database as database_module
 import resonance.logging as logging_module
+import resonance.middleware.security_headers as security_headers_module
 import resonance.middleware.session as session_middleware
 import resonance.migrations as migrations_module
 import resonance.models.task as task_models
@@ -104,13 +105,22 @@ def create_app(settings: config_module.Settings | None = None) -> fastapi.FastAP
     # Fail fast on placeholder secrets in production (#141, finding #4).
     settings.ensure_secure_secrets()
     logging_module.configure_logging(settings.log_level)
+    # Swagger UI and the raw OpenAPI spec are dev-only (#141, finding #9):
+    # exposed in debug, withheld in production to avoid endpoint enumeration.
     application = fastapi.FastAPI(
         title=settings.app_name,
-        docs_url="/docs",
+        docs_url="/docs" if settings.debug else None,
+        openapi_url="/openapi.json" if settings.debug else None,
         redoc_url=None,
         lifespan=lifespan,
     )
     application.state.settings = settings
+
+    # Security headers + CSP on every response (#141, finding #8).
+    application.add_middleware(
+        security_headers_module.SecurityHeadersMiddleware,
+        csp=security_headers_module.DEFAULT_CSP,
+    )
 
     session_redis = aioredis.from_url(settings.redis_url, decode_responses=True)  # type: ignore[no-untyped-call]  # redis 5.x lacks stubs
     application.add_middleware(
@@ -129,7 +139,10 @@ def create_app(settings: config_module.Settings | None = None) -> fastapi.FastAP
     application.include_router(ui_artists_module.router)
     application.include_router(ui_dashboard_module.router)
     application.include_router(ui_events_module.router)
-    application.include_router(ui_playground_module.router)
+    # The component playground is a dev tool; don't expose it in production at
+    # all (#141, finding #11). It's also admin-gated for defense in depth.
+    if settings.debug:
+        application.include_router(ui_playground_module.router)
     application.include_router(ui_playlists_module.router)
     application.include_router(ui_sync_module.router)
     application.include_router(ui_tracks_module.router)

--- a/src/resonance/middleware/security_headers.py
+++ b/src/resonance/middleware/security_headers.py
@@ -1,0 +1,71 @@
+"""Security-header middleware (security review #141, finding #8).
+
+Adds a Content-Security-Policy plus the standard hardening headers to every
+response. The CSP is defense-in-depth on top of the output-escaping fix (#6):
+it restricts where scripts/styles/images may load from, and blocks framing and
+MIME sniffing.
+
+The policy allows ``'unsafe-inline'`` for scripts because the templates rely on
+inline ``<script>`` blocks (theme bootstrap, timezone capture, per-page
+``window.LINEUP_*`` config). That means the CSP does not by itself stop an
+injected inline script — the breakout hole that enabled that is closed by the
+``tojson`` escaping in #6. A future hardening could move to nonce-based inline
+scripts and drop ``'unsafe-inline'``.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import starlette.middleware.base as base_middleware
+
+if typing.TYPE_CHECKING:
+    import starlette.requests as starlette_requests
+    import starlette.responses as starlette_responses
+    import starlette.types as starlette_types
+
+# Allowed sources mirror what base.html actually loads:
+# - scripts: unpkg (htmx, lucide) + jsdelivr (Swagger UI in dev) + inline blocks
+# - styles: jsdelivr (Pico CSS) + /static + inline
+# Everything else is same-origin only; framing and plugins are denied.
+DEFAULT_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "img-src 'self' data:; "
+    "font-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "object-src 'none'"
+)
+
+
+class SecurityHeadersMiddleware(base_middleware.BaseHTTPMiddleware):
+    """Attach CSP + hardening headers to every response.
+
+    Uses ``setdefault`` so a route that sets its own value (rare) is not
+    clobbered.
+    """
+
+    def __init__(
+        self,
+        app: starlette_types.ASGIApp,
+        csp: str = DEFAULT_CSP,
+    ) -> None:
+        super().__init__(app)
+        self.csp = csp
+
+    async def dispatch(
+        self,
+        request: starlette_requests.Request,
+        call_next: base_middleware.RequestResponseEndpoint,
+    ) -> starlette_responses.Response:
+        response = await call_next(request)
+        headers = response.headers
+        headers.setdefault("Content-Security-Policy", self.csp)
+        headers.setdefault("X-Content-Type-Options", "nosniff")
+        headers.setdefault("X-Frame-Options", "DENY")
+        headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        return response

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -237,6 +237,24 @@ class TestAuthCallback:
         )
         assert response.status_code == 400
 
+    async def test_callback_empty_state_rejected_for_standard_service(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """An empty state must NOT bypass CSRF for a standard OAuth2 service.
+
+        Previously `if state and ...` skipped the check whenever state was empty,
+        so an attacker could defeat it by omitting state (#141, finding #2).
+        """
+        response = await client.get("/api/v1/auth/spotify/callback?code=test&state=")
+        assert response.status_code == 400
+
+    async def test_callback_missing_state_param_rejected(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """A missing state param is likewise rejected for a standard service."""
+        response = await client.get("/api/v1/auth/spotify/callback?code=test")
+        assert response.status_code == 400
+
     async def test_callback_unknown_service_returns_404(
         self, client: httpx.AsyncClient
     ) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,80 @@
+"""App-level wiring tests: security headers, docs gating, playground gating.
+
+Covers security review #141 findings #8 (CSP/headers), #9 (Swagger gated to
+debug), and #11 (component playground not registered in production).
+"""
+
+from __future__ import annotations
+
+import httpx
+
+import resonance.app as app_module
+import resonance.config as config_module
+
+
+def _prod_settings(**overrides: object) -> config_module.Settings:
+    """Production-mode settings (debug off) with real secrets so the #4 guard
+    passes."""
+    base: dict[str, object] = {
+        "debug": False,
+        "session_secret_key": "real-session-signing-key",
+        "token_encryption_key": "real-fernet-encryption-key",
+        "pgpassword": "real-db-password",
+    }
+    base.update(overrides)
+    return config_module.Settings(**base)  # type: ignore[arg-type]
+
+
+def _client(settings: config_module.Settings) -> httpx.AsyncClient:
+    app = app_module.create_app(settings)
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    )
+
+
+class TestSecurityHeaders:
+    """CSP + hardening headers on every response (#141, finding #8)."""
+
+    async def test_headers_present_on_response(self) -> None:
+        async with _client(_prod_settings()) as c:
+            resp = await c.get("/login")
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert "default-src 'self'" in csp
+        assert "frame-ancestors 'none'" in csp
+        assert "object-src 'none'" in csp
+        # Inline scripts + the external CDNs the templates actually use.
+        assert "https://unpkg.com" in csp
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.headers["X-Frame-Options"] == "DENY"
+        assert resp.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+class TestDocsGating:
+    """Swagger UI + OpenAPI spec are dev-only (#141, finding #9)."""
+
+    async def test_docs_and_openapi_hidden_in_prod(self) -> None:
+        async with _client(_prod_settings()) as c:
+            assert (await c.get("/docs")).status_code == 404
+            assert (await c.get("/openapi.json")).status_code == 404
+
+    async def test_docs_available_in_debug(self) -> None:
+        async with _client(config_module.Settings(debug=True)) as c:
+            assert (await c.get("/openapi.json")).status_code == 200
+
+
+class TestPlaygroundGating:
+    """The dev component playground is not exposed in production (#141, #11)."""
+
+    async def test_playground_not_registered_in_prod(self) -> None:
+        async with _client(_prod_settings()) as c:
+            # Route isn't registered at all -> 404 (not an auth redirect).
+            assert (await c.get("/dev/components")).status_code == 404
+
+    async def test_playground_registered_but_gated_in_debug(self) -> None:
+        async with _client(config_module.Settings(debug=True)) as c:
+            resp = await c.get("/dev/components")
+        # Registered in dev, but still admin-gated -> redirect to login.
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/login"


### PR DESCRIPTION
Four hardening findings from the 2026-06-26 review, batched. Relates to #141 (findings #2, #8, #9, #11).

## Summary

**#2 — OAuth state CSRF bypass.** The callback skipped state validation whenever `state` was empty (`if state and ...`) — intended for Last.fm, but it applied to every service, so an attacker could defeat OAuth-CSRF for Spotify/Dex/MusicBrainz just by omitting `state`. Now only Last.fm (which genuinely doesn't echo state) skips the check; every standard service **requires** a state matching the stored value, compared with `secrets.compare_digest`.

**#8 — Security headers + CSP.** New `SecurityHeadersMiddleware` adds a `Content-Security-Policy` plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy` to every response. The CSP allows the CDNs the templates actually load (unpkg for htmx/lucide, jsdelivr for Pico) and `'unsafe-inline'` for the inline `<script>` blocks the UI relies on; framing and plugins are denied. Defense-in-depth on top of the #6 escaping fix.

**#9 — Swagger gating.** `/docs` and `/openapi.json` are exposed only when `debug=True`, withheld in production.

**#11 — Playground gating.** `/dev/components` is registered only in `debug` (it was already admin-gated; this removes it from prod entirely).

<details>
<summary>How to Review</summary>

One commit (d07cade):
- `middleware/security_headers.py` (new) — `SecurityHeadersMiddleware` + `DEFAULT_CSP`. The CSP comment documents the `'unsafe-inline'` tradeoff.
- `app.py` — adds the middleware, gates `docs_url`/`openapi_url` on `debug`, wraps the playground router include in `if settings.debug`.
- `api/v1/auth.py` — `skip_state_check = service_type == LASTFM`; all other services require + `compare_digest` the state.
- `tests/test_app.py` (new) + `tests/test_api_auth.py` — coverage below.

Note on the CSP: `'unsafe-inline'` is required because the templates use inline scripts (theme bootstrap, tz capture, per-page `window.LINEUP_*`). So the CSP doesn't by itself stop an injected inline script — that hole is closed by #6. A future hardening could move to nonce-based inline scripts and drop `'unsafe-inline'`.
</details>

<details>
<summary>Test Plan</summary>

- [x] #2: empty state and missing-state param both rejected (400) for a standard service; existing wrong-state and full-flow-matching-state tests still pass
- [x] #8: CSP + all three hardening headers present and correctly formed
- [x] #9: `/docs` + `/openapi.json` → 404 in prod, `/openapi.json` → 200 in debug
- [x] #11: `/dev/components` → 404 in prod (not registered), login-redirect in debug (admin-gated)
- [x] Full suite: 1626 pass (+7); ruff + ruff format + mypy strict clean
</details>

<details>
<summary>Impact</summary>

- CSP applies to all responses. Verified the policy matches what `base.html` loads; I'll also confirm no console CSP violations against the live app after deploy.
- OAuth login for standard services now hard-requires a valid state (the normal flow already sends one). Last.fm is unaffected.
- Swagger/OpenAPI and the dev playground disappear in production; both remain in local dev (`debug=True`).
- No schema changes.
</details>

Follow-up: #10 (rate limiting) ships as its own PR next; #3 (owner-landrush) is proposed as accepted-risk (an admin can demote/delete a bad actor; the only fix adds a required `OWNER_EXTERNAL_ID` setup step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)