### PR TITLE
feat(genre): genre model Arc 1 — artist disambiguation for #136

### DIFF
--- a/alembic/versions/r9s0t1u2v3w4_add_artist_tags_and_genre_backfill.py
+++ b/alembic/versions/r9s0t1u2v3w4_add_artist_tags_and_genre_backfill.py
@@ -1,0 +1,74 @@
+"""add artist_tags table and artists.genre_attempted_at
+
+#136 genre model, Arc 1. Stores artist genre/folksonomy tags as durable domain
+data (NOT a cache), mirroring artist_similarities. Each row records that
+``source`` (default MusicBrainz, fetched via the ListenBrainz artist metadata
+endpoint) reports ``tag`` with folksonomy ``count``. ``genre_mbid`` is non-NULL
+only for canonical MusicBrainz genres, so genre-vs-noise filtering is data-driven
+rather than a hand-maintained stoplist. ``fetched_at`` drives refresh-if-old.
+
+Also adds ``artists.genre_attempted_at``: the GENRE_BACKFILL resume key,
+mirroring ``mb_attempted_at``. NULL = not yet attempted; NOT NULL with zero
+artist_tags rows = attempted, no tags found.
+
+Additive and non-breaking: a new table plus a nullable column. Safe to deploy
+ahead of the code that reads them.
+
+Revision ID: r9s0t1u2v3w4
+Revises: q8r9s0t1u2v3
+Create Date: 2026-07-01
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "r9s0t1u2v3w4"
+down_revision: str = "q8r9s0t1u2v3"
+branch_labels: None = None
+depends_on: None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artist_tags",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("artist_id", sa.Uuid(), nullable=False),
+        sa.Column("tag", sa.String(length=256), nullable=False),
+        sa.Column("genre_mbid", sa.String(length=64), nullable=True),
+        sa.Column("count", sa.Integer(), nullable=False),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["artist_id"], ["artists.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("artist_id", "tag", name="uq_artist_tags_artist_tag"),
+        sa.CheckConstraint("count >= 0", name="ck_artist_tags_count_nonneg"),
+    )
+    op.add_column(
+        "artists",
+        sa.Column("genre_attempted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("artists", "genre_attempted_at")
+    op.drop_table("artist_tags")

--- a/alembic/versions/s0t1u2v3w4x5_add_genre_backfill_task_type.py
+++ b/alembic/versions/s0t1u2v3w4x5_add_genre_backfill_task_type.py
@@ -1,0 +1,76 @@
+"""add GENRE_BACKFILL to the sync_tasks task_type CHECK constraint
+
+TaskType.GENRE_BACKFILL (#136 genre model) was added in code; the sync_tasks
+task_type CHECK constraint must list it or inserts of genre-backfill tasks fail
+with a check violation (same class of bug fixed for MBID_BACKFILL /
+POPULARITY_BACKFILL / RELATED_ARTIST_ENRICHMENT).
+
+SQLAlchemy stores the enum .name (UPPERCASE) for native_enum=False columns, so the
+constraint lists 'GENRE_BACKFILL'. The test_task_type_constraint guard asserts the
+head-most CHECK definer lists exactly the TaskType enum names.
+
+Revision ID: s0t1u2v3w4x5
+Revises: r9s0t1u2v3w4
+Create Date: 2026-07-01
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "s0t1u2v3w4x5"
+down_revision: str = "r9s0t1u2v3w4"
+branch_labels: None = None
+depends_on: None = None
+
+_ALL_TYPES = (
+    "'SYNC_JOB', 'TIME_RANGE', 'PAGE_FETCH', 'BULK_JOB', "
+    "'CALENDAR_SYNC', 'PLAYLIST_GENERATION', "
+    "'TRACK_DISCOVERY', 'TRACK_SCORING', "
+    "'CONCERT_ARCHIVES_IMPORT', 'CONCERT_ARCHIVES_CHUNK', "
+    "'PLAYLIST_EXPORT', 'MBID_BACKFILL', 'POPULARITY_BACKFILL', "
+    "'RELATED_ARTIST_ENRICHMENT', 'GENRE_BACKFILL'"
+)
+
+_ALL_TYPES_WITHOUT_GENRE = (
+    "'SYNC_JOB', 'TIME_RANGE', 'PAGE_FETCH', 'BULK_JOB', "
+    "'CALENDAR_SYNC', 'PLAYLIST_GENERATION', "
+    "'TRACK_DISCOVERY', 'TRACK_SCORING', "
+    "'CONCERT_ARCHIVES_IMPORT', 'CONCERT_ARCHIVES_CHUNK', "
+    "'PLAYLIST_EXPORT', 'MBID_BACKFILL', 'POPULARITY_BACKFILL', "
+    "'RELATED_ARTIST_ENRICHMENT'"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks DROP CONSTRAINT IF EXISTS "
+            '"ck_sync_tasks_task_type_tasktype"'
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks ADD CONSTRAINT "
+            '"ck_sync_tasks_task_type_tasktype" '
+            f"CHECK (task_type IN ({_ALL_TYPES}))"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks DROP CONSTRAINT IF EXISTS "
+            '"ck_sync_tasks_task_type_tasktype"'
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE sync_tasks ADD CONSTRAINT "
+            '"ck_sync_tasks_task_type_tasktype" '
+            f"CHECK (task_type IN ({_ALL_TYPES_WITHOUT_GENRE}))"
+        )
+    )

--- a/src/resonance/api/v1/admin.py
+++ b/src/resonance/api/v1/admin.py
@@ -480,6 +480,88 @@ async def admin_backfill_popularity_coverage_endpoint(
     return await get_popularity_coverage(db)
 
 
+async def get_genre_coverage(db: sa_async.AsyncSession) -> dict[str, object]:
+    """Genre-tag backfill coverage over MBID-bearing artists (#136).
+
+    ``mb_linked`` is how many artists carry a MusicBrainz artist MBID at
+    ``service_links["musicbrainz"]["id"]`` (the backfill candidate set);
+    ``attempted`` is how many of those have ``genre_attempted_at`` set; ``with_tags``
+    is how many have at least one ArtistTag row. The gap between ``attempted`` and
+    ``with_tags`` is the "attempted, no tags" set (genuinely tag-less on MB),
+    distinct from the unattempted remainder (``mb_linked - attempted``).
+    """
+    mb_link = music_models.Artist.service_links["musicbrainz"]["id"].as_string()
+    linked = await db.scalar(
+        sa.select(sa.func.count())
+        .select_from(music_models.Artist)
+        .where(mb_link.isnot(None))
+    )
+    attempted = await db.scalar(
+        sa.select(sa.func.count())
+        .select_from(music_models.Artist)
+        .where(
+            mb_link.isnot(None),
+            music_models.Artist.genre_attempted_at.isnot(None),
+        )
+    )
+    with_tags = await db.scalar(
+        sa.select(sa.func.count(sa.distinct(music_models.ArtistTag.artist_id)))
+        .select_from(music_models.ArtistTag)
+        .join(
+            music_models.Artist,
+            music_models.Artist.id == music_models.ArtistTag.artist_id,
+        )
+        .where(mb_link.isnot(None))
+    )
+    return {
+        "mb_linked": linked or 0,
+        "attempted": attempted or 0,
+        "with_tags": with_tags or 0,
+    }
+
+
+@router.post(
+    "/backfill-genres",
+    summary="Enqueue artist genre-tag backfill",
+)
+async def admin_backfill_genres_endpoint(
+    request: fastapi.Request,
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, str]:
+    """Enqueue a GENRE_BACKFILL task (#136).
+
+    Fetches MusicBrainz genre/folksonomy tags for every MBID-bearing artist from
+    ListenBrainz's public artist metadata endpoint and stores them in artist_tags.
+    """
+    task = task_models.Task(
+        task_type=types_module.TaskType.GENRE_BACKFILL,
+        status=types_module.SyncStatus.PENDING,
+        params={},
+        description="Genre Backfill",
+    )
+    db.add(task)
+    await db.commit()
+    task_id = str(task.id)
+
+    arq_redis = request.app.state.arq_redis
+    await arq_redis.enqueue_job(
+        "backfill_genres",
+        task_id,
+        _job_id=f"genre-backfill:{task_id}",
+    )
+    return {"task_id": task_id, "status": "started"}
+
+
+@router.get(
+    "/backfill-genres",
+    summary="Artist genre-tag backfill coverage",
+)
+async def admin_backfill_genres_coverage_endpoint(
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+) -> dict[str, object]:
+    return await get_genre_coverage(db)
+
+
 # ---------------------------------------------------------------------------
 # Legacy endpoints
 # ---------------------------------------------------------------------------

--- a/src/resonance/api/v1/artists.py
+++ b/src/resonance/api/v1/artists.py
@@ -14,6 +14,7 @@ import structlog
 import resonance.connectors.base as base_module
 import resonance.crypto as crypto_module
 import resonance.dependencies as deps_module
+import resonance.generators.genre as genre_module
 import resonance.models.music as music_models
 import resonance.models.user as user_models
 import resonance.services.artist_import as artist_import_module
@@ -22,6 +23,11 @@ import resonance.types as types_module
 logger = structlog.get_logger()
 
 _PAGE_SIZE = 50
+# Widen the name-match candidate pool before ranking so the right artist can't
+# fall outside the returned window just for being alphabetically later (#136).
+_SEARCH_CANDIDATE_CAP = 50
+# How many genre names to surface in a picker result for disambiguation.
+_DISPLAY_GENRES = 3
 
 router = fastapi.APIRouter(prefix="/artists", tags=["artists"])
 
@@ -63,6 +69,88 @@ def _format_artist_summary(artist: music_models.Artist | Any) -> dict[str, Any]:
         "end_year": getattr(artist, "end_year", None),
         "service_links": artist.service_links,
     }
+
+
+async def _load_artist_tags(
+    db: sa_async.AsyncSession, artist_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, list[music_models.ArtistTag]]:
+    """Batch-load ArtistTag rows for the given artists (one query, no N+1)."""
+    if not artist_ids:
+        return {}
+    result = await db.execute(
+        sa.select(music_models.ArtistTag).where(
+            music_models.ArtistTag.artist_id.in_(artist_ids)
+        )
+    )
+    out: dict[uuid.UUID, list[music_models.ArtistTag]] = {}
+    for tag in result.scalars().all():
+        out.setdefault(tag.artist_id, []).append(tag)
+    return out
+
+
+def _genre_pairs(
+    tags: list[music_models.ArtistTag],
+) -> list[tuple[str | None, float]]:
+    """Adapt ArtistTag rows to the affinity primitive's (genre_mbid, count) pairs."""
+    return [(t.genre_mbid, float(t.count)) for t in tags]
+
+
+def _display_genres(tags: list[music_models.ArtistTag]) -> list[str]:
+    """Top canonical-genre tag names by count, for picker disambiguation."""
+    genres = sorted(
+        (t for t in tags if t.genre_mbid),
+        key=lambda t: t.count,
+        reverse=True,
+    )
+    return [t.tag for t in genres[:_DISPLAY_GENRES]]
+
+
+def _genre_sort_value(affinity: float | None) -> float:
+    """Rank key from an affinity score, keeping unknown distinct from mismatch.
+
+    Positive overlap ranks highest (its value), an unknown-genre candidate
+    (``None``) is neutral at 0.0, and a confirmed 0.0 genre mismatch sinks below
+    neutral -- so an untagged possible-match is never tied below a known off-genre
+    artist (#136 / affinity primitive finding).
+    """
+    if affinity is None:
+        return 0.0
+    if affinity == 0.0:
+        return -1.0
+    return affinity
+
+
+def rank_search_candidates(
+    candidates: list[music_models.Artist | Any],
+    in_library: set[uuid.UUID],
+    tags_by_artist: dict[uuid.UUID, list[music_models.ArtistTag]],
+    seed_tag_lists: list[list[tuple[str | None, float]]],
+) -> list[music_models.Artist | Any]:
+    """Order name-match candidates for disambiguation (#136). Pure, no I/O.
+
+    In-library artists first, then higher genre affinity to the seed set, then
+    name A-Z. Affinity is computed only when there is a seed set; otherwise every
+    candidate is genre-neutral and the order is in-library-then-name.
+    """
+    affinity_sort: dict[uuid.UUID, float] = {}
+    for a in candidates:
+        score = (
+            genre_module.affinity_score(
+                _genre_pairs(tags_by_artist.get(a.id, [])), seed_tag_lists
+            )
+            if seed_tag_lists
+            else None
+        )
+        affinity_sort[a.id] = _genre_sort_value(score)
+
+    return sorted(
+        candidates,
+        key=lambda a: (
+            a.id not in in_library,
+            -affinity_sort[a.id],
+            a.name.lower(),
+        ),
+    )
 
 
 @router.get(
@@ -108,21 +196,69 @@ async def search_artists(
     q: str,
     user_id: Annotated[uuid.UUID, fastapi.Depends(deps_module.get_current_user_id)],
     db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
-    limit: int = 10,
+    limit: Annotated[int, fastapi.Query(ge=1, le=_SEARCH_CANDIDATE_CAP)] = 10,
+    seed_artist_ids: Annotated[list[uuid.UUID] | None, fastapi.Query()] = None,
 ) -> dict[str, Any]:
-    stmt = (
-        sa.select(music_models.Artist)
-        .where(music_models.Artist.name.ilike(f"%{_escape_ilike(q)}%"))
-        .order_by(music_models.Artist.name)
-        .limit(min(limit, 50))
+    """Search artists by name, ranked for disambiguation (#136).
+
+    Candidates are all exact-name matches (never truncated -- the literal
+    same-name collision like two artists named "Nite" is the core #136 case) plus
+    a capped alphabetical pool of substring matches. They are then ranked so the
+    artist the user most likely means surfaces first:
+
+    1. In-library artists (we have their tracks) beat cold same-name matches.
+    2. Then genre affinity to ``seed_artist_ids`` (the artists already in the
+       builder) -- e.g. metal seeds prefer the metal "Nite" over the electronic
+       one. Unknown-genre stays neutral; a confirmed off-genre match sinks.
+    3. Then name, for a stable order.
+
+    Each result carries ``genres`` (top canonical genres) so two same-name artists
+    are visually distinguishable in the picker.
+    """
+    q_clean = q.strip()
+    # Exact-name matches are never dropped by the cap (the same-name collision is
+    # exactly what #136 is about); the substring pool is capped alphabetically and
+    # ranked around them.
+    exact_stmt = sa.select(music_models.Artist).where(
+        sa.func.lower(music_models.Artist.name) == q_clean.lower()
     )
-    result = await db.execute(stmt)
-    artists = list(result.scalars().all())
-    in_library = await artists_in_library(db, [a.id for a in artists])
+    sub_stmt = (
+        sa.select(music_models.Artist)
+        .where(music_models.Artist.name.ilike(f"%{_escape_ilike(q_clean)}%"))
+        .order_by(music_models.Artist.name)
+        .limit(_SEARCH_CANDIDATE_CAP)
+    )
+    exact = list((await db.execute(exact_stmt)).scalars().all())
+    substring = list((await db.execute(sub_stmt)).scalars().all())
+    # Merge exact-first, dedup by id (exact rows are a subset of substring but may
+    # sit past the alphabetical cap).
+    seen: set[uuid.UUID] = set()
+    candidates: list[music_models.Artist] = []
+    for a in (*exact, *substring):
+        if a.id not in seen:
+            seen.add(a.id)
+            candidates.append(a)
+
+    in_library = await artists_in_library(db, [a.id for a in candidates])
+
+    # Batch-load genre tags for candidates + seeds in one query each (no N+1).
+    seed_ids = list(seed_artist_ids or [])
+    tags_by_artist = await _load_artist_tags(db, [a.id for a in candidates] + seed_ids)
+    seed_tag_lists = [
+        _genre_pairs(tags_by_artist.get(sid, []))
+        for sid in seed_ids
+        if tags_by_artist.get(sid)
+    ]
+
+    ranked = rank_search_candidates(
+        candidates, in_library, tags_by_artist, seed_tag_lists
+    )
+
     items = []
-    for a in artists:
+    for a in ranked[:limit]:  # limit is bounded to [1, cap] by the Query gate
         summary = _format_artist_summary(a)
         summary["in_library"] = a.id in in_library
+        summary["genres"] = _display_genres(tags_by_artist.get(a.id, []))
         items.append(summary)
     return {"items": items}
 

--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -84,6 +84,7 @@ Commands:
   dedup <type> [--no-wait]     Run deduplication
   backfill-mbids [opts]        Backfill MusicBrainz MBIDs (#71)
   backfill-popularity [opts]   Backfill ListenBrainz popularity
+  backfill-genres [opts]       Backfill artist genre tags (#136)
   task <task_id>               Check task status
   track <query>                Search tracks by title
   profile <subcommand>         Manage generator profiles
@@ -1254,6 +1255,39 @@ def _cmd_backfill_popularity() -> None:
     print(json.dumps(result, indent=2))
 
 
+_GENRE_BACKFILL_USAGE = """\
+Usage: resonance-api backfill-genres [opts]
+
+Options:
+  --status       Show coverage (mb-linked / attempted / with-tags), do not enqueue
+  --no-wait      Enqueue and return immediately (don't poll)
+
+Fetches MusicBrainz genre/folksonomy tags for every MBID-bearing artist from
+ListenBrainz's public artist metadata endpoint and stores them in artist_tags.
+Default polls the task to completion and prints the updated/no-tags counts.
+"""
+
+
+def _cmd_backfill_genres() -> None:
+    args = sys.argv[2:]
+    if "--help" in args or "-h" in args:
+        print(_GENRE_BACKFILL_USAGE)
+        return
+    if "--status" in args:
+        resp = _api_request("GET", "/api/v1/admin/backfill-genres")
+        print(json.dumps(resp.json(), indent=2))
+        return
+
+    resp = _api_request("POST", "/api/v1/admin/backfill-genres")
+    task_id = resp.json().get("task_id", "")
+
+    if "--no-wait" in args:
+        print(f"backfill-genres: task {task_id}")
+        return
+    result = _poll_task(task_id, "Backfilling genres")
+    print(json.dumps(result, indent=2))
+
+
 _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "healthz": ("Health + deployed revision", _cmd_healthz),
     "status": ("Recent sync job overview", _cmd_status),
@@ -1267,6 +1301,10 @@ _COMMANDS: dict[str, tuple[str, Callable[[], None]]] = {
     "backfill-popularity": (
         "Backfill ListenBrainz popularity",
         _cmd_backfill_popularity,
+    ),
+    "backfill-genres": (
+        "Backfill artist genre tags",
+        _cmd_backfill_genres,
     ),
     "task": ("Check task status", _cmd_task),
     "track": ("Search tracks by title", _cmd_track),

--- a/src/resonance/generators/genre.py
+++ b/src/resonance/generators/genre.py
@@ -1,0 +1,133 @@
+"""Genre-affinity primitive for artist disambiguation and ranking (#136).
+
+The shared core of the genre model (Arc 1) that every Arc 2 consumer
+(genre-aware generation, discovery, concert lens) plugs into. Pure functions, no
+ORM or I/O -- callers adapt ArtistTag rows to ``(genre_mbid, count)`` pairs.
+
+Model: an artist's genre profile is a sparse vector keyed by ``genre_mbid`` with
+folksonomy ``count`` weights. Only canonical-genre tags participate
+(``genre_mbid`` present); free folksonomy tags ("seen live") are dropped as noise.
+
+Affinity of a candidate to a seed *set* is the cosine of the candidate vector
+against the aggregated seed profile. Each seed vector is L2-normalized BEFORE
+aggregation, so every seed artist contributes equally regardless of its raw
+folksonomy count magnitude -- a MusicBrainz vote tally is not comparable across
+artists (a famous act accrues hundreds of votes, an obscure one gets two), so
+summing raw counts would let one heavily-tagged seed hijack the profile. Intra
+-artist relative counts (metal:9 vs thrash:1) are preserved; only the cross
+-artist scale is normalized away.
+
+No-data vs wrong-genre: ``affinity_score`` returns ``None`` when there is no basis
+to compare (the candidate has no canonical-genre tags, or the seed set has none),
+and a float in ``[0.0, 1.0]`` otherwise. This keeps "unknown genre" (None)
+distinct from "known mismatch" (0.0) so a ranking consumer never suppresses an
+untagged true match down to the same rank as a confirmed off-genre one. Callers
+choose the neutral for None (e.g. skip the genre term entirely).
+
+Sparse behavior: when both sides carry a single genre, cosine is 1.0 on a shared
+genre and 0.0 otherwise -- a binary, lossy signal at the sparse end (two single
+-tag candidates sharing the seed genre tie at 1.0, discarding count detail). This
+is tolerated because multi-tag artists are the common case; it is information loss
+at the tail, not a correctness claim. Smoothing (a floor, or blending shared-tag
+overlap) can be added behind ``affinity_score`` in Arc 2 -- consumers depend on
+the function, not the cosine internals.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import collections.abc as abc
+
+# A genre profile: genre_mbid -> summed folksonomy count weight.
+GenreVector = dict[str, float]
+
+
+def build_vector(tags: abc.Iterable[tuple[str | None, float]]) -> GenreVector:
+    """Build a genre vector from ``(genre_mbid, count)`` pairs.
+
+    Tags with no ``genre_mbid`` (free folksonomy tags) are dropped -- only
+    canonical genres shape the vector. Negative counts are floored to 0;
+    non-finite counts (inf/nan) are dropped so they cannot poison a downstream
+    cosine with NaN. Repeated genres are summed.
+    """
+    vec: GenreVector = {}
+    for genre_mbid, count in tags:
+        if not genre_mbid:
+            continue
+        weight = float(count)
+        if not math.isfinite(weight):
+            continue
+        vec[genre_mbid] = vec.get(genre_mbid, 0.0) + max(0.0, weight)
+    return vec
+
+
+def l2_normalize(vec: GenreVector) -> GenreVector:
+    """Return ``vec`` scaled to unit L2 norm (empty/zero-norm -> empty)."""
+    norm = math.sqrt(sum(w * w for w in vec.values()))
+    if norm == 0.0:
+        return {}
+    return {k: w / norm for k, w in vec.items()}
+
+
+def aggregate_vectors(vectors: abc.Iterable[GenreVector]) -> GenreVector:
+    """Sum genre vectors component-wise into one profile.
+
+    A plain component-wise sum -- callers that need equal per-vector weight should
+    ``l2_normalize`` each input before aggregating (``affinity_score`` does).
+    """
+    out: GenreVector = {}
+    for vec in vectors:
+        for genre_mbid, weight in vec.items():
+            out[genre_mbid] = out.get(genre_mbid, 0.0) + weight
+    return out
+
+
+def cosine(a: GenreVector, b: GenreVector) -> float:
+    """Cosine similarity of two genre vectors, in ``[0.0, 1.0]``.
+
+    Returns 0.0 when either vector is empty/zero-magnitude, or when the two share
+    no genre. Weights are non-negative, so the result never goes below 0 and is
+    clamped to 1.0 against float rounding.
+    """
+    if not a or not b:
+        return 0.0
+    shared = a.keys() & b.keys()
+    if not shared:
+        return 0.0
+    dot = sum(a[k] * b[k] for k in shared)
+    # Weights are non-negative, so dot >= 0; == 0 only if every shared genre has
+    # zero weight on one side (division would be fine, but short-circuit anyway).
+    if dot == 0.0:
+        return 0.0
+    norm_a = math.sqrt(sum(w * w for w in a.values()))
+    norm_b = math.sqrt(sum(w * w for w in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return min(1.0, dot / (norm_a * norm_b))
+
+
+def affinity_score(
+    candidate_tags: abc.Iterable[tuple[str | None, float]],
+    seed_tag_lists: abc.Iterable[abc.Iterable[tuple[str | None, float]]],
+) -> float | None:
+    """Genre affinity of a candidate artist to a seed set.
+
+    The public entry point for #136 ranking. Each seed vector is L2-normalized
+    before aggregation so seeds contribute equally regardless of raw count scale.
+
+    Returns:
+        A cosine similarity in ``[0.0, 1.0]``, or ``None`` when there is no basis
+        to compare (candidate has no canonical-genre tags, or no seed does). A
+        consumer maps ``None`` to its own neutral (typically: omit the genre term)
+        and keeps it distinct from a genuine 0.0 mismatch.
+    """
+    candidate = build_vector(candidate_tags)
+    seed_profile = aggregate_vectors(
+        l2_normalize(build_vector(t)) for t in seed_tag_lists
+    )
+    if not candidate or not seed_profile:
+        return None
+    return cosine(candidate, seed_profile)

--- a/src/resonance/models/__init__.py
+++ b/src/resonance/models/__init__.py
@@ -12,7 +12,7 @@ from resonance.models.concert import (
     VenueCandidate,
 )
 from resonance.models.generator import GenerationRecord, GeneratorProfile
-from resonance.models.music import Artist, ListeningEvent, Track
+from resonance.models.music import Artist, ArtistTag, ListeningEvent, Track
 from resonance.models.playlist import Playlist, PlaylistTrack
 from resonance.models.task import Task
 from resonance.models.taste import (
@@ -25,6 +25,7 @@ from resonance.models.user import ServiceConnection, User
 __all__ = [
     "Artist",
     "ArtistSimilarity",
+    "ArtistTag",
     "Base",
     "EntityExclusion",
     "Event",

--- a/src/resonance/models/music.py
+++ b/src/resonance/models/music.py
@@ -54,10 +54,82 @@ class Artist(base_module.TimestampMixin, base_module.Base):
         nullable=True,
         default=None,
     )
+    # Genre-tag backfill bookkeeping (#136 genre model, Arc 1). genre_attempted_at
+    # IS NULL means "not yet attempted" and is the resume key for GENRE_BACKFILL;
+    # the tags themselves live in the artist_tags table. "attempted but no tags"
+    # is genre_attempted_at IS NOT NULL AND no ArtistTag rows -- distinct from
+    # unattempted (NULL).
+    genre_attempted_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        sa.DateTime(timezone=True), nullable=True, default=None
+    )
 
     tracks: orm.Mapped[list[Track]] = orm.relationship(
         back_populates="artist", cascade="all, delete-orphan"
     )
+    # Named "tags" not "genres" because rows include non-genre folksonomy tags
+    # ("seen live", "american"); the genre subset is those with genre_mbid set.
+    # Async: access requires eager loading (selectinload) or awaitable_attrs.
+    tags: orm.Mapped[list[ArtistTag]] = orm.relationship(
+        back_populates="artist", cascade="all, delete-orphan"
+    )
+
+
+class ArtistTag(base_module.TimestampMixin, base_module.Base):
+    """A genre/folksonomy tag for an artist (#136 genre model, Arc 1).
+
+    Durable domain data, NOT a cache -- mirrors ArtistSimilarity. Each row records
+    that ``source`` (default MusicBrainz, fetched via the ListenBrainz artist
+    metadata endpoint) reports ``tag`` on the artist with folksonomy ``count``.
+    ``genre_mbid`` is non-NULL only for canonical MusicBrainz *genres* (e.g.
+    "electronic", "death metal"); it is NULL for free folksonomy tags ("seen
+    live", "american"), so genre-vs-noise filtering is data-driven, not a
+    hand-maintained stoplist. ``fetched_at`` drives refresh-if-old, not eviction.
+
+    ``source`` is a plain string (default "musicbrainz"), NOT the ServiceType
+    enum used for connector provenance elsewhere: ServiceType has no MUSICBRAINZ
+    member, and this records the tag *taxonomy origin* (MusicBrainz) rather than
+    the fetch transport (ListenBrainz). The writer normalizes it lowercase. Kept
+    a string (not an enum + CHECK) so a future taxonomy source needs no migration.
+
+    Tags for an artist are replaced wholesale on refresh; the unique constraint
+    guards against in-batch duplicates.
+    """
+
+    __tablename__ = "artist_tags"
+    # The (artist_id, tag) unique constraint's composite btree also serves every
+    # artist_id lookup (leftmost prefix): per-artist reads, the batch-load
+    # WHERE artist_id IN (...), and the coverage NOT EXISTS anti-join. No separate
+    # ix_artist_tags_artist_id is needed (the ArtistSimilarity precedent's extra
+    # index is redundant for the same reason) -- do not "restore" it.
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "artist_id",
+            "tag",
+            name="uq_artist_tags_artist_tag",
+        ),
+        sa.CheckConstraint("count >= 0", name="ck_artist_tags_count_nonneg"),
+    )
+
+    id: orm.Mapped[uuid.UUID] = orm.mapped_column(
+        sa.Uuid, primary_key=True, default=uuid.uuid4
+    )
+    artist_id: orm.Mapped[uuid.UUID] = orm.mapped_column(
+        sa.ForeignKey("artists.id", ondelete="CASCADE"), nullable=False
+    )
+    tag: orm.Mapped[str] = orm.mapped_column(sa.String(256), nullable=False)
+    # Non-NULL only for canonical MusicBrainz genres; NULL for folksonomy tags.
+    genre_mbid: orm.Mapped[str | None] = orm.mapped_column(
+        sa.String(64), nullable=True, default=None
+    )
+    count: orm.Mapped[int] = orm.mapped_column(sa.Integer, nullable=False)
+    source: orm.Mapped[str] = orm.mapped_column(
+        sa.String(64), nullable=False, default="musicbrainz"
+    )
+    fetched_at: orm.Mapped[datetime.datetime] = orm.mapped_column(
+        sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+    )
+
+    artist: orm.Mapped[Artist] = orm.relationship(back_populates="tags")
 
 
 class Track(base_module.TimestampMixin, base_module.Base):

--- a/src/resonance/services/artist_tags.py
+++ b/src/resonance/services/artist_tags.py
@@ -1,0 +1,202 @@
+"""Client for the ListenBrainz artist metadata endpoint (genre/folksonomy tags).
+
+Fetches MusicBrainz tags for artists by MBID via the public
+``GET /1/metadata/artist/?artist_mbids=<csv>&inc=tag`` endpoint (#136 genre model).
+
+Design notes:
+
+- Deliberately separate from ``connectors.listenbrainz`` (the OAuth user
+  connection) and from ``mbid_mapper`` (which carries a user token): this endpoint
+  is **token-free** today. A focused GET loop reuses ``RateLimitBudget`` for
+  pacing/backoff, mirroring the mapper without inheriting its token/POST path.
+- The response is a JSON array; each entry carries an ``artist_mbid`` field and a
+  ``tag.artist`` list of ``{tag, count, genre_mbid?}``. We key results BY
+  ``artist_mbid`` (not by position) so a reordered or partial response maps
+  correctly, and a requested MBID absent from the response simply yields no tags
+  (a valid "attempted, no tags" outcome). Because we key by field rather than
+  align by position, there is no positional length-check to share with the
+  mapper's ``_parse_results`` -- the DRY concern dissolves by construction.
+- ``genre_mbid`` is present only on canonical MusicBrainz genres ("rock",
+  "art pop"); it is absent on free folksonomy tags ("alternative", "seen live").
+
+Transient failures (timeouts, 429, 5xx) raise ``ArtistTagsUnavailableError`` so
+the backfill leaves the artist unattempted (retried later) rather than recording a
+false "no tags". Hard failures (4xx other than 429) propagate as
+``httpx.HTTPStatusError``.
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+import pydantic
+import structlog
+
+import resonance.config as config_module
+import resonance.connectors.ratelimit as ratelimit_module
+
+logger = structlog.get_logger()
+
+_DEFAULT_BASE_URL = "https://api.listenbrainz.org/1"
+_ARTIST_PATH = "/metadata/artist/"
+# Matches the ArtistTag.tag column width (models.music).
+_MAX_TAG_LEN = 256
+
+
+class ArtistTagResult(pydantic.BaseModel):
+    """One genre/folksonomy tag reported for an artist.
+
+    ``genre_mbid`` is non-None only for canonical MusicBrainz genres; None marks a
+    free folksonomy tag. ``count`` is the folksonomy vote count.
+    """
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    tag: str
+    count: int = 0
+    genre_mbid: str | None = None
+
+
+class ArtistTagsUnavailableError(Exception):
+    """Raised when the artist-tags endpoint cannot produce a usable batch answer.
+
+    Covers transient conditions (timeouts, connection errors, 429, 5xx) and
+    malformed responses (payload not a list). The backfill treats this as "not
+    attempted" (leaves ``genre_attempted_at`` NULL) so artists are retried.
+    """
+
+
+class ArtistTagsClient:
+    """Batch client for the ListenBrainz artist-tags endpoint (token-free)."""
+
+    _TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+        httpx.ReadTimeout,
+        httpx.ConnectError,
+        httpx.RemoteProtocolError,
+    )
+    _MAX_RETRIES = 5
+    _BACKOFF_BASE = 2.0  # seconds — doubles each retry
+
+    def __init__(
+        self,
+        settings: config_module.Settings,
+        *,
+        base_url: str | None = None,
+    ) -> None:
+        self._base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        # Mirror the recording batch size (default 50); the endpoint takes a
+        # comma-separated artist_mbids list.
+        self._batch_size = max(1, settings.mbid_mapper_batch_size)
+        self._budget = ratelimit_module.RateLimitBudget(default_interval=0.0)
+        self._http_client: httpx.AsyncClient | None = None
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Lazily create the HTTP client (tests inject via ``_http_client``)."""
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=60.0)
+        return self._http_client
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def fetch_tags(
+        self, artist_mbids: list[str]
+    ) -> dict[str, list[ArtistTagResult]]:
+        """Fetch tags for artist MBIDs, keyed by MBID.
+
+        Splits into chunks of ``mbid_mapper_batch_size`` and GETs each. A MBID
+        absent from the merged result had no tags (or was unknown to LB) -- the
+        caller treats that as "attempted, no tags".
+
+        Args:
+            artist_mbids: MusicBrainz artist MBIDs.
+
+        Returns:
+            ``{artist_mbid: [ArtistTagResult, ...]}`` for MBIDs that returned tags.
+
+        Raises:
+            ArtistTagsUnavailableError: On transient failure for any chunk.
+            httpx.HTTPStatusError: On hard HTTP errors.
+        """
+        if not artist_mbids:
+            return {}
+        out: dict[str, list[ArtistTagResult]] = {}
+        for start in range(0, len(artist_mbids), self._batch_size):
+            chunk = artist_mbids[start : start + self._batch_size]
+            out.update(await self._fetch_chunk(chunk))
+        return out
+
+    async def _fetch_chunk(self, chunk: list[str]) -> dict[str, list[ArtistTagResult]]:
+        url = f"{self._base_url}{_ARTIST_PATH}"
+        params = {"artist_mbids": ",".join(chunk), "inc": "tag"}
+        attempt = 0
+        while True:
+            interval = self._budget.paced_interval()
+            if interval > 0:
+                await asyncio.sleep(interval)
+
+            try:
+                response = await self.http_client.get(url, params=params)
+            except self._TRANSIENT_ERRORS as exc:
+                attempt += 1
+                if attempt > self._MAX_RETRIES:
+                    raise ArtistTagsUnavailableError(
+                        f"transient error after {attempt} attempts: {exc}"
+                    ) from exc
+                await asyncio.sleep(self._BACKOFF_BASE**attempt)
+                continue
+
+            self._budget.update_from_headers(dict(response.headers))
+            self._budget.record_request()
+
+            if response.status_code == 429 or response.status_code >= 500:
+                attempt += 1
+                if attempt > self._MAX_RETRIES:
+                    raise ArtistTagsUnavailableError(
+                        f"artist-tags {response.status_code} after {attempt} attempts"
+                    )
+                await asyncio.sleep(self._BACKOFF_BASE**attempt)
+                continue
+
+            response.raise_for_status()
+            return self._parse(response.json())
+
+    @staticmethod
+    def _parse(payload: Any) -> dict[str, list[ArtistTagResult]]:
+        """Parse the artist array into ``{artist_mbid: [tags]}``.
+
+        The payload is a list of artist objects, each with an ``artist_mbid`` and a
+        ``tag.artist`` list. A payload that is not a list is treated as transient
+        (raises ``ArtistTagsUnavailableError``). Per-entry shape problems yield no
+        tags for that artist rather than failing the whole batch.
+        """
+        if not isinstance(payload, list):
+            raise ArtistTagsUnavailableError(
+                "unexpected artist-tags response shape (expected a list)"
+            )
+        out: dict[str, list[ArtistTagResult]] = {}
+        for entry in payload:
+            if not isinstance(entry, dict):
+                continue
+            mbid = entry.get("artist_mbid") or entry.get("mbid")
+            if not mbid:
+                continue
+            tag_block = entry.get("tag")
+            raw_tags = tag_block.get("artist") if isinstance(tag_block, dict) else None
+            # Dedup by (truncated) tag name -- last wins -- and clip to the
+            # ArtistTag.tag column width, so a duplicate or overlong tag from the
+            # source can never trip the (artist_id, tag) unique constraint or the
+            # length limit on insert.
+            deduped: dict[str, ArtistTagResult] = {}
+            if isinstance(raw_tags, list):
+                for raw in raw_tags:
+                    if isinstance(raw, dict) and raw.get("tag"):
+                        res = ArtistTagResult.model_validate(raw)
+                        res.tag = res.tag[:_MAX_TAG_LEN]
+                        deduped[res.tag] = res
+            out[mbid] = list(deduped.values())
+        return out

--- a/src/resonance/static/lineup.core.js
+++ b/src/resonance/static/lineup.core.js
@@ -24,10 +24,22 @@ export function escapeHtml(s) {
 
 export function artistMeta(a) {
   const bits = [];
+  // Genres lead — the strongest disambiguator between same-name artists
+  // (#136: the metal "Nite" vs the electronic one).
+  if (a.genres && a.genres.length) bits.push(a.genres.join(", "));
   if (a.disambiguation) bits.push(a.disambiguation);
   if (a.area) bits.push(a.area);
   if (a.begin_year) bits.push(String(a.begin_year));
   return bits.join(" · ");
+}
+
+/* All artist IDs currently in the builder, for seeding genre-affinity search. */
+export function allArtistIds(groups) {
+  const ids = [];
+  for (const g of groups) {
+    for (const a of g.artists) ids.push(a.id);
+  }
+  return ids;
 }
 
 /* Stable identity for a group, used to target toggle/remove operations. */

--- a/src/resonance/static/lineup.js
+++ b/src/resonance/static/lineup.js
@@ -9,6 +9,7 @@
 import {
   addEventGroup,
   addManualArtist,
+  allArtistIds,
   artistMeta,
   escapeHtml,
   groupKey,
@@ -423,10 +424,19 @@ function onSearch() {
     resultsEl.innerHTML = "";
     return;
   }
+  // Seed genre-affinity ranking with the artists already in the builder, so an
+  // ambiguous name resolves toward the pool's genre (#136). Dedup so an artist in
+  // two groups doesn't double-weight the seed profile or bloat the URL.
+  const seedParams = [...new Set(allArtistIds(state.groups))]
+    .map((id) => "&seed_artist_ids=" + encodeURIComponent(id))
+    .join("");
   searchTimer = setTimeout(() => {
-    fetch("/api/v1/artists/search?q=" + encodeURIComponent(q) + "&limit=8", {
-      credentials: "same-origin",
-    })
+    fetch(
+      "/api/v1/artists/search?q=" + encodeURIComponent(q) + "&limit=8" + seedParams,
+      {
+        credentials: "same-origin",
+      },
+    )
       .then((r) => (r.ok ? r.json() : { items: [] }))
       .then((data) => renderResults(data.items || []))
       .catch(() => {

--- a/src/resonance/sync/backfill.py
+++ b/src/resonance/sync/backfill.py
@@ -44,7 +44,8 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import math
-from typing import TYPE_CHECKING, Any
+import uuid
+from typing import Any
 
 import httpx
 import sqlalchemy as sa
@@ -55,12 +56,10 @@ import resonance.config as config_module
 import resonance.connectors.listenbrainz as listenbrainz_module
 import resonance.models.music as music_module
 import resonance.normalize as normalize_module
+import resonance.services.artist_tags as artist_tags_module
 import resonance.services.artist_utils as artist_utils
 import resonance.services.mbid_mapper as mapper_module
 import resonance.types as types_module
-
-if TYPE_CHECKING:
-    import uuid
 
 logger = structlog.get_logger()
 
@@ -414,6 +413,132 @@ async def run_popularity_backfill(
         await session.commit()
 
     logger.info("popularity_backfill_done", **dataclasses.asdict(counts))
+    return counts
+
+
+@dataclasses.dataclass
+class GenreBackfillCounts:
+    """Outcome tally for a ListenBrainz artist-tag (genre) backfill run."""
+
+    candidates: int = 0
+    updated: int = 0
+    no_tags: int = 0
+    transient: int = 0
+
+
+def _is_valid_mbid(mbid: str) -> bool:
+    """True if ``mbid`` parses as a UUID.
+
+    The LB artist endpoint returns HTTP 400 (a hard error) if ANY MBID in the
+    batch is malformed, which would poison the whole batch. We validate before the
+    fetch and exclude bad MBIDs (they get stamped attempted-no-tags instead), so a
+    single garbage MBID from a prior import can't stall forward progress.
+    """
+    try:
+        uuid.UUID(str(mbid))
+    except ValueError, TypeError, AttributeError:
+        return False
+    return True
+
+
+async def run_genre_backfill(
+    session: Any,
+    settings: config_module.Settings,
+    client: artist_tags_module.ArtistTagsClient,
+) -> GenreBackfillCounts:
+    """Backfill artist genre/folksonomy tags from the ListenBrainz artist endpoint.
+
+    Candidates are artists that carry a MusicBrainz artist MBID
+    (``service_links["musicbrainz"]["id"]``) and have not been attempted
+    (``genre_attempted_at IS NULL``) -- the resume key, mirroring the MBID
+    backfill. Artists without a canonical MBID are simply not candidates; they
+    become candidates once the MBID backfill canonicalizes them, so they are left
+    unattempted rather than stamped.
+
+    Each batch fetches tags for its MBIDs in one call and wholesale-replaces each
+    artist's ``ArtistTag`` rows, then stamps ``genre_attempted_at`` -- all in the
+    per-batch transaction, and only on a successful fetch. A transient endpoint
+    failure raises ``ArtistTagsUnavailableError``; the batch is left unattempted
+    (retried next run) instead of recording a false "no tags".
+
+    Tags with a non-NULL ``genre_mbid`` are canonical MusicBrainz genres; free
+    folksonomy tags (NULL) are stored too, so genre-vs-noise filtering stays a
+    read-time decision on durable data.
+    """
+    counts = GenreBackfillCounts()
+    # Canonical MB artist MBID present (the dominant location get_mbid returns);
+    # this bounds candidates and gives clean resume without re-scanning no-MBID
+    # artists each run.
+    mb_id = music_module.Artist.service_links["musicbrainz"]["id"].as_string()
+    while True:
+        stmt = (
+            sa.select(music_module.Artist)
+            .where(
+                music_module.Artist.genre_attempted_at.is_(None),
+                mb_id.isnot(None),
+            )
+            .limit(settings.mbid_mapper_batch_size)
+        )
+        artists = list((await session.execute(stmt)).scalars().all())
+        if not artists:
+            break
+
+        by_mbid: dict[str, list[music_module.Artist]] = {}
+        for artist in artists:
+            mbid = artist_utils.get_mbid(artist.service_links)
+            # Only fetch valid-UUID MBIDs. A malformed MBID would 400 the whole
+            # batch; excluding it here means the fetch sees only clean input and
+            # that artist falls through to attempted-no-tags below.
+            if mbid and _is_valid_mbid(mbid):
+                by_mbid.setdefault(mbid, []).append(artist)
+
+        if not by_mbid:
+            # No artist in this batch had a usable (valid-UUID) MBID despite the
+            # SQL filter (legacy-only shape, or a malformed id) -- stamp them
+            # attempted so the scan makes progress instead of looping.
+            for artist in artists:
+                artist.genre_attempted_at = _now()
+                counts.candidates += 1
+                counts.no_tags += 1
+            await session.commit()
+            continue
+
+        try:
+            tags_by_mbid = await client.fetch_tags(list(by_mbid.keys()))
+        except artist_tags_module.ArtistTagsUnavailableError:
+            logger.warning("genre_backfill_unavailable", batch=len(artists))
+            counts.transient += len(artists)
+            break  # leave the rest unattempted; retried next run
+
+        for artist in artists:
+            counts.candidates += 1
+            mbid = artist_utils.get_mbid(artist.service_links)
+            results = tags_by_mbid.get(mbid, []) if mbid else []
+            # Wholesale-replace this artist's tags.
+            await session.execute(
+                sa.delete(music_module.ArtistTag).where(
+                    music_module.ArtistTag.artist_id == artist.id
+                )
+            )
+            for res in results:
+                session.add(
+                    music_module.ArtistTag(
+                        artist_id=artist.id,
+                        tag=res.tag,
+                        genre_mbid=res.genre_mbid,
+                        count=max(0, res.count),
+                        source="musicbrainz",
+                    )
+                )
+            artist.genre_attempted_at = _now()
+            if results:
+                counts.updated += 1
+            else:
+                counts.no_tags += 1
+
+        await session.commit()
+
+    logger.info("genre_backfill_done", **dataclasses.asdict(counts))
     return counts
 
 

--- a/src/resonance/types.py
+++ b/src/resonance/types.py
@@ -90,6 +90,7 @@ class TaskType(enum.StrEnum):
     MBID_BACKFILL = "mbid_backfill"
     POPULARITY_BACKFILL = "popularity_backfill"
     RELATED_ARTIST_ENRICHMENT = "related_artist_enrichment"
+    GENRE_BACKFILL = "genre_backfill"
 
 
 class SyncStatus(enum.StrEnum):

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -63,6 +63,7 @@ import resonance.models.task as task_module
 import resonance.models.taste as taste_models
 import resonance.models.user as user_models
 import resonance.services.artist_import as artist_import_module
+import resonance.services.artist_tags as artist_tags_module
 import resonance.services.artist_utils as artist_utils
 import resonance.services.mbid_mapper as mbid_mapper_module
 import resonance.sync.backfill as backfill_module
@@ -127,6 +128,10 @@ _TASK_DISPATCH: dict[
     ),
     types_module.TaskType.RELATED_ARTIST_ENRICHMENT: (
         "enrich_related_artists",
+        lambda t: (str(t.id),),
+    ),
+    types_module.TaskType.GENRE_BACKFILL: (
+        "backfill_genres",
         lambda t: (str(t.id),),
     ),
 }
@@ -709,6 +714,60 @@ async def backfill_popularity(ctx: dict[str, Any], task_id: str) -> None:
             if task is not None:
                 await lifecycle_module.fail_task(session, task, traceback.format_exc())
                 await session.commit()
+
+
+async def backfill_genres(ctx: dict[str, Any], task_id: str) -> None:
+    """Execute a GENRE_BACKFILL task (#136): fetch artist genre/folksonomy tags.
+
+    Fetches MusicBrainz tags for each MBID-bearing artist from ListenBrainz's
+    public artist metadata endpoint (token-free) and wholesale-replaces the
+    artist's ArtistTag rows. Batched and resumable across worker restarts off
+    ``genre_attempted_at IS NULL``; a transient endpoint outage leaves the
+    remainder unattempted for retry.
+
+    Args:
+        ctx: arq worker context dict.
+        task_id: UUID string of the GENRE_BACKFILL Task.
+    """
+    wctx = typing.cast("WorkerContext", ctx)
+    settings = wctx["settings"]
+    session_factory = wctx["session_factory"]
+    log = logger.bind(task_id=task_id)
+
+    client = artist_tags_module.ArtistTagsClient(settings)
+
+    async with session_factory() as session:
+        task: task_module.Task | None = None
+        try:
+            task = await _load_task(session, task_id)
+            if task is None:
+                log.error("genre_backfill_task_not_found")
+                return
+
+            if await lifecycle_module.is_cancelled(session, task):
+                await lifecycle_module.fail_task(
+                    session, task, "Parent task was cancelled"
+                )
+                await session.commit()
+                return
+
+            task.status = types_module.SyncStatus.RUNNING
+            task.started_at = datetime.datetime.now(datetime.UTC)
+            await session.commit()
+
+            log.info("genre_backfill_started")
+            counts = await backfill_module.run_genre_backfill(session, settings, client)
+            result: dict[str, object] = dataclasses.asdict(counts)
+            await lifecycle_module.complete_task(session, task, result)
+            await session.commit()
+            log.info("genre_backfill_done", result=result)
+        except Exception:
+            log.exception("genre_backfill_failed")
+            if task is not None:
+                await lifecycle_module.fail_task(session, task, traceback.format_exc())
+                await session.commit()
+        finally:
+            await client.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -2995,6 +3054,7 @@ class WorkerSettings:
         arq.func(heartbeat_module.with_heartbeat(backfill_mbids), timeout=3600),
         arq.func(heartbeat_module.with_heartbeat(backfill_popularity), timeout=3600),
         arq.func(heartbeat_module.with_heartbeat(enrich_related_artists), timeout=3600),
+        arq.func(heartbeat_module.with_heartbeat(backfill_genres), timeout=3600),
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/tests/js/lineup.core.test.js
+++ b/tests/js/lineup.core.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addEventGroup,
   addManualArtist,
+  allArtistIds,
   artistMeta,
   escapeHtml,
   groupKey,
@@ -37,6 +38,28 @@ describe("artistMeta", () => {
   it("omits empty fields", () => {
     expect(artistMeta({ area: "US" })).toBe("US");
     expect(artistMeta({})).toBe("");
+  });
+  it("leads with genres when present", () => {
+    expect(artistMeta({ genres: ["black metal", "thrash"], area: "NO" })).toBe(
+      "black metal, thrash · NO"
+    );
+  });
+  it("ignores an empty genres list", () => {
+    expect(artistMeta({ genres: [], area: "US" })).toBe("US");
+  });
+});
+
+describe("allArtistIds", () => {
+  it("collects ids across all groups", () => {
+    const groups = [
+      { artists: [{ id: "a" }, { id: "b" }] },
+      { artists: [] },
+      { artists: [{ id: "c" }] },
+    ];
+    expect(allArtistIds(groups)).toEqual(["a", "b", "c"]);
+  });
+  it("is empty for no artists", () => {
+    expect(allArtistIds([{ artists: [] }])).toEqual([]);
   });
 });
 

--- a/tests/test_api_matching.py
+++ b/tests/test_api_matching.py
@@ -261,6 +261,44 @@ class TestArtistSearch:
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "The Red Pears"
 
+    async def test_accepts_seed_ids_and_returns_genres(
+        self, user_id: uuid.UUID
+    ) -> None:
+        # The #136 wiring contract: the seed_artist_ids query param binds (no 422)
+        # and each result carries a `genres` list for picker disambiguation.
+        artist = _make_artist(name="Nite")
+        tag = SimpleNamespace(
+            artist_id=artist.id, tag="black metal", genre_mbid="g1", count=9
+        )
+        db = FakeAsyncSession()
+        # Query order: exact-name, substring, in-library, tags.
+        db.set_results(
+            [
+                FakeResult([artist]),
+                FakeResult([]),
+                FakeResult([]),
+                FakeResult([tag]),
+            ]
+        )
+
+        app = _create_app(user_id, db)
+        settings = _make_settings()
+        cookie = _make_session_cookie(settings.session_secret_key)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            cookies={"session_id": cookie},
+        ) as c:
+            resp = await c.get(
+                f"/api/v1/artists/search?q=Nite&seed_artist_ids={uuid.uuid4()}"
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"][0]["name"] == "Nite"
+        assert data["items"][0]["genres"] == ["black metal"]
+
     async def test_requires_q_param(self, authed_client: httpx.AsyncClient) -> None:
         resp = await authed_client.get("/api/v1/artists/search")
         assert resp.status_code == 422

--- a/tests/test_artist_search_ranking.py
+++ b/tests/test_artist_search_ranking.py
@@ -1,0 +1,83 @@
+"""Tests for artist search disambiguation ranking (#136 Arc 1 phase 4)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import resonance.api.v1.artists as artists_module
+
+
+def _artist(name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), name=name)
+
+
+def _tag(genre_mbid: str | None, count: int) -> SimpleNamespace:
+    return SimpleNamespace(genre_mbid=genre_mbid, count=count)
+
+
+def _rank(
+    candidates: list[Any],
+    in_library: set[uuid.UUID],
+    tags: dict[uuid.UUID, list[Any]],
+    seeds: list[list[tuple[str | None, float]]],
+) -> list[str]:
+    ranked = artists_module.rank_search_candidates(candidates, in_library, tags, seeds)
+    return [a.name for a in ranked]
+
+
+class TestRankSearchCandidates:
+    def test_in_library_beats_cold_match(self) -> None:
+        cold = _artist("Nite")  # electronic collision, alphabetically same
+        mine = _artist("Nite")  # the one we have tracks for
+        order = _rank([cold, mine], {mine.id}, {}, [])
+        assert order[0] == "Nite"  # both named Nite; the in-library one is first
+        ranked = artists_module.rank_search_candidates([cold, mine], {mine.id}, {}, [])
+        assert ranked[0] is mine
+
+    def test_metal_seed_prefers_metal_over_electronic(self) -> None:
+        # Neither in library; genre affinity to metal seeds breaks the tie.
+        metal = _artist("Nite")
+        electronic = _artist("Nite")
+        tags = {
+            metal.id: [_tag("g-metal", 9), _tag("g-thrash", 2)],
+            electronic.id: [_tag("g-house", 8), _tag("g-techno", 3)],
+        }
+        seeds = [[("g-metal", 8), ("g-black", 3)], [("g-metal", 5)]]
+        ranked = artists_module.rank_search_candidates(
+            [electronic, metal], set(), tags, seeds
+        )
+        assert ranked[0] is metal
+
+    def test_unknown_genre_outranks_confirmed_mismatch(self) -> None:
+        # untagged (could be the right band) must beat a known off-genre artist.
+        untagged = _artist("Nite")
+        wrong = _artist("Nite")
+        tags = {wrong.id: [_tag("g-polka", 5)]}  # untagged has no tags
+        seeds = [[("g-metal", 8)]]
+        ranked = artists_module.rank_search_candidates(
+            [wrong, untagged], set(), tags, seeds
+        )
+        assert ranked[0] is untagged
+
+    def test_no_seeds_falls_back_to_in_library_then_name(self) -> None:
+        b = _artist("Beta")
+        a = _artist("Alpha")
+        order = _rank([b, a], set(), {}, [])
+        assert order == ["Alpha", "Beta"]
+
+    def test_in_library_dominates_genre(self) -> None:
+        # An in-library off-genre artist still beats a cold on-genre one: the
+        # library signal is primary (you listen to the one you mean).
+        cold_metal = _artist("X")
+        mine_pop = _artist("X")
+        tags = {
+            cold_metal.id: [_tag("g-metal", 9)],
+            mine_pop.id: [_tag("g-pop", 9)],
+        }
+        seeds = [[("g-metal", 9)]]
+        ranked = artists_module.rank_search_candidates(
+            [cold_metal, mine_pop], {mine_pop.id}, tags, seeds
+        )
+        assert ranked[0] is mine_pop

--- a/tests/test_artist_tags.py
+++ b/tests/test_artist_tags.py
@@ -1,0 +1,125 @@
+"""Tests for the ListenBrainz artist-tags client (#136 genre model)."""
+
+from __future__ import annotations
+
+import pytest
+
+import resonance.config as config_module
+import resonance.services.artist_tags as artist_tags_module
+
+
+def _settings() -> config_module.Settings:
+    return config_module.Settings(mbid_mapper_batch_size=2)
+
+
+def _client() -> artist_tags_module.ArtistTagsClient:
+    return artist_tags_module.ArtistTagsClient(_settings())
+
+
+# A trimmed real-shape response (verified live against the LB artist endpoint).
+_RADIOHEAD = "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+_PAYLOAD = [
+    {
+        "artist_mbid": _RADIOHEAD,
+        "name": "Radiohead",
+        "tag": {
+            "artist": [
+                {"artist_mbid": _RADIOHEAD, "count": 2, "tag": "alternative"},
+                {
+                    "artist_mbid": _RADIOHEAD,
+                    "count": 18,
+                    "genre_mbid": "0e3fc579-2d24-4f20-9dae-736e1ec78798",
+                    "tag": "rock",
+                },
+            ]
+        },
+    }
+]
+
+
+class TestParse:
+    def test_keys_by_artist_mbid_and_extracts_fields(self) -> None:
+        out = artist_tags_module.ArtistTagsClient._parse(_PAYLOAD)
+        assert set(out) == {_RADIOHEAD}
+        tags = {t.tag: t for t in out[_RADIOHEAD]}
+        assert tags["rock"].count == 18
+        assert tags["rock"].genre_mbid == "0e3fc579-2d24-4f20-9dae-736e1ec78798"
+        # Folksonomy tag: no genre_mbid.
+        assert tags["alternative"].genre_mbid is None
+
+    def test_missing_tag_block_yields_empty_list(self) -> None:
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [{"artist_mbid": _RADIOHEAD, "name": "Radiohead"}]
+        )
+        assert out == {_RADIOHEAD: []}
+
+    def test_entry_without_mbid_is_skipped(self) -> None:
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [{"name": "no mbid", "tag": {"artist": [{"tag": "x", "count": 1}]}}]
+        )
+        assert out == {}
+
+    def test_falls_back_to_mbid_field(self) -> None:
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [{"mbid": _RADIOHEAD, "tag": {"artist": []}}]
+        )
+        assert out == {_RADIOHEAD: []}
+
+    def test_tag_without_name_is_dropped(self) -> None:
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [{"artist_mbid": _RADIOHEAD, "tag": {"artist": [{"count": 3}]}}]
+        )
+        assert out == {_RADIOHEAD: []}
+
+    def test_non_list_payload_raises_transient(self) -> None:
+        with pytest.raises(artist_tags_module.ArtistTagsUnavailableError):
+            artist_tags_module.ArtistTagsClient._parse({"error": "nope"})
+
+    def test_duplicate_tag_deduped_last_wins(self) -> None:
+        # Guards the (artist_id, tag) unique constraint against a duplicate tag
+        # in the source response.
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [
+                {
+                    "artist_mbid": _RADIOHEAD,
+                    "tag": {
+                        "artist": [
+                            {"tag": "rock", "count": 1},
+                            {"tag": "rock", "count": 9, "genre_mbid": "g"},
+                        ]
+                    },
+                }
+            ]
+        )
+        tags = out[_RADIOHEAD]
+        assert len(tags) == 1
+        assert tags[0].count == 9  # last wins
+        assert tags[0].genre_mbid == "g"
+
+    def test_overlong_tag_truncated_to_column_width(self) -> None:
+        long_tag = "x" * 400
+        out = artist_tags_module.ArtistTagsClient._parse(
+            [{"artist_mbid": _RADIOHEAD, "tag": {"artist": [{"tag": long_tag}]}}]
+        )
+        assert len(out[_RADIOHEAD][0].tag) == 256
+
+
+class TestFetchTagsChunking:
+    @pytest.mark.anyio()
+    async def test_splits_into_batches_and_merges(self) -> None:
+        client = _client()  # batch size 2
+        seen_chunks: list[list[str]] = []
+
+        async def fake_chunk(chunk: list[str]) -> dict[str, list[object]]:
+            seen_chunks.append(chunk)
+            return {m: [] for m in chunk}
+
+        client._fetch_chunk = fake_chunk  # type: ignore[method-assign]
+        out = await client.fetch_tags(["a", "b", "c"])
+
+        assert seen_chunks == [["a", "b"], ["c"]]
+        assert set(out) == {"a", "b", "c"}
+
+    @pytest.mark.anyio()
+    async def test_empty_input_returns_empty(self) -> None:
+        assert await _client().fetch_tags([]) == {}

--- a/tests/test_genre_affinity.py
+++ b/tests/test_genre_affinity.py
@@ -1,0 +1,128 @@
+"""Tests for the genre-affinity primitive (#136 genre model, Arc 1 phase 3)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import resonance.generators.genre as genre
+
+_APPROX = {"abs": 1e-9}
+
+
+class TestBuildVector:
+    def test_drops_non_genre_tags(self) -> None:
+        # Only genre_mbid-bearing tags participate; folksonomy tags are noise.
+        vec = genre.build_vector([("g-rock", 5), (None, 99), ("g-jazz", 2), (None, 1)])
+        assert vec == {"g-rock": 5.0, "g-jazz": 2.0}
+
+    def test_sums_repeated_genres(self) -> None:
+        assert genre.build_vector([("g", 3), ("g", 4)]) == {"g": 7.0}
+
+    def test_floors_negative_counts(self) -> None:
+        assert genre.build_vector([("g", -5)]) == {"g": 0.0}
+
+    def test_drops_non_finite_counts(self) -> None:
+        # inf/nan must not survive into a downstream cosine (NaN poisons sort).
+        assert genre.build_vector([("g", float("inf"))]) == {}
+        assert genre.build_vector([("g", float("nan"))]) == {}
+
+    def test_empty(self) -> None:
+        assert genre.build_vector([]) == {}
+
+
+class TestCosine:
+    def test_identical_vectors_is_one(self) -> None:
+        v = {"g-rock": 3.0, "g-jazz": 1.0}
+        assert genre.cosine(v, v) == pytest.approx(1.0, **_APPROX)
+
+    def test_disjoint_genres_is_zero(self) -> None:
+        assert genre.cosine({"g-rock": 5.0}, {"g-jazz": 5.0}) == 0.0
+
+    def test_empty_is_zero(self) -> None:
+        assert genre.cosine({}, {"g": 1.0}) == 0.0
+        assert genre.cosine({"g": 1.0}, {}) == 0.0
+
+    def test_partial_overlap(self) -> None:
+        # a=(1,0), b=(1,1) -> cos = 1/sqrt(2)
+        a = {"metal": 1.0}
+        b = {"metal": 1.0, "rock": 1.0}
+        assert genre.cosine(a, b) == pytest.approx(1.0 / math.sqrt(2), **_APPROX)
+
+    def test_never_exceeds_one(self) -> None:
+        a = {"a": 3.0, "b": 4.0, "c": 5.0}
+        assert genre.cosine(a, a) <= 1.0
+
+
+class TestSparseSingleTag:
+    """The deliberate binary low-end behavior, pinned by the design."""
+
+    def test_same_single_genre_is_one(self) -> None:
+        assert genre.cosine({"metal": 1.0}, {"metal": 1.0}) == pytest.approx(
+            1.0, **_APPROX
+        )
+
+    def test_different_single_genre_is_zero(self) -> None:
+        assert genre.cosine({"metal": 1.0}, {"jazz": 1.0}) == 0.0
+
+
+class TestAffinityScore:
+    def test_metal_candidate_beats_electronic_for_metal_seeds(self) -> None:
+        # The #136 case: seeds are metal bands; the metal candidate outranks the
+        # electronic one, so disambiguation prefers the right artist.
+        seeds = [
+            [("g-metal", 8), ("g-thrash", 3), (None, 20)],
+            [("g-metal", 5), ("g-death", 2)],
+        ]
+        metal = [("g-metal", 9), ("g-thrash", 1)]
+        electronic = [("g-house", 7), ("g-techno", 4)]
+        m = genre.affinity_score(metal, seeds)
+        e = genre.affinity_score(electronic, seeds)
+        assert m is not None and e is not None
+        assert m > e
+
+    def test_seed_majority_beats_one_heavy_off_genre_seed(self) -> None:
+        # Three metal seeds (small counts) + one pop seed with a huge count.
+        # Per-seed L2 normalization must keep the metal *consensus* winning over
+        # the single loud pop seed -- the finding-#1 regression guard.
+        seeds = [
+            [("metal", 5)],
+            [("metal", 5)],
+            [("metal", 5)],
+            [("pop", 1000)],
+        ]
+        metal = genre.affinity_score([("metal", 5)], seeds)
+        pop = genre.affinity_score([("pop", 5)], seeds)
+        assert metal is not None and pop is not None
+        assert metal > pop
+
+    def test_no_candidate_genre_is_none_not_zero(self) -> None:
+        # "unknown genre" (None) must stay distinct from "wrong genre" (0.0) so a
+        # ranker never ties an untagged true match with a confirmed mismatch.
+        seeds = [[("g-metal", 5)]]
+        assert genre.affinity_score([], seeds) is None
+        assert genre.affinity_score([(None, 3)], seeds) is None
+
+    def test_wrong_genre_is_zero_not_none(self) -> None:
+        # Both sides have genre data but share nothing -> a real 0.0 mismatch.
+        assert genre.affinity_score([("g-house", 5)], [[("g-metal", 5)]]) == 0.0
+
+    def test_empty_seed_set_is_none(self) -> None:
+        assert genre.affinity_score([("g-metal", 5)], []) is None
+
+    def test_bounded_zero_to_one(self) -> None:
+        seeds = [[("g-metal", 8)], [("g-metal", 3), ("g-rock", 2)]]
+        score = genre.affinity_score([("g-metal", 5), ("g-rock", 1)], seeds)
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+
+
+class TestL2Normalize:
+    def test_unit_norm(self) -> None:
+        out = genre.l2_normalize({"a": 3.0, "b": 4.0})
+        assert math.isclose(math.sqrt(sum(w * w for w in out.values())), 1.0)
+
+    def test_zero_norm_is_empty(self) -> None:
+        assert genre.l2_normalize({}) == {}
+        assert genre.l2_normalize({"a": 0.0}) == {}

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -1,0 +1,191 @@
+"""Tests for the artist genre-tag backfill (#136 genre model)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import sqlalchemy as sa
+
+import resonance.config as config_module
+import resonance.models.music as music_module
+import resonance.services.artist_tags as artist_tags_module
+import resonance.sync.backfill as backfill_module
+
+
+def _settings() -> config_module.Settings:
+    return config_module.Settings(mbid_mapper_batch_size=50)
+
+
+def _artist(mbid: str | None) -> SimpleNamespace:
+    links = {"musicbrainz": {"id": mbid}} if mbid else None
+    return SimpleNamespace(
+        id=uuid.uuid4(), service_links=links, genre_attempted_at=None
+    )
+
+
+class _FakeResult:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def scalars(self) -> _FakeResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return self._items
+
+
+class _RoutingSession:
+    """Fake session: Select -> next batch, Delete -> noop; records adds/commits."""
+
+    def __init__(self, select_batches: list[list[Any]]) -> None:
+        self._batches = list(select_batches)
+        self.added: list[music_module.ArtistTag] = []
+        self.deletes = 0
+        self.commits = 0
+
+    async def execute(self, stmt: Any, *a: Any, **k: Any) -> Any:
+        if isinstance(stmt, sa.Delete):
+            self.deletes += 1
+            return SimpleNamespace()
+        # Treat everything else as the SELECT.
+        batch = self._batches.pop(0) if self._batches else []
+        return _FakeResult(batch)
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def _client(tags: dict[str, list[artist_tags_module.ArtistTagResult]]) -> Any:
+    return SimpleNamespace(fetch_tags=AsyncMock(return_value=tags))
+
+
+def _tag(name: str, count: int = 1, genre_mbid: str | None = None) -> Any:
+    return artist_tags_module.ArtistTagResult(
+        tag=name, count=count, genre_mbid=genre_mbid
+    )
+
+
+class TestRunGenreBackfill:
+    @pytest.mark.anyio()
+    async def test_happy_path_stores_tags_and_stamps(self) -> None:
+        art = _artist("33333333-3333-3333-3333-333333333333")
+        session = _RoutingSession([[art], []])
+        client = _client(
+            {
+                "33333333-3333-3333-3333-333333333333": [
+                    _tag("rock", 5, "g-rock"),
+                    _tag("indie", 2),
+                ]
+            }
+        )
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        assert counts.candidates == 1
+        assert counts.updated == 1
+        assert counts.no_tags == 0
+        assert art.genre_attempted_at is not None  # stamped
+        assert session.deletes == 1  # wholesale-replace issued
+        stored = {t.tag: t for t in session.added}
+        assert stored["rock"].genre_mbid == "g-rock"
+        assert stored["rock"].count == 5
+        assert stored["indie"].genre_mbid is None
+
+    @pytest.mark.anyio()
+    async def test_no_tags_still_stamps_attempted(self) -> None:
+        art = _artist("33333333-3333-3333-3333-333333333333")
+        session = _RoutingSession([[art], []])
+        client = _client({})  # LB returned nothing for this MBID
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        assert counts.no_tags == 1
+        assert counts.updated == 0
+        assert art.genre_attempted_at is not None  # attempted, no tags
+        assert session.added == []
+        assert session.deletes == 1  # still clears any stale tags
+
+    @pytest.mark.anyio()
+    async def test_transient_leaves_unattempted(self) -> None:
+        art = _artist("33333333-3333-3333-3333-333333333333")
+        session = _RoutingSession([[art], []])
+        client = SimpleNamespace(
+            fetch_tags=AsyncMock(
+                side_effect=artist_tags_module.ArtistTagsUnavailableError("down")
+            )
+        )
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        assert counts.transient == 1
+        assert counts.updated == 0
+        assert art.genre_attempted_at is None  # retried next run (CRITICAL)
+        assert session.added == []
+
+    @pytest.mark.anyio()
+    async def test_negative_count_clamped_to_zero(self) -> None:
+        art = _artist("33333333-3333-3333-3333-333333333333")
+        session = _RoutingSession([[art], []])
+        client = _client(
+            {"33333333-3333-3333-3333-333333333333": [_tag("weird", -3, "g")]}
+        )
+
+        await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        assert session.added[0].count == 0  # CHECK(count >= 0) protected
+
+    @pytest.mark.anyio()
+    async def test_invalid_mbid_not_fetched_but_stamped(self) -> None:
+        # A malformed MBID must NOT reach fetch_tags (it would 400 the batch);
+        # the artist is stamped attempted-no-tags instead.
+        good = _artist("a74b1b7f-71a5-4011-9441-d0b5e4122711")
+        bad = _artist("not-a-uuid")
+        session = _RoutingSession([[good, bad], []])
+        fetch = AsyncMock(return_value={"a74b1b7f-71a5-4011-9441-d0b5e4122711": []})
+        client = SimpleNamespace(fetch_tags=fetch)
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        # Only the valid MBID was sent to the endpoint.
+        fetch.assert_awaited_once_with(["a74b1b7f-71a5-4011-9441-d0b5e4122711"])
+        assert good.genre_attempted_at is not None
+        assert bad.genre_attempted_at is not None  # stamped, not re-scanned
+        assert counts.candidates == 2
+
+    @pytest.mark.anyio()
+    async def test_all_invalid_batch_skips_fetch(self) -> None:
+        bad = _artist("garbage")
+        session = _RoutingSession([[bad], []])
+        fetch = AsyncMock(return_value={})
+        client = SimpleNamespace(fetch_tags=fetch)
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        fetch.assert_not_awaited()  # no valid MBID -> no 400 risk
+        assert bad.genre_attempted_at is not None
+        assert counts.no_tags == 1
+
+    @pytest.mark.anyio()
+    async def test_multi_batch_pagination(self) -> None:
+        a1 = _artist("11111111-1111-1111-1111-111111111111")
+        a2 = _artist("22222222-2222-2222-2222-222222222222")
+        session = _RoutingSession([[a1], [a2], []])
+        client = _client(
+            {
+                "11111111-1111-1111-1111-111111111111": [_tag("rock")],
+                "22222222-2222-2222-2222-222222222222": [_tag("jazz")],
+            }
+        )
+
+        counts = await backfill_module.run_genre_backfill(session, _settings(), client)
+
+        assert counts.candidates == 2
+        assert counts.updated == 2
+        assert session.commits == 2  # one per populated batch

--- a/tests/test_lineup_builder.py
+++ b/tests/test_lineup_builder.py
@@ -285,8 +285,10 @@ class TestArtistSearchInLibrary:
         db = FakeAsyncSession()
         db.set_results(
             [
-                FakeResult([nite_metal, nite_electronic]),  # name search
+                FakeResult([nite_metal, nite_electronic]),  # exact-name matches
+                FakeResult([]),  # substring pool (already covered by exact)
                 FakeResult([nite_metal.id]),  # in-library subset
+                FakeResult([]),  # genre tags (none)
             ]
         )
         app = _api_app(user_id, db)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,7 @@ class TestTaskType:
         assert types_module.TaskType.CALENDAR_SYNC == "calendar_sync"
 
     def test_task_type_count(self) -> None:
-        assert len(types_module.TaskType) == 14
+        assert len(types_module.TaskType) == 15
 
 
 class TestAttendanceStatus:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -96,7 +96,7 @@ class TestTaskTypeNewValues:
 
     def test_tasktype_member_count(self) -> None:
         """TaskType members (bump when adding a task type)."""
-        assert len(types_module.TaskType) == 14
+        assert len(types_module.TaskType) == 15
 
     def test_mbid_backfill_value(self) -> None:
         assert types_module.TaskType.MBID_BACKFILL == "mbid_backfill"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -47,7 +47,7 @@ class TestWorkerSettings:
 
     def test_functions_registered(self) -> None:
         funcs = worker_module.WorkerSettings.functions
-        assert len(funcs) == 13
+        assert len(funcs) == 14
         names = {f.name for f in funcs}
         assert names == {
             "plan_sync",
@@ -63,6 +63,7 @@ class TestWorkerSettings:
             "backfill_mbids",
             "backfill_popularity",
             "enrich_related_artists",
+            "backfill_genres",
         }
 
     def test_lifecycle_hooks(self) -> None:


### PR DESCRIPTION
## Summary

Genre model, Arc 1 — fixes #136 (ambiguous artist name picks the wrong artist; related expansion then drags playlists off-genre).

Adds a durable artist genre layer sourced from MusicBrainz tags (via ListenBrainz's token-free artist endpoint, keyed on the artist MBIDs we already backfilled) and wires it into the artist picker so an ambiguous name resolves to the artist you actually mean — the metal *Nite*, not the electronic one.

Built in 4 reviewed phases; each phase got a fresh-context adversarial review before landing (the "outside voice" caught a real landmine in every phase — see commit messages).

<details>
<summary>What shipped (Arc 1)</summary>

1. **Schema** — `ArtistTag` table (artist → tag → `genre_mbid`/count/source), mirroring `ArtistSimilarity`'s durable-data pattern, plus a `genre_attempted_at` resume marker. `genre_mbid` is non-null only for canonical MusicBrainz genres, so genre-vs-folksonomy-noise filtering is data-driven, not a stoplist.
2. **Backfill** — token-free `services/artist_tags.py` client + `GENRE_BACKFILL` worker, admin `POST/GET /api/v1/admin/backfill-genres`, and `resonance-api backfill-genres` CLI. Idempotent + resumable; malformed MBIDs are validated out before the fetch.
3. **Affinity primitive** — `generators/genre.py`: count-weighted cosine over genre vectors, with per-seed L2 normalization so one heavily-tagged seed can't hijack the profile. Returns `None` (no basis) vs `0.0` (real mismatch).
4. **Picker wiring** — `/api/v1/artists/search` ranks in-library → genre affinity to the current pool (`seed_artist_ids`) → name; exact-name matches are never truncated; each result shows its top genres.
</details>

<details>
<summary>Deferred to follow-ups</summary>

Both need genres for artists not yet in the table (the bulk backfill covers the tabled case):
- In-request seeds-only fetch-on-demand of genres.
- The related-expansion genre guard in the enrich worker.

Arc 2 (the other genre consumers — genre-aware generation, discovery/taste stats, concert lens) is a separate arc that plugs into the affinity primitive.
</details>

<details>
<summary>Test plan</summary>

- [x] `pytest` — 1675 passed
- [x] `npm test` (vitest) — 21 passed
- [x] `mypy --strict` + `ruff` clean
- [x] Migrations apply + downgrade round-trip on local PG
- [ ] Post-deploy: run `backfill-genres` on prod, verify castle/nite in the picker (needs real library data)
</details>

Relates to #136. Design + per-phase adversarial reviews done in-session.
