### PR TITLE
fix(security): per-IP rate limiting on auth + admin paths (#141, finding #10)

### DIFF
--- a/src/resonance/app.py
+++ b/src/resonance/app.py
@@ -26,6 +26,7 @@ import resonance.connectors.spotify as spotify_module
 import resonance.connectors.test as test_connector_module
 import resonance.database as database_module
 import resonance.logging as logging_module
+import resonance.middleware.rate_limit as rate_limit_module
 import resonance.middleware.security_headers as security_headers_module
 import resonance.middleware.session as session_middleware
 import resonance.migrations as migrations_module
@@ -129,6 +130,14 @@ def create_app(settings: config_module.Settings | None = None) -> fastapi.FastAP
         secret_key=settings.session_secret_key,
         secure=not settings.debug,
     )
+
+    # Per-IP rate limiting on auth + admin paths (#141, finding #10). Added after
+    # session so it sits outermost and rejects abusive clients early.
+    if settings.rate_limit_enabled:
+        application.add_middleware(
+            rate_limit_module.RateLimitMiddleware,
+            redis=session_redis,
+        )
 
     # Register API routes
     application.include_router(api_v1_module.router)

--- a/src/resonance/config.py
+++ b/src/resonance/config.py
@@ -61,6 +61,10 @@ class Settings(pydantic_settings.BaseSettings):
     # Admin API token (for CLI/programmatic access)
     admin_api_token: str = ""
 
+    # Per-IP rate limiting on auth + admin paths (#141, finding #10). Kill switch
+    # in case the limiter ever misbehaves in production.
+    rate_limit_enabled: bool = True
+
     # Allow the admin token to assume a user identity on user-scoped endpoints
     # (X-Assume-User header / ?as_user=) for agent-first live testing (#135).
     # The admin token is already omnipotent, so this is not a privilege

--- a/src/resonance/middleware/rate_limit.py
+++ b/src/resonance/middleware/rate_limit.py
@@ -1,0 +1,110 @@
+"""Per-IP rate limiting on auth + admin paths (security review #141, finding #10).
+
+Blunts brute-force against the login/callback flow and the admin bearer token
+(compounds #7's constant-time compare). Fixed-window counters in Redis, keyed by
+client IP and path scope.
+
+Two deliberate choices:
+
+- **Client IP comes from ``X-Forwarded-For``** when present. Behind the gateway
+  (nginx-gateway-fabric) every request's socket peer is the gateway, so
+  ``request.client.host`` would lump all clients together. We take the first hop
+  in XFF, falling back to the socket peer for direct/local requests.
+- **Fail open.** If Redis is unavailable the request is allowed through rather
+  than blocked — a Redis blip must not lock everyone out of authentication.
+  Availability wins over the rate-limit hardening here.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import typing
+
+import starlette.middleware.base as base_middleware
+import starlette.responses as starlette_responses
+import structlog
+
+if typing.TYPE_CHECKING:
+    import starlette.requests as starlette_requests
+    import starlette.types as starlette_types
+
+    from resonance.middleware.session import RedisClient
+
+logger = structlog.get_logger()
+
+
+@dataclasses.dataclass(frozen=True)
+class RateLimitRule:
+    """A path prefix and its per-IP budget."""
+
+    prefix: str
+    max_requests: int
+    window_seconds: int
+
+
+# Generous enough for real use (a person logging in, an agent driving the admin
+# API), tight enough to make credential brute-force impractical.
+DEFAULT_RULES: tuple[RateLimitRule, ...] = (
+    RateLimitRule("/api/v1/auth/", max_requests=20, window_seconds=60),
+    RateLimitRule("/api/v1/admin/", max_requests=60, window_seconds=60),
+)
+
+
+def client_ip(request: starlette_requests.Request) -> str:
+    """The originating client IP, honoring X-Forwarded-For behind the gateway."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",", 1)[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else "unknown"
+
+
+class RateLimitMiddleware(base_middleware.BaseHTTPMiddleware):
+    """Fixed-window per-IP rate limiting on the configured path prefixes."""
+
+    def __init__(
+        self,
+        app: starlette_types.ASGIApp,
+        redis: RedisClient,
+        rules: tuple[RateLimitRule, ...] = DEFAULT_RULES,
+    ) -> None:
+        super().__init__(app)
+        self.redis = redis
+        self.rules = rules
+
+    async def dispatch(
+        self,
+        request: starlette_requests.Request,
+        call_next: base_middleware.RequestResponseEndpoint,
+    ) -> starlette_responses.Response:
+        rule = next(
+            (r for r in self.rules if request.url.path.startswith(r.prefix)),
+            None,
+        )
+        if rule is None:
+            return await call_next(request)
+
+        ip = client_ip(request)
+        key = f"ratelimit:{rule.prefix}:{ip}"
+        try:
+            count = await self.redis.incr(key)
+            if count == 1:
+                await self.redis.expire(key, rule.window_seconds)
+        except Exception:
+            # Fail open: don't let a Redis problem block authentication.
+            logger.warning("rate_limit_redis_error", key=key, exc_info=True)
+            return await call_next(request)
+
+        if count > rule.max_requests:
+            ttl = await self.redis.ttl(key)
+            retry_after = (
+                ttl if isinstance(ttl, int) and ttl > 0 else rule.window_seconds
+            )
+            return starlette_responses.JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded. Please slow down."},
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        return await call_next(request)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,118 @@
+"""Tests for per-IP rate limiting (security review #141, finding #10)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import fastapi
+import httpx
+
+import resonance.middleware.rate_limit as rate_limit_module
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stand-in for incr/expire/ttl."""
+
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = {}
+        self.ttls: dict[str, int] = {}
+        self.fail = False
+
+    async def incr(self, key: str) -> int:
+        if self.fail:
+            raise RuntimeError("redis down")
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    async def expire(self, key: str, seconds: int) -> None:
+        self.ttls[key] = seconds
+
+    async def ttl(self, key: str) -> int:
+        return self.ttls.get(key, -1)
+
+
+def _app(redis: FakeRedis, rules: tuple[rate_limit_module.RateLimitRule, ...]) -> Any:
+    app = fastapi.FastAPI()
+    app.add_middleware(rate_limit_module.RateLimitMiddleware, redis=redis, rules=rules)
+
+    @app.get("/api/v1/auth/ping")
+    async def auth_ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/health")
+    async def health() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+_RULES = (rate_limit_module.RateLimitRule("/api/v1/auth/", 3, 60),)
+
+
+class TestRateLimitMiddleware:
+    async def test_allows_under_limit_then_429s_over(self) -> None:
+        redis = FakeRedis()
+        async with _client(_app(redis, _RULES)) as c:
+            for _ in range(3):
+                assert (await c.get("/api/v1/auth/ping")).status_code == 200
+            blocked = await c.get("/api/v1/auth/ping")
+        assert blocked.status_code == 429
+        assert blocked.headers["Retry-After"] == "60"
+
+    async def test_non_matching_path_never_limited(self) -> None:
+        redis = FakeRedis()
+        async with _client(_app(redis, _RULES)) as c:
+            for _ in range(10):
+                assert (await c.get("/health")).status_code == 200
+        # No counter was created for the unmatched path.
+        assert redis.counts == {}
+
+    async def test_per_ip_isolation_via_xff(self) -> None:
+        """Different X-Forwarded-For clients get independent budgets."""
+        redis = FakeRedis()
+        async with _client(_app(redis, _RULES)) as c:
+            for _ in range(3):
+                await c.get("/api/v1/auth/ping", headers={"X-Forwarded-For": "1.1.1.1"})
+            # A different client is unaffected by the first's exhausted budget.
+            other = await c.get(
+                "/api/v1/auth/ping", headers={"X-Forwarded-For": "2.2.2.2"}
+            )
+            same = await c.get(
+                "/api/v1/auth/ping", headers={"X-Forwarded-For": "1.1.1.1"}
+            )
+        assert other.status_code == 200
+        assert same.status_code == 429
+
+    async def test_fails_open_when_redis_errors(self) -> None:
+        """A Redis failure must not block auth — requests pass through."""
+        redis = FakeRedis()
+        redis.fail = True
+        async with _client(_app(redis, _RULES)) as c:
+            for _ in range(5):
+                assert (await c.get("/api/v1/auth/ping")).status_code == 200
+
+
+class TestClientIp:
+    def _request(self, xff: str | None, peer: str | None) -> Any:
+        scope: dict[str, Any] = {
+            "type": "http",
+            "headers": [(b"x-forwarded-for", xff.encode())] if xff else [],
+            "client": (peer, 12345) if peer else None,
+        }
+        import starlette.requests as starlette_requests
+
+        return starlette_requests.Request(scope)
+
+    def test_prefers_first_xff_hop(self) -> None:
+        req = self._request("9.9.9.9, 10.0.0.1", "172.16.0.1")
+        assert rate_limit_module.client_ip(req) == "9.9.9.9"
+
+    def test_falls_back_to_peer(self) -> None:
+        req = self._request(None, "203.0.113.5")
+        assert rate_limit_module.client_ip(req) == "203.0.113.5"


### PR DESCRIPTION
The last active finding from the 2026-06-26 review. Blunts brute-force against the login/callback flow and the admin bearer token (compounds #7's constant-time compare). Relates to #141 (finding #10).

## Summary

New `RateLimitMiddleware` does fixed-window per-IP counting in Redis, keyed by path scope:

| Scope | Budget |
|-------|--------|
| `/api/v1/auth/` | 20 requests / 60s |
| `/api/v1/admin/` | 60 requests / 60s |

Over the budget → `429` with a `Retry-After` header. Non-auth/admin paths are never touched (no Redis call). Gated by `settings.rate_limit_enabled` (default on) as a kill switch.

Two deliberate design choices:
- **Client IP from `X-Forwarded-For`** (first hop). Behind nginx-gateway-fabric every request's socket peer is the gateway, so `request.client.host` would lump all clients into one bucket. Falls back to the socket peer for direct/local requests.
- **Fails open.** If Redis is unavailable the request passes through rather than being blocked — a Redis blip must not lock everyone out of authentication. Availability wins over the hardening here.

<details>
<summary>How to Review</summary>

One commit (20c8c26):
- `middleware/rate_limit.py` (new) — `RateLimitMiddleware`, `RateLimitRule`, `DEFAULT_RULES`, `client_ip()`.
- `config.py` — `rate_limit_enabled` flag.
- `app.py` — import + conditional `add_middleware` (added after session so it sits outermost and rejects early).
- `tests/test_rate_limit.py` (new) — coverage below.

The budgets are generous on purpose: a person logging in or an agent driving the admin API won't hit them, but credential brute-force becomes impractical.
</details>

<details>
<summary>Test Plan</summary>

- [x] Under the limit passes, then 429 with `Retry-After` over it
- [x] Non-matching paths are never limited (no counter created)
- [x] Per-IP isolation: distinct `X-Forwarded-For` clients have independent budgets
- [x] Fails open when Redis errors (requests pass through)
- [x] `client_ip()` prefers the first XFF hop, falls back to the socket peer
- [x] Full suite: 1632 pass (+6); ruff + ruff format + mypy strict clean
</details>

<details>
<summary>Impact</summary>

- Only `/api/v1/auth/*` and `/api/v1/admin/*` are rate-limited; all other routes are unaffected.
- Legitimate use (human login, agent/CLI admin calls) stays well under the budgets.
- A Redis outage degrades to "no rate limiting" rather than "no auth".
- With this merged, the security review is closed: 10 of 11 findings fixed, #3 accepted-risk.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)