### PR TITLE
feat(rediscovery): listening-history rediscovery generator

### DIFF
--- a/src/resonance/cli.py
+++ b/src/resonance/cli.py
@@ -456,9 +456,13 @@ Subcommands:
   create --type <type> --name <n>   Create a profile
            [--source event:<uuid> ...]    Layered pool sources (#128)
            [--source artist:<uuid> ...]
-           [--source related:<n>[:seed] ...]
            [--exclude <artist-uuid> ...]  Drop artists from the pool
-           [--param key=val ...]
+           [--window <spec>]              Rediscovery: seed from listening history.
+                                          <spec>: last-2-weeks | a-month-ago |
+                                          this-time-last-year | relative:<days> |
+                                          absolute:<start>:<end> (ISO dates)
+           [--seed-count <n>]             Rediscovery: # of seed artists (def 20)
+           [--param key=val ...]          e.g. new_ratio=50 (rediscovery dials)
            [--input key=val ...]          Legacy (e.g. event_id=<uuid>)
   update <profile-id>               Update a profile
            [--name <n>]
@@ -567,6 +571,104 @@ def _parse_pool_sources(args: list[str]) -> dict[str, object] | None:
     return {"sources": sources, "exclude_artist_ids": excludes}
 
 
+_REDISCOVERY_PRESETS = ("last-2-weeks", "a-month-ago", "this-time-last-year")
+
+
+def _preset_window(preset: str, now: datetime.datetime) -> dict[str, object]:
+    """Build a listening window from a named preset (#rediscovery).
+
+    Relative presets store a lookback (seed rolls forward on regenerate); the
+    older-anchor absolute presets freeze dates computed once at create time and
+    widen the window +/- 2 weeks around the anchor so enough seeds fall inside.
+    """
+    if preset == "last-2-weeks":
+        return {"kind": "relative", "lookback_days": 14}
+    if preset == "a-month-ago":
+        center = now - datetime.timedelta(days=30)
+        return {
+            "kind": "absolute",
+            "start": (center - datetime.timedelta(days=14)).isoformat(),
+            "end": (center + datetime.timedelta(days=14)).isoformat(),
+        }
+    if preset == "this-time-last-year":
+        center = now - datetime.timedelta(days=365)
+        return {
+            "kind": "absolute",
+            "start": (center - datetime.timedelta(days=14)).isoformat(),
+            "end": (center + datetime.timedelta(days=14)).isoformat(),
+        }
+    print(
+        f"Unknown window preset: {preset!r} (expected one of "
+        f"{', '.join(_REDISCOVERY_PRESETS)}, relative:N, or absolute:START:END)"
+    )
+    sys.exit(1)
+
+
+def _parse_window_spec(spec: str, now: datetime.datetime) -> dict[str, object]:
+    """Parse a ``--window`` spec into a window dict.
+
+    Grammar: a preset name (``last-2-weeks``, ``a-month-ago``,
+    ``this-time-last-year``), ``relative:<days>``, or
+    ``absolute:<start>:<end>`` (ISO dates, naive treated as UTC).
+    """
+    if spec in _REDISCOVERY_PRESETS:
+        return _preset_window(spec, now)
+    kind, _, rest = spec.partition(":")
+    if kind == "relative":
+        try:
+            days = int(rest)
+        except ValueError:
+            print(f"Invalid relative lookback: {rest!r} (expected an integer)")
+            sys.exit(1)
+        return {"kind": "relative", "lookback_days": days}
+    if kind == "absolute":
+        start_s, _, end_s = rest.partition(":")
+        try:
+            start = datetime.datetime.fromisoformat(start_s)
+            end = datetime.datetime.fromisoformat(end_s)
+        except ValueError:
+            print(f"Invalid absolute window: {rest!r} (expected START:END ISO dates)")
+            sys.exit(1)
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=datetime.UTC)
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=datetime.UTC)
+        return {"kind": "absolute", "start": start.isoformat(), "end": end.isoformat()}
+    print(f"Unknown window spec: {spec!r} (expected a preset, relative:N, or absolute)")
+    sys.exit(1)
+
+
+def _parse_listening_range(args: list[str]) -> dict[str, object] | None:
+    """Parse ``--window`` / ``--seed-count`` into a listening_range recipe.
+
+    Returns a ``{"sources": [listening_range], "exclude_artist_ids": []}`` dict for
+    a rediscovery profile, or None when ``--window`` is absent so the caller falls
+    back to the event/artist source grammar.
+    """
+    window_spec: str | None = None
+    seed_count = 20
+    i = 0
+    while i < len(args):
+        if args[i] == "--window" and i + 1 < len(args):
+            window_spec = args[i + 1]
+            i += 2
+        elif args[i] == "--seed-count" and i + 1 < len(args):
+            seed_count = int(args[i + 1])
+            i += 2
+        else:
+            i += 1
+    if window_spec is None:
+        return None
+    now = datetime.datetime.now(datetime.UTC)
+    source: dict[str, object] = {
+        "kind": "listening_range",
+        "enabled": True,
+        "window": _parse_window_spec(window_spec, now),
+        "seed_artist_count": seed_count,
+    }
+    return {"sources": [source], "exclude_artist_ids": []}
+
+
 def _cmd_profile() -> None:
     if len(sys.argv) < 3:
         print(_PROFILE_USAGE)
@@ -643,14 +745,19 @@ def _cmd_profile() -> None:
         if not name or not gen_type:
             print("Usage: resonance-api profile create --type <type> --name <name>")
             sys.exit(1)
-        # Prefer the layered --source/--exclude grammar; fall back to the legacy
+        # Rediscovery: a --window flag builds a listening_range source. Otherwise
+        # prefer the layered --source/--exclude grammar; fall back to the legacy
         # --input key=value form (e.g. --input event_id=<uuid>) (#128).
-        layered = _parse_pool_sources(remaining)
-        input_refs: dict[str, object] = (
-            layered
-            if layered is not None
-            else dict(_parse_key_value_args(remaining, "--input"))
-        )
+        rediscovery_refs = _parse_listening_range(remaining)
+        if rediscovery_refs is not None:
+            input_refs: dict[str, object] = rediscovery_refs
+        else:
+            layered = _parse_pool_sources(remaining)
+            input_refs = (
+                layered
+                if layered is not None
+                else dict(_parse_key_value_args(remaining, "--input"))
+            )
         params = _parse_key_value_args(remaining, "--param")
         body: dict[str, object] = {
             "name": name,

--- a/src/resonance/generators/concert_prep.py
+++ b/src/resonance/generators/concert_prep.py
@@ -8,7 +8,7 @@ tracks for playlist inclusion.
 from __future__ import annotations
 
 import dataclasses
-from collections import Counter, deque
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import resonance.generators.scoring as scoring_module
@@ -57,124 +57,6 @@ class SelectionResult:
     freshness_actual: float | None
 
 
-def _score_candidate(
-    candidate: CandidateTrack,
-    params: dict[str, int],
-) -> float:
-    """Compute the composite score for a single candidate track."""
-    fam_val = scoring_module.familiarity_signal(
-        listen_count=candidate.listen_count,
-        in_library=candidate.in_library,
-    )
-    pop_val = scoring_module.popularity_signal(
-        popularity_score=candidate.popularity_score,
-    )
-    return scoring_module.composite_score(
-        familiarity_val=fam_val,
-        popularity_val=pop_val,
-        params=params,
-    )
-
-
-def _select_one_pool(
-    scored: list[tuple[CandidateTrack, float]],
-    max_tracks: int,
-    weights: dict[uuid.UUID, int] | None = None,
-) -> list[tuple[CandidateTrack, float]]:
-    """Select ``max_tracks`` by **weighted round-robin** across the pool's artists.
-
-    Provenance (event / manual / related) never touches selection -- there is one
-    pool. ``composite_score`` (familiarity + hit_depth) decides WHICH of an artist's
-    tracks fill its slots; round-robin decides HOW MANY each artist gets, so every
-    artist on the bill is represented (not buried by a heavy-rotation neighbor).
-    This restores the per-artist spread that #128 dropped (round-0 + global fill),
-    which let well-listened artists monopolize every post-round-0 slot.
-
-    ``scored`` must already be sorted by score descending. Tracks are grouped by
-    artist (each group stays score-desc); artists are dealt in best-track-score
-    order. Each round, every artist with tracks left contributes its next-best
-    track -- ``weights[artist_id]`` of them per round (default 1 = even). Dealing
-    stops at ``max_tracks`` or when every artist is exhausted; an artist that runs
-    out simply drops from later rounds, so its unused share redistributes to the
-    others automatically (a 6-track band among five gives 6; the rest absorb the
-    slack).
-
-    ``weights`` is the plumbed seam for a future seed/headliner emphasis (and
-    jitter): a higher weight = more tracks per round. Today it is unset (all 1), so
-    the deal is even -- the behavior the owner asked for (#round-robin, D7).
-
-    Edge cases, all handled by the deal order (best-track-score desc):
-    - ``max_tracks < n_artists``: only the highest-scoring artists get a slot in
-      round 1; the lowest never get dealt (graceful, keeps the top of the bill).
-    - ``max_tracks`` not divisible by artist count: the partial final round deals
-      to the highest-scoring artists first, so they get the extra slots.
-    - one artist: deals its top ``max_tracks`` by score.
-    - empty pool: returns empty (handled by the caller's no-candidates guard).
-    """
-    weights = weights or {}
-    # Group tracks by artist, preserving score-desc order within each group.
-    # First-seen order == best-track-score order (``scored`` is score-desc), so the
-    # artist deal order is best-score desc without a separate sort.
-    groups: dict[uuid.UUID, deque[tuple[CandidateTrack, float]]] = {}
-    order: list[uuid.UUID] = []
-    for pair in scored:
-        artist_id = pair[0].artist_id
-        if artist_id not in groups:
-            groups[artist_id] = deque()
-            order.append(artist_id)
-        groups[artist_id].append(pair)
-
-    selected: list[tuple[CandidateTrack, float]] = []
-    while len(selected) < max_tracks:
-        dealt_this_round = False
-        for artist_id in order:
-            if len(selected) >= max_tracks:
-                break
-            group = groups[artist_id]
-            # weight = tracks this artist deals per round (>=1); default even.
-            for _ in range(max(1, weights.get(artist_id, 1))):
-                if not group or len(selected) >= max_tracks:
-                    break
-                selected.append(group.popleft())
-                dealt_this_round = True
-        if not dealt_this_round:
-            break  # every artist exhausted before reaching max_tracks
-    return selected
-
-
-def _apply_freshness_filter(
-    scored: list[tuple[CandidateTrack, float]],
-    previous_track_ids: set[uuid.UUID],
-    freshness_target: int | None,
-    max_tracks: int,
-) -> list[tuple[CandidateTrack, float]]:
-    """Filter scored candidates to meet the freshness target.
-
-    If freshness_target is set and >0 and there are previous_track_ids,
-    limits how many previous tracks can appear. A freshness_target of 100
-    means all tracks should be new; a target of 0 means repeats are fine.
-
-    The repeat allowance is computed as:
-        max_repeats = floor(max_tracks * (100 - freshness_target) / 100)
-    """
-    if freshness_target is None or freshness_target <= 0 or not previous_track_ids:
-        return scored
-
-    max_repeats = int(max_tracks * (100 - freshness_target) / 100)
-    repeat_count = 0
-    result: list[tuple[CandidateTrack, float]] = []
-
-    for candidate, score in scored:
-        is_repeat = candidate.track_id in previous_track_ids
-        if is_repeat:
-            if repeat_count >= max_repeats:
-                continue
-            repeat_count += 1
-        result.append((candidate, score))
-
-    return result
-
-
 def score_and_select(
     *,
     candidates: list[CandidateTrack],
@@ -206,14 +88,25 @@ def score_and_select(
             freshness_actual=None,
         )
 
-    # 1. Score each candidate
-    scored = [(c, _score_candidate(c, params)) for c in candidates]
+    # 1. Score each candidate (shared scoring glue).
+    scored = [
+        (
+            c,
+            scoring_module.score_track(
+                listen_count=c.listen_count,
+                in_library=c.in_library,
+                popularity_score=c.popularity_score,
+                params=params,
+            ),
+        )
+        for c in candidates
+    ]
 
     # 2. Sort by score descending
     scored.sort(key=lambda pair: pair[1], reverse=True)
 
     # 3. Apply freshness filter
-    scored = _apply_freshness_filter(
+    scored = scoring_module.apply_freshness_filter(
         scored, previous_track_ids, freshness_target, max_tracks
     )
 
@@ -222,7 +115,7 @@ def score_and_select(
     #    tracks fill its slots. Provenance (target vs adjacent) is metadata only.
     #    Pool composition (which related artists are present) is decided upstream by
     #    enrichment (#133), not here.
-    selected = _select_one_pool(scored, max_tracks, weights)
+    selected = scoring_module.round_robin_select(scored, max_tracks, weights)
 
     # 5. Re-sort the merged selection by score for final ordering, then assign
     #    1-indexed positions and build the ScoredTrack list.

--- a/src/resonance/generators/parameters.py
+++ b/src/resonance/generators/parameters.py
@@ -67,6 +67,30 @@ PARAMETER_REGISTRY: dict[str, ParameterDefinition] = {
     # NOTE: the old "similar_artist_ratio" parameter was removed in #133. Related
     # artists are now added to the pool explicitly via the enrich endpoint as
     # concrete artist sources, not folded in at generation time by a slider.
+    "new_ratio": ParameterDefinition(
+        name="new_ratio",
+        display_name="New vs Deep Cuts",
+        description=(
+            "Balance between never-heard new artists and less-heard deep cuts "
+            "from artists you already spin (#rediscovery)"
+        ),
+        # Unipolar: the value IS the fraction of the track budget given to the
+        # new-artist stream (0 = all deep cuts, 100 = all new), not a -1..1 weight.
+        scale_type=types_module.ParameterScaleType.UNIPOLAR,
+        default_value=50,
+        labels=("All Deep Cuts", "All New Artists"),
+    ),
+    "less_heard_percentile": ParameterDefinition(
+        name="less_heard_percentile",
+        display_name="Deep Cut Depth",
+        description=(
+            "How far down each seed artist's play distribution counts as a deep "
+            "cut -- 33 = bottom third of that artist's own tracks (#rediscovery)"
+        ),
+        scale_type=types_module.ParameterScaleType.UNIPOLAR,
+        default_value=33,
+        labels=("Rarest Only", "Broader Catalog"),
+    ),
 }
 
 GENERATOR_TYPE_CONFIG: dict[types_module.GeneratorType, GeneratorTypeConfig] = {
@@ -78,6 +102,24 @@ GENERATOR_TYPE_CONFIG: dict[types_module.GeneratorType, GeneratorTypeConfig] = {
         required_inputs=frozenset(),
         description="Generate a playlist to prepare for a concert",
         default_pool_seed=pool_module.PoolSourceKind.EVENT.value,
+    ),
+    types_module.GeneratorType.REDISCOVERY: GeneratorTypeConfig(
+        featured_parameters=frozenset(
+            {"familiarity", "hit_depth", "new_ratio", "less_heard_percentile"}
+        ),
+        required_inputs=frozenset(),
+        description=(
+            "Rediscover a slice of your listening history: never-heard new artists "
+            "on that period's genres, mixed with less-heard deep cuts from the "
+            "artists you were spinning"
+        ),
+        # A new rediscovery profile seeds its pool from a listening-history window
+        # (the reusable seed-window primitive), not an event.
+        default_pool_seed=pool_module.PoolSourceKind.LISTENING_RANGE.value,
+        # Balanced 50/50 new-vs-deep-cut by default (design premise 2). These match
+        # the registry defaults; stated explicitly so the type's intended vibe is
+        # documented at the config, not inferred from the registry.
+        default_param_values={"new_ratio": 50, "less_heard_percentile": 33},
     ),
 }
 

--- a/src/resonance/generators/pool.py
+++ b/src/resonance/generators/pool.py
@@ -37,9 +37,11 @@ The DB/connector resolution step (event -> artists) lives in the worker's
 from __future__ import annotations
 
 import dataclasses
+import datetime
 import enum
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
+from typing import Literal
 
 
 class PoolSourceKind(enum.StrEnum):
@@ -47,6 +49,12 @@ class PoolSourceKind(enum.StrEnum):
 
     EVENT = "event"
     ARTIST = "artist"
+    # A time window over listening history that resolves to the user's top seed
+    # artists in that window (#rediscovery). The reusable "seed-window" primitive:
+    # scoped as a source kind so a future generic generator can consume it too
+    # (deferred Approach C). Its window kind drives regenerate semantics (see
+    # ListeningWindow).
+    LISTENING_RANGE = "listening_range"
 
 
 # Provenance shares the source vocabulary: an artist enters the pool *via* the kind
@@ -80,7 +88,51 @@ class ArtistSource:
     via_seed: str | None = None
 
 
-PoolSource = EventSource | ArtistSource
+@dataclasses.dataclass(frozen=True)
+class ListeningWindow:
+    """A time window over listening history, selecting seed artists (#rediscovery).
+
+    ``kind`` drives regenerate semantics (design R4):
+
+    * ``relative`` -- re-resolves to ``[now - lookback_days, now]`` on every
+      generation, so the seed set rolls forward. A living feed of the current
+      rotation ("last 2 weeks").
+    * ``absolute`` -- fixed ``start``/``end`` (stored once at create), so the seed
+      set is frozen. A stable artifact you return to ("this time last year"), and
+      the kind under which deep cuts are exempt from the freshness drop so a
+      rediscovered cut persists across regenerates.
+
+    Exactly one shape is populated: ``lookback_days`` for ``relative``, or
+    ``start`` + ``end`` for ``absolute``. This is a pure recipe object; the DB
+    query that turns bounds into seed artists lives in the worker.
+    """
+
+    kind: Literal["relative", "absolute"]
+    lookback_days: int | None = None
+    start: datetime.datetime | None = None
+    end: datetime.datetime | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ListeningRangeSource:
+    """Resolve a listening-history window to the user's top seed artists.
+
+    The window defines *which* artists seed the pool; ``seed_artist_count`` caps
+    how many (ranked by distinct-track listens in the window). ``deep_cut_basis``
+    and ``novelty_basis`` are the non-numeric recipe flags the int-only parameter
+    system can't hold (design R1); they live here on the source rather than at the
+    top level so the enrich round-trip (which re-serializes sources) can't drop
+    them. v1 scores lifetime-only; the ``window`` basis path is a plumbed seam.
+    """
+
+    window: ListeningWindow
+    seed_artist_count: int = 20
+    deep_cut_basis: Literal["lifetime", "window"] = "lifetime"
+    novelty_basis: Literal["lifetime", "window"] = "lifetime"
+    enabled: bool = True
+
+
+PoolSource = EventSource | ArtistSource | ListeningRangeSource
 
 
 @dataclasses.dataclass(frozen=True)
@@ -123,6 +175,104 @@ def _parse_via_seed(value: object) -> str | None:
     return value
 
 
+def _parse_positive_int(value: object, field: str) -> int:
+    """Parse a positive integer field, raising a clear error on bad input.
+
+    Accepts an int or a numeric string (JSON round-trips ints, but the CLI may
+    pass strings). ``bool`` is rejected explicitly (it is an ``int`` subclass, so
+    ``True`` would silently parse to 1).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        msg = f"{field} must be an integer, got {value!r}"
+        raise ValueError(msg)
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        msg = f"{field} must be an integer, got {value!r}"
+        raise ValueError(msg) from exc
+    if parsed <= 0:
+        msg = f"{field} must be a positive integer, got {parsed}"
+        raise ValueError(msg)
+    return parsed
+
+
+def _parse_datetime(value: object, field: str) -> datetime.datetime:
+    """Parse an ISO 8601 datetime string (or passthrough a datetime)."""
+    if isinstance(value, datetime.datetime):
+        return value
+    try:
+        return datetime.datetime.fromisoformat(str(value))
+    except (ValueError, TypeError) as exc:
+        msg = f"Invalid datetime for {field}: {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _parse_basis(value: object, field: str) -> Literal["lifetime", "window"]:
+    """Parse a scoring-basis flag, defaulting to ``lifetime`` when absent."""
+    if value is None:
+        return "lifetime"
+    if value in ("lifetime", "window"):
+        return value  # type: ignore[return-value]
+    msg = f"{field} must be 'lifetime' or 'window', got {value!r}"
+    raise ValueError(msg)
+
+
+def _parse_window(raw: object) -> ListeningWindow:
+    """Parse a listening window object into a typed :class:`ListeningWindow`.
+
+    Requires ``kind`` of ``relative`` (with a positive ``lookback_days``) or
+    ``absolute`` (with ``start`` before ``end``). Raises on any other shape.
+    """
+    if not isinstance(raw, Mapping):
+        msg = f"'window' must be an object, got {type(raw).__name__}"
+        raise ValueError(msg)
+    kind = raw.get("kind")
+    if kind == "relative":
+        return ListeningWindow(
+            kind="relative",
+            lookback_days=_parse_positive_int(
+                raw.get("lookback_days"), "window.lookback_days"
+            ),
+        )
+    if kind == "absolute":
+        start = _parse_datetime(raw.get("start"), "window.start")
+        end = _parse_datetime(raw.get("end"), "window.end")
+        if end <= start:
+            msg = (
+                "window.end must be after window.start "
+                f"(start={start.isoformat()}, end={end.isoformat()})"
+            )
+            raise ValueError(msg)
+        return ListeningWindow(kind="absolute", start=start, end=end)
+    msg = f"Unknown window kind: {kind!r} (expected 'relative' or 'absolute')"
+    raise ValueError(msg)
+
+
+def resolve_window_bounds(
+    window: ListeningWindow, now: datetime.datetime
+) -> tuple[datetime.datetime, datetime.datetime]:
+    """Resolve a window to concrete ``(start, end)`` bounds against ``now``.
+
+    ``relative`` computes ``[now - lookback_days, now]`` (rolls forward on every
+    call, so the seed set follows the current rotation); ``absolute`` returns its
+    stored ``start``/``end`` (frozen). Pure -- the caller supplies ``now`` so the
+    resolution is deterministic and unit-testable. This is the reusable
+    seed-window primitive's pure half; the DB seed query lives in the worker.
+
+    Raises:
+        ValueError: If the window's fields are inconsistent with its kind.
+    """
+    if window.kind == "relative":
+        if window.lookback_days is None:
+            msg = "relative window requires lookback_days"
+            raise ValueError(msg)
+        return (now - datetime.timedelta(days=window.lookback_days), now)
+    if window.start is None or window.end is None:
+        msg = "absolute window requires start and end"
+        raise ValueError(msg)
+    return (window.start, window.end)
+
+
 def _parse_source(raw: object) -> PoolSource:
     """Parse one source entry into a typed source.
 
@@ -145,6 +295,16 @@ def _parse_source(raw: object) -> PoolSource:
     if kind is PoolSourceKind.EVENT:
         return EventSource(
             event_id=_parse_uuid(raw.get("event_id"), "event_id"), enabled=enabled
+        )
+    if kind is PoolSourceKind.LISTENING_RANGE:
+        return ListeningRangeSource(
+            window=_parse_window(raw.get("window")),
+            seed_artist_count=_parse_positive_int(
+                raw.get("seed_artist_count", 20), "seed_artist_count"
+            ),
+            deep_cut_basis=_parse_basis(raw.get("deep_cut_basis"), "deep_cut_basis"),
+            novelty_basis=_parse_basis(raw.get("novelty_basis"), "novelty_basis"),
+            enabled=enabled,
         )
     # ARTIST (the only remaining kind; unknown kinds raised above).
     return ArtistSource(
@@ -266,6 +426,17 @@ def build_pool(
     return pool
 
 
+def _serialize_window(window: ListeningWindow) -> dict[str, object]:
+    """Serialize a :class:`ListeningWindow` to its stored JSON shape."""
+    if window.kind == "relative":
+        return {"kind": "relative", "lookback_days": window.lookback_days}
+    return {
+        "kind": "absolute",
+        "start": window.start.isoformat() if window.start is not None else None,
+        "end": window.end.isoformat() if window.end is not None else None,
+    }
+
+
 def serialize_source(source: PoolSource) -> dict[str, object]:
     """Serialize a typed source back to its stored JSON shape."""
     if isinstance(source, EventSource):
@@ -273,6 +444,15 @@ def serialize_source(source: PoolSource) -> dict[str, object]:
             "kind": PoolSourceKind.EVENT.value,
             "event_id": str(source.event_id),
             "enabled": source.enabled,
+        }
+    if isinstance(source, ListeningRangeSource):
+        return {
+            "kind": PoolSourceKind.LISTENING_RANGE.value,
+            "enabled": source.enabled,
+            "window": _serialize_window(source.window),
+            "seed_artist_count": source.seed_artist_count,
+            "deep_cut_basis": source.deep_cut_basis,
+            "novelty_basis": source.novelty_basis,
         }
     # ARTIST (the only remaining kind).
     payload: dict[str, object] = {
@@ -285,6 +465,21 @@ def serialize_source(source: PoolSource) -> dict[str, object]:
     if source.via_seed is not None:
         payload["via_seed"] = source.via_seed
     return payload
+
+
+def find_listening_range_source(
+    input_references: Mapping[str, object],
+) -> ListeningRangeSource | None:
+    """Return the first enabled listening_range source, or None (#rediscovery).
+
+    A rediscovery profile carries exactly one. The worker reads it to get the
+    window (which drives freshness/regenerate semantics) and the basis flags,
+    without re-parsing the whole source list at each use site.
+    """
+    for source in normalize_sources(input_references):
+        if isinstance(source, ListeningRangeSource) and source.enabled:
+            return source
+    return None
 
 
 def serialize_input_references(

--- a/src/resonance/generators/rediscovery.py
+++ b/src/resonance/generators/rediscovery.py
@@ -1,0 +1,227 @@
+"""Rediscovery generator -- "more but different" from a listening-history window.
+
+Pure logic (no DB). A rediscovery playlist mixes two streams:
+
+* **new** -- never-heard on-genre artists materialized into the pool up front by
+  related-artist enrichment (#133), tagged ``via_seed``. These are the "different."
+* **deep-cut** -- less-heard tracks from the seed artists the user already spins
+  (the listening-range seeds). These are the "more."
+
+``new_ratio`` (0-100) splits the *track budget* between the two streams; within a
+stream, the shared weighted round-robin (:func:`scoring.round_robin_select`) spreads
+tracks across that stream's artists so no single artist monopolizes its half. The
+worker (:func:`worker.score_and_build_playlist`) supplies the candidate tracks, the
+via_seed artist-id set, and each seed artist's play distribution; this module
+decides which of a seed's tracks are deep cuts, splits the budget, and assembles
+the final ordered selection.
+
+The deep-cut definition is *relative* per artist (design premise 4): a track whose
+lifetime play count sits at or below the ``less_heard_percentile`` of that artist's
+own per-track play distribution, floored at ``play_count >= 1`` (rediscovery, not
+cold strangers). A thin-seed guard drops an artist with too few distinct played
+tracks, since the percentile of ``[1, 1, 2]`` is degenerate (design R5).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import resonance.generators.concert_prep as concert_prep_module
+import resonance.generators.scoring as scoring_module
+import resonance.types as types_module
+
+if TYPE_CHECKING:
+    import uuid
+    from collections.abc import Mapping, Sequence
+
+# Reuse concert_prep's track dataclasses so the worker builds one candidate shape
+# and consumes one selection shape regardless of generator type.
+CandidateTrack = concert_prep_module.CandidateTrack
+ScoredTrack = concert_prep_module.ScoredTrack
+SelectionResult = concert_prep_module.SelectionResult
+
+# Minimum distinct played tracks a seed artist needs before the deep-cut percentile
+# is meaningful; below this the artist is dropped from the deep-cut stream (R5).
+DEFAULT_MIN_DISTINCT_TRACKS = 4
+
+
+def select_deep_cut_track_ids(
+    play_counts: Mapping[uuid.UUID, int],
+    *,
+    percentile: int,
+    min_distinct: int = DEFAULT_MIN_DISTINCT_TRACKS,
+) -> set[uuid.UUID]:
+    """Deep-cut track ids for ONE seed artist from its per-track play distribution.
+
+    ``play_counts`` maps each of the artist's tracks to its lifetime play count. A
+    deep cut is a track whose count is at or below the ``percentile`` of the
+    artist's own played-track distribution, with ``count >= 1`` (a rediscovery, not
+    a never-heard track). Uses the nearest-rank percentile method.
+
+    The thin-seed guard (design R5): if the artist has fewer than ``min_distinct``
+    distinct played tracks, the distribution is too small to have a meaningful
+    "bottom third" (the 33rd percentile of ``[1, 1, 2]`` is 1, which would make
+    every track a deep cut), so the artist contributes NO deep cuts and is dropped
+    from the deep-cut stream. It still seeds enrichment and can appear via the pool.
+
+    Returns the set of qualifying track ids (empty when the guard trips).
+    """
+    played = {tid: count for tid, count in play_counts.items() if count >= 1}
+    if len(played) < min_distinct:
+        return set()
+    counts = sorted(played.values())
+    n = len(counts)
+    # Nearest-rank: index of the percentile value, clamped into range.
+    idx = max(0, min(n - 1, math.ceil(percentile / 100 * n) - 1))
+    threshold = counts[idx]
+    return {tid for tid, count in played.items() if count <= threshold}
+
+
+def split_budget(*, new_ratio: int, max_tracks: int) -> tuple[int, int]:
+    """Split ``max_tracks`` between the new and deep-cut streams by ``new_ratio``.
+
+    ``new_ratio`` is a 0-100 percentage of the budget given to the new-artist
+    stream (0 = all deep cuts, 100 = all new). Returns ``(new_slots, deep_slots)``
+    with ``new_slots + deep_slots == max_tracks``. Rounding favors whichever side
+    ``round`` lands on; the remainder always goes to deep cuts so the total is
+    exact.
+    """
+    new_slots = round(new_ratio / 100 * max_tracks)
+    new_slots = max(0, min(max_tracks, new_slots))
+    return new_slots, max_tracks - new_slots
+
+
+def _score_stream(
+    candidates: Sequence[CandidateTrack],
+    params: dict[str, int],
+) -> list[tuple[CandidateTrack, float]]:
+    """Score a stream's candidates and return them sorted best-first."""
+    scored = [
+        (
+            c,
+            scoring_module.score_track(
+                listen_count=c.listen_count,
+                in_library=c.in_library,
+                popularity_score=c.popularity_score,
+                params=params,
+            ),
+        )
+        for c in candidates
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored
+
+
+def score_and_select(
+    *,
+    candidates: Sequence[CandidateTrack],
+    new_artist_ids: set[uuid.UUID],
+    deep_cut_track_ids: set[uuid.UUID],
+    params: dict[str, int],
+    new_ratio: int,
+    max_tracks: int,
+    previous_track_ids: set[uuid.UUID],
+    freshness_target: int | None,
+    exempt_deep_cuts_from_freshness: bool,
+) -> SelectionResult:
+    """Two-stream rediscovery selection (design R2/R4).
+
+    Partitions ``candidates`` into the new stream (artist in ``new_artist_ids``)
+    and the deep-cut stream (artist NOT in ``new_artist_ids`` AND track in
+    ``deep_cut_track_ids``), scores each, applies freshness, splits the budget by
+    ``new_ratio``, and deals each stream by weighted round-robin. A short stream's
+    unused slots redistribute to the other so the playlist still fills.
+
+    Freshness: the new stream is always subject to the freshness target; the
+    deep-cut stream is exempt when ``exempt_deep_cuts_from_freshness`` is true
+    (absolute window kind) so rediscovered cuts persist across regenerates, and
+    subject to normal freshness otherwise (relative window). Freshness is applied
+    per stream against that stream's own budget.
+
+    Args:
+        candidates: Pre-fetched candidate tracks (both streams, mixed).
+        new_artist_ids: Artist ids materialized by enrichment (the new stream).
+        deep_cut_track_ids: Track ids that qualify as deep cuts (deep-cut stream).
+        params: Generator parameter values (familiarity, hit_depth, ...).
+        new_ratio: 0-100 budget share for the new stream.
+        max_tracks: Total tracks to select.
+        previous_track_ids: Track ids from the prior generation (freshness).
+        freshness_target: Target freshness percentage (0-100), or None to skip.
+        exempt_deep_cuts_from_freshness: When true, deep cuts bypass the freshness
+            filter (absolute window kind).
+
+    Returns:
+        A SelectionResult with scored, positioned tracks and metadata.
+    """
+    if not candidates:
+        return SelectionResult(tracks=[], sources_summary={}, freshness_actual=None)
+
+    new_candidates = [c for c in candidates if c.artist_id in new_artist_ids]
+    deep_candidates = [
+        c
+        for c in candidates
+        if c.artist_id not in new_artist_ids and c.track_id in deep_cut_track_ids
+    ]
+
+    new_slots, deep_slots = split_budget(new_ratio=new_ratio, max_tracks=max_tracks)
+
+    new_scored = _score_stream(new_candidates, params)
+    deep_scored = _score_stream(deep_candidates, params)
+
+    # New stream: always freshness-filtered. Deep stream: exempt under an absolute
+    # window (rediscovered cuts persist), normal freshness under relative.
+    new_scored = scoring_module.apply_freshness_filter(
+        new_scored, previous_track_ids, freshness_target, max(1, new_slots)
+    )
+    if not exempt_deep_cuts_from_freshness:
+        deep_scored = scoring_module.apply_freshness_filter(
+            deep_scored, previous_track_ids, freshness_target, max(1, deep_slots)
+        )
+
+    # Deal each stream, then redistribute a short stream's slack to the other so
+    # the playlist fills to max_tracks when candidates allow (mirrors how
+    # concert_prep redistributes a short band's slack).
+    new_selected = scoring_module.round_robin_select(new_scored, new_slots)
+    deep_selected = scoring_module.round_robin_select(deep_scored, deep_slots)
+    new_short = new_slots - len(new_selected)
+    deep_short = deep_slots - len(deep_selected)
+    if new_short > 0 and deep_short <= 0:
+        deep_selected = scoring_module.round_robin_select(
+            deep_scored, deep_slots + new_short
+        )
+    elif deep_short > 0 and new_short <= 0:
+        new_selected = scoring_module.round_robin_select(
+            new_scored, new_slots + deep_short
+        )
+
+    selected = new_selected + deep_selected
+    # Final order by score (matches concert_prep: the merged selection is
+    # re-sorted so the strongest tracks lead regardless of stream).
+    selected.sort(key=lambda pair: pair[1], reverse=True)
+    tracks = [
+        ScoredTrack(
+            track_id=candidate.track_id,
+            title=candidate.title,
+            artist_name=candidate.artist_name,
+            position=i + 1,
+            score=score,
+            source=candidate.source,
+        )
+        for i, (candidate, score) in enumerate(selected)
+    ]
+
+    source_counts: Counter[types_module.TrackSource] = Counter(t.source for t in tracks)
+    sources_summary = dict(source_counts)
+
+    freshness_actual: float | None = None
+    if previous_track_ids and tracks:
+        new_count = sum(1 for t in tracks if t.track_id not in previous_track_ids)
+        freshness_actual = (new_count / len(tracks)) * 100.0
+
+    return SelectionResult(
+        tracks=tracks,
+        sources_summary=sources_summary,
+        freshness_actual=freshness_actual,
+    )

--- a/src/resonance/generators/scoring.py
+++ b/src/resonance/generators/scoring.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import math
+from collections import deque
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import uuid
 
 
 def familiarity_signal(*, listen_count: int, in_library: bool) -> float:
@@ -55,3 +60,128 @@ def composite_score(
     score += hit_weight * (popularity_val - 0.5)
 
     return max(0.0, min(1.0, score))
+
+
+def score_track(
+    *,
+    listen_count: int,
+    in_library: bool,
+    popularity_score: int,
+    params: dict[str, int],
+) -> float:
+    """Composite score for one track from its raw per-track signals.
+
+    The scoring glue shared by every generator (concert_prep, rediscovery): turns
+    listen count / library membership / popularity into a familiarity + popularity
+    composite via the familiarity and hit_depth dials.
+    """
+    fam_val = familiarity_signal(listen_count=listen_count, in_library=in_library)
+    pop_val = popularity_signal(popularity_score=popularity_score)
+    return composite_score(
+        familiarity_val=fam_val, popularity_val=pop_val, params=params
+    )
+
+
+class _Selectable(Protocol):
+    """Structural type for tracks the selection helpers operate on.
+
+    Declared as read-only properties (not bare attributes) so a *frozen* dataclass
+    field satisfies the protocol -- a mutable protocol attribute would reject a
+    frozen dataclass. Any track type exposing ``artist_id`` and ``track_id`` (e.g.
+    concert_prep's ``CandidateTrack``) matches, so the round-robin and freshness
+    primitives stay generator-agnostic without importing a concrete track type
+    (which would be circular).
+    """
+
+    @property
+    def artist_id(self) -> uuid.UUID: ...
+
+    @property
+    def track_id(self) -> uuid.UUID: ...
+
+
+def round_robin_select[T: _Selectable](
+    scored: list[tuple[T, float]],
+    max_tracks: int,
+    weights: dict[uuid.UUID, int] | None = None,
+) -> list[tuple[T, float]]:
+    """Select ``max_tracks`` by **weighted round-robin** across the pool's artists.
+
+    ``scored`` must already be sorted by score descending. Tracks are grouped by
+    artist (each group stays score-desc); artists are dealt in best-track-score
+    order (first-seen order == best-score order because ``scored`` is score-desc).
+    Each round every artist with tracks left contributes its next-best track --
+    ``weights[artist_id]`` of them per round (default 1 = even). Dealing stops at
+    ``max_tracks`` or when every artist is exhausted; an artist that runs out drops
+    from later rounds, so its unused share redistributes to the others.
+
+    This is the shared spread primitive extracted from concert_prep's
+    ``_select_one_pool`` (#128 round-robin); it decides HOW MANY tracks each artist
+    gets, while the caller's score decides WHICH. ``weights`` is the plumbed seam
+    for future seed/headliner emphasis; unset today (all 1 = even).
+
+    Edge cases (all handled by the best-track-score deal order):
+    - ``max_tracks < n_artists``: only the highest-scoring artists get a round-1
+      slot; the lowest never get dealt (keeps the top of the bill).
+    - not divisible: the partial final round deals to the highest-scoring first.
+    - one artist: deals its top ``max_tracks`` by score.
+    - empty pool: returns empty.
+    """
+    weights = weights or {}
+    groups: dict[uuid.UUID, deque[tuple[T, float]]] = {}
+    order: list[uuid.UUID] = []
+    for pair in scored:
+        artist_id = pair[0].artist_id
+        if artist_id not in groups:
+            groups[artist_id] = deque()
+            order.append(artist_id)
+        groups[artist_id].append(pair)
+
+    selected: list[tuple[T, float]] = []
+    while len(selected) < max_tracks:
+        dealt_this_round = False
+        for artist_id in order:
+            if len(selected) >= max_tracks:
+                break
+            group = groups[artist_id]
+            for _ in range(max(1, weights.get(artist_id, 1))):
+                if not group or len(selected) >= max_tracks:
+                    break
+                selected.append(group.popleft())
+                dealt_this_round = True
+        if not dealt_this_round:
+            break  # every artist exhausted before reaching max_tracks
+    return selected
+
+
+def apply_freshness_filter[T: _Selectable](
+    scored: list[tuple[T, float]],
+    previous_track_ids: set[uuid.UUID],
+    freshness_target: int | None,
+    max_tracks: int,
+) -> list[tuple[T, float]]:
+    """Filter scored candidates to meet a freshness target.
+
+    If ``freshness_target`` is set, > 0, and there are ``previous_track_ids``,
+    limits how many previous tracks may appear: a target of 100 means all new, 0
+    means repeats are fine. The repeat allowance is
+    ``floor(max_tracks * (100 - freshness_target) / 100)``.
+
+    Shared primitive extracted from concert_prep's ``_apply_freshness_filter``.
+    """
+    if freshness_target is None or freshness_target <= 0 or not previous_track_ids:
+        return scored
+
+    max_repeats = int(max_tracks * (100 - freshness_target) / 100)
+    repeat_count = 0
+    result: list[tuple[T, float]] = []
+
+    for candidate, score in scored:
+        is_repeat = candidate.track_id in previous_track_ids
+        if is_repeat:
+            if repeat_count >= max_repeats:
+                continue
+            repeat_count += 1
+        result.append((candidate, score))
+
+    return result

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -53,6 +53,7 @@ import resonance.generators.concert_prep as concert_prep_module
 import resonance.generators.genre as genre_module
 import resonance.generators.parameters as params_module
 import resonance.generators.pool as pool_module
+import resonance.generators.rediscovery as rediscovery_module
 import resonance.heartbeat as heartbeat_module
 import resonance.logging as logging_module
 import resonance.migrations as migrations_module
@@ -807,9 +808,50 @@ def _artists_needing_discovery(
     ]
 
 
+async def _seed_artists_in_window(
+    session: sa_async.AsyncSession,
+    user_id: uuid.UUID,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    limit: int,
+) -> list[uuid.UUID]:
+    """Top artists by distinct-track listens in ``[start, end]`` (#rediscovery).
+
+    Ranks by ``COUNT(DISTINCT track_id)`` per artist (not raw scrobbles), matching
+    the ``track_coverage`` definition elsewhere, so one repeat-played track can't
+    dominate the seed set. Bounds are inclusive on both ends. Returns artist ids
+    highest-count-first, capped at ``limit``. The DB half of the seed-window
+    primitive; the pure bounds computation is ``pool.resolve_window_bounds``.
+    """
+    result = await session.execute(
+        sa.select(
+            music_models.Track.artist_id,
+            sa.func.count(sa.distinct(music_models.ListeningEvent.track_id)).label(
+                "cnt"
+            ),
+        )
+        .join(
+            music_models.Track,
+            music_models.Track.id == music_models.ListeningEvent.track_id,
+        )
+        .where(
+            music_models.ListeningEvent.user_id == user_id,
+            music_models.ListeningEvent.listened_at >= start,
+            music_models.ListeningEvent.listened_at <= end,
+        )
+        .group_by(music_models.Track.artist_id)
+        .order_by(sa.desc("cnt"))
+        .limit(limit)
+    )
+    return [row[0] for row in result.all()]
+
+
 async def resolve_pool(
     session: sa_async.AsyncSession,
     input_references: collections.abc.Mapping[str, object],
+    *,
+    user_id: uuid.UUID | None = None,
+    now: datetime.datetime | None = None,
 ) -> list[pool_module.ResolvedArtist]:
     """Resolve a profile's ``input_references`` into a deduplicated artist pool.
 
@@ -823,13 +865,22 @@ async def resolve_pool(
     * ``event``  -> the event's confirmed ``EventArtist`` rows plus accepted
       ``EventArtistCandidate`` matches. Every enabled event source is resolved in
       one ``event_id IN (...)`` query per table rather than per-event (#128 T14).
+    * ``listening_range`` -> the user's top seed artists in the window's time
+      bounds (#rediscovery). ``relative`` windows re-resolve to ``[now-N, now]``
+      each call (seed rolls forward); ``absolute`` windows read their frozen
+      stored bounds. Requires ``user_id`` (listens are per-user); ``now`` defaults
+      to the current UTC time when omitted.
     * ``artist`` -> the artist itself (including artists added by related-artist
       enrichment, which persists them as concrete ``artist`` sources, #133).
 
-    Returns the deduplicated, exclude-filtered artists in first-seen order (event
-    sources before artist sources), each tagged with provenance. This is the single
-    target-resolution path shared by both worker generation functions, replacing the
-    event-resolution blocks that were duplicated across them.
+    Returns the deduplicated, exclude-filtered artists in first-seen order (event,
+    then listening-range seeds, then artist sources), each tagged with provenance.
+    This is the single target-resolution path shared by both worker generation
+    functions, replacing the event-resolution blocks that were duplicated across
+    them.
+
+    Raises:
+        ValueError: If a listening_range source is present but ``user_id`` is None.
     """
     sources = pool_module.normalize_sources(input_references)
     exclude_ids = pool_module.extract_excludes(input_references)
@@ -869,6 +920,33 @@ async def resolve_pool(
                     pool_module.ResolvedArtist(
                         artist_id=cand.matched_artist_id,
                         via=pool_module.PoolProvenance.EVENT,
+                    )
+                )
+
+    # Listening-range sources: resolve each window to its top seed artists
+    # (#rediscovery). Per-user, so user_id is required when one is present.
+    range_sources = [
+        s
+        for s in sources
+        if isinstance(s, pool_module.ListeningRangeSource) and s.enabled
+    ]
+    if range_sources:
+        if user_id is None:
+            msg = "resolve_pool requires user_id to resolve a listening_range source"
+            raise ValueError(msg)
+        resolve_now = now or datetime.datetime.now(datetime.UTC)
+        for range_source in range_sources:
+            start, end = pool_module.resolve_window_bounds(
+                range_source.window, resolve_now
+            )
+            seed_ids = await _seed_artists_in_window(
+                session, user_id, start, end, range_source.seed_artist_count
+            )
+            for seed_id in seed_ids:
+                resolved.append(
+                    pool_module.ResolvedArtist(
+                        artist_id=seed_id,
+                        via=pool_module.PoolProvenance.LISTENING_RANGE,
                     )
                 )
 
@@ -945,7 +1023,9 @@ async def generate_playlist(ctx: dict[str, Any], task_id: str) -> None:
             event_id = str(profile.input_references.get("event_id", ""))
             log = log.bind(event_id=event_id)
 
-            pool = await resolve_pool(session, profile.input_references)
+            pool = await resolve_pool(
+                session, profile.input_references, user_id=task.user_id
+            )
             artist_ids: list[uuid.UUID] = [r.artist_id for r in pool]
             log = log.bind(pool_size=len(artist_ids))
 
@@ -1731,7 +1811,7 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
                 for s in sources
                 if isinstance(s, pool_module.ArtistSource) and s.via_seed is not None
             }
-            pool = await resolve_pool(session, refs)
+            pool = await resolve_pool(session, refs, user_id=task.user_id)
             current_pool_ids = {r.artist_id for r in pool}
 
             # Load every artist we might seed from (pool + explicit seeds).
@@ -1961,6 +2041,71 @@ async def enrich_related_artists(ctx: dict[str, Any], task_id: str) -> None:
                 await session.commit()
 
 
+def _select_rediscovery(
+    *,
+    candidates: list[concert_prep_module.CandidateTrack],
+    input_references: collections.abc.Mapping[str, object],
+    listen_counts: collections.abc.Mapping[uuid.UUID, int],
+    params: dict[str, int],
+    max_tracks: int,
+    previous_track_ids: set[uuid.UUID],
+    freshness_target: int | None,
+) -> rediscovery_module.SelectionResult:
+    """Assemble rediscovery inputs from resolved data and run two-stream select.
+
+    Derives, from already-fetched data (no new queries):
+
+    * the new-artist set -- artists materialized by enrichment (``via_seed`` sources),
+      which form the never-heard "new" stream;
+    * each seed artist's deep-cut track ids -- the bottom ``less_heard_percentile``
+      of that artist's lifetime play distribution, with the thin-seed guard
+      (:func:`rediscovery.select_deep_cut_track_ids`). The deep-cut stream is every
+      pool artist that is NOT a via_seed discovery.
+
+    Deep cuts are exempt from the freshness filter only under an ``absolute`` window
+    (design R4), so rediscovered cuts persist across regenerates; a ``relative``
+    window applies normal freshness. Delegates to
+    :func:`rediscovery.score_and_select`.
+    """
+    new_artist_ids = {
+        source.artist_id
+        for source in pool_module.normalize_sources(input_references)
+        if isinstance(source, pool_module.ArtistSource) and source.via_seed is not None
+    }
+
+    # Group each deep-cut-stream artist's candidate tracks into a lifetime play
+    # distribution, then pick its deep cuts. via_seed (new-stream) artists are not
+    # deep-cut sources.
+    percentile = params.get("less_heard_percentile", 33)
+    per_artist_counts: dict[uuid.UUID, dict[uuid.UUID, int]] = {}
+    for candidate in candidates:
+        if candidate.artist_id in new_artist_ids:
+            continue
+        per_artist_counts.setdefault(candidate.artist_id, {})[candidate.track_id] = (
+            listen_counts.get(candidate.track_id, 0)
+        )
+    deep_cut_track_ids: set[uuid.UUID] = set()
+    for track_counts in per_artist_counts.values():
+        deep_cut_track_ids |= rediscovery_module.select_deep_cut_track_ids(
+            track_counts, percentile=percentile
+        )
+
+    source = pool_module.find_listening_range_source(input_references)
+    exempt = source is not None and source.window.kind == "absolute"
+
+    return rediscovery_module.score_and_select(
+        candidates=candidates,
+        new_artist_ids=new_artist_ids,
+        deep_cut_track_ids=deep_cut_track_ids,
+        params=params,
+        new_ratio=params.get("new_ratio", 50),
+        max_tracks=max_tracks,
+        previous_track_ids=previous_track_ids,
+        freshness_target=freshness_target,
+        exempt_deep_cuts_from_freshness=exempt,
+    )
+
+
 async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
     """Score tracks and build the final playlist.
 
@@ -2028,7 +2173,9 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
             event_id = str(profile.input_references.get("event_id", ""))
             log = log.bind(event_id=event_id)
 
-            pool = await resolve_pool(session, profile.input_references)
+            pool = await resolve_pool(
+                session, profile.input_references, user_id=task.user_id
+            )
             artist_ids: set[uuid.UUID] = {r.artist_id for r in pool}
 
             params = params_module.apply_defaults(dict(profile.parameter_values))
@@ -2170,14 +2317,28 @@ async def score_and_build_playlist(ctx: dict[str, Any], task_id: str) -> None:
                 else None
             )
 
-            # Score and select
-            selection = concert_prep_module.score_and_select(
-                candidates=candidates,
-                params=params,
-                max_tracks=max_tracks,
-                previous_track_ids=previous_track_ids,
-                freshness_target=freshness_target,
-            )
+            # Score and select. Dispatch on generator type: rediscovery runs the
+            # two-stream (new artists vs deep cuts) selection with its own budget
+            # split and window-aware freshness exemption; every other type uses the
+            # single-pool concert_prep path unchanged.
+            if profile.generator_type == types_module.GeneratorType.REDISCOVERY:
+                selection = _select_rediscovery(
+                    candidates=candidates,
+                    input_references=profile.input_references,
+                    listen_counts=listen_counts,
+                    params=params,
+                    max_tracks=max_tracks,
+                    previous_track_ids=previous_track_ids,
+                    freshness_target=freshness_target,
+                )
+            else:
+                selection = concert_prep_module.score_and_select(
+                    candidates=candidates,
+                    params=params,
+                    max_tracks=max_tracks,
+                    previous_track_ids=previous_track_ids,
+                    freshness_target=freshness_target,
+                )
 
             # Regenerate in place (#versions): reuse the current Playlist row when one
             # exists, so its identity -- and the Spotify export anchor in

--- a/tests/test_api_generators.py
+++ b/tests/test_api_generators.py
@@ -259,6 +259,48 @@ class TestValidateProfileInputs:
             )
 
 
+class TestRediscoveryProfile:
+    """Creating/validating a REDISCOVERY profile (#rediscovery)."""
+
+    def test_listening_range_profile_passes_validation(self) -> None:
+        body = {
+            "name": "Last 2 Weeks",
+            "generator_type": "rediscovery",
+            "input_references": {
+                "sources": [
+                    {
+                        "kind": "listening_range",
+                        "enabled": True,
+                        "window": {"kind": "relative", "lookback_days": 14},
+                        "seed_artist_count": 20,
+                    }
+                ]
+            },
+            "parameter_values": {"new_ratio": 50, "less_heard_percentile": 33},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        assert request.generator_type == types_module.GeneratorType.REDISCOVERY
+        # A listening_range source is a non-empty enabled pool -> passes.
+        generators_module.validate_profile_inputs(
+            request.input_references, request.generator_type
+        )
+
+    def test_malformed_window_rejected(self) -> None:
+        body = {
+            "name": "Bad Window",
+            "generator_type": "rediscovery",
+            "input_references": {
+                "sources": [{"kind": "listening_range", "window": {"kind": "nope"}}]
+            },
+            "parameter_values": {},
+        }
+        request = generators_module.CreateProfileRequest(**body)
+        with pytest.raises(ValueError, match="Invalid input_references"):
+            generators_module.validate_profile_inputs(
+                request.input_references, request.generator_type
+            )
+
+
 # --- enrich endpoint (#133) ---
 
 

--- a/tests/test_listening_range.py
+++ b/tests/test_listening_range.py
@@ -1,0 +1,257 @@
+"""Tests for the listening_range pool source + seed-window primitive (#rediscovery).
+
+Covers the pure half of the seed-window resolver: parsing/serializing the
+listening_range source and its window, the ``resolve_window_bounds`` primitive
+(relative rolls forward, absolute stays frozen), and the ``find_listening_range_source``
+accessor. The DB seed query lives in the worker and is covered there.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+import resonance.generators.parameters as params_module
+import resonance.generators.pool as pool_module
+import resonance.types as types_module
+
+
+class TestParseListeningRangeSource:
+    def test_relative_window_parses_with_defaults(self) -> None:
+        sources = pool_module.normalize_sources(
+            {
+                "sources": [
+                    {
+                        "kind": "listening_range",
+                        "window": {"kind": "relative", "lookback_days": 14},
+                    }
+                ]
+            }
+        )
+        assert sources == [
+            pool_module.ListeningRangeSource(
+                window=pool_module.ListeningWindow(kind="relative", lookback_days=14),
+                seed_artist_count=20,
+                deep_cut_basis="lifetime",
+                novelty_basis="lifetime",
+                enabled=True,
+            )
+        ]
+
+    def test_absolute_window_parses(self) -> None:
+        raw = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "enabled": True,
+                    "window": {
+                        "kind": "absolute",
+                        "start": "2025-07-01T00:00:00+00:00",
+                        "end": "2025-07-15T00:00:00+00:00",
+                    },
+                    "seed_artist_count": 10,
+                    "deep_cut_basis": "window",
+                    "novelty_basis": "lifetime",
+                }
+            ]
+        }
+        (source,) = pool_module.normalize_sources(raw)
+        assert isinstance(source, pool_module.ListeningRangeSource)
+        assert source.window.kind == "absolute"
+        assert source.window.start == datetime.datetime(2025, 7, 1, tzinfo=datetime.UTC)
+        assert source.window.end == datetime.datetime(2025, 7, 15, tzinfo=datetime.UTC)
+        assert source.seed_artist_count == 10
+        assert source.deep_cut_basis == "window"
+        assert source.novelty_basis == "lifetime"
+
+    def test_unknown_window_kind_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown window kind"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {"kind": "listening_range", "window": {"kind": "forever"}}
+                    ]
+                }
+            )
+
+    def test_relative_requires_positive_lookback(self) -> None:
+        with pytest.raises(ValueError, match="lookback_days must be a positive"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {
+                            "kind": "listening_range",
+                            "window": {"kind": "relative", "lookback_days": 0},
+                        }
+                    ]
+                }
+            )
+
+    def test_absolute_end_must_be_after_start(self) -> None:
+        with pytest.raises(ValueError, match=r"window\.end must be after"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {
+                            "kind": "listening_range",
+                            "window": {
+                                "kind": "absolute",
+                                "start": "2025-07-15T00:00:00+00:00",
+                                "end": "2025-07-01T00:00:00+00:00",
+                            },
+                        }
+                    ]
+                }
+            )
+
+    def test_bad_basis_rejected(self) -> None:
+        with pytest.raises(ValueError, match="deep_cut_basis must be"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {
+                            "kind": "listening_range",
+                            "window": {"kind": "relative", "lookback_days": 14},
+                            "deep_cut_basis": "yesterday",
+                        }
+                    ]
+                }
+            )
+
+    def test_seed_artist_count_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="seed_artist_count must be a positive"):
+            pool_module.normalize_sources(
+                {
+                    "sources": [
+                        {
+                            "kind": "listening_range",
+                            "window": {"kind": "relative", "lookback_days": 14},
+                            "seed_artist_count": -1,
+                        }
+                    ]
+                }
+            )
+
+
+class TestSerializeRoundTrip:
+    def test_relative_round_trips(self) -> None:
+        source = pool_module.ListeningRangeSource(
+            window=pool_module.ListeningWindow(kind="relative", lookback_days=30),
+            seed_artist_count=15,
+            deep_cut_basis="lifetime",
+            novelty_basis="lifetime",
+        )
+        raw = pool_module.serialize_source(source)
+        assert pool_module.normalize_sources({"sources": [raw]}) == [source]
+
+    def test_absolute_round_trips(self) -> None:
+        source = pool_module.ListeningRangeSource(
+            window=pool_module.ListeningWindow(
+                kind="absolute",
+                start=datetime.datetime(2024, 7, 10, tzinfo=datetime.UTC),
+                end=datetime.datetime(2024, 7, 24, tzinfo=datetime.UTC),
+            ),
+        )
+        raw = pool_module.serialize_source(source)
+        assert pool_module.normalize_sources({"sources": [raw]}) == [source]
+
+    def test_survives_enrich_replace_round_trip(self) -> None:
+        # replace_via_seed_sources re-serializes every non-via_seed source; the
+        # listening_range source (window + basis flags) must survive so enrich
+        # (create -> enrich -> generate) doesn't drop the recipe.
+        lr = pool_module.serialize_source(
+            pool_module.ListeningRangeSource(
+                window=pool_module.ListeningWindow(kind="relative", lookback_days=14),
+            )
+        )
+        refs = {"sources": [lr], "exclude_artist_ids": []}
+        import uuid
+
+        discovered = uuid.uuid4()
+        merged = pool_module.replace_via_seed_sources(refs, "lineup", [discovered])
+        source = pool_module.find_listening_range_source(merged)
+        assert source is not None
+        assert source.window == pool_module.ListeningWindow(
+            kind="relative", lookback_days=14
+        )
+        # the discovered artist landed as a via_seed source alongside it
+        assert pool_module.scope_artist_ids(merged, "lineup") == [discovered]
+
+
+class TestResolveWindowBounds:
+    def test_relative_rolls_from_now(self) -> None:
+        now = datetime.datetime(2026, 7, 10, 12, 0, tzinfo=datetime.UTC)
+        window = pool_module.ListeningWindow(kind="relative", lookback_days=14)
+        start, end = pool_module.resolve_window_bounds(window, now)
+        assert end == now
+        assert start == now - datetime.timedelta(days=14)
+
+    def test_absolute_is_frozen(self) -> None:
+        now = datetime.datetime(2026, 7, 10, tzinfo=datetime.UTC)
+        window = pool_module.ListeningWindow(
+            kind="absolute",
+            start=datetime.datetime(2025, 7, 1, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 7, 15, tzinfo=datetime.UTC),
+        )
+        start, end = pool_module.resolve_window_bounds(window, now)
+        assert start == datetime.datetime(2025, 7, 1, tzinfo=datetime.UTC)
+        assert end == datetime.datetime(2025, 7, 15, tzinfo=datetime.UTC)
+
+
+class TestFindListeningRangeSource:
+    def test_finds_enabled_source(self) -> None:
+        refs = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "window": {"kind": "relative", "lookback_days": 14},
+                }
+            ]
+        }
+        source = pool_module.find_listening_range_source(refs)
+        assert source is not None
+        assert source.window.lookback_days == 14
+
+    def test_skips_disabled_source(self) -> None:
+        refs = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "enabled": False,
+                    "window": {"kind": "relative", "lookback_days": 14},
+                }
+            ]
+        }
+        assert pool_module.find_listening_range_source(refs) is None
+
+    def test_none_when_absent(self) -> None:
+        assert pool_module.find_listening_range_source({"sources": []}) is None
+
+
+class TestRediscoveryParameters:
+    def test_type_registered_with_listening_range_seed(self) -> None:
+        config = params_module.GENERATOR_TYPE_CONFIG[
+            types_module.GeneratorType.REDISCOVERY
+        ]
+        assert (
+            config.default_pool_seed == pool_module.PoolSourceKind.LISTENING_RANGE.value
+        )
+        assert "new_ratio" in config.featured_parameters
+        assert "less_heard_percentile" in config.featured_parameters
+
+    def test_dials_registered_with_balanced_defaults(self) -> None:
+        assert params_module.PARAMETER_REGISTRY["new_ratio"].default_value == 50
+        assert (
+            params_module.PARAMETER_REGISTRY["less_heard_percentile"].default_value
+            == 33
+        )
+
+    def test_apply_defaults_fills_new_dials(self) -> None:
+        applied = params_module.apply_defaults({})
+        assert applied["new_ratio"] == 50
+        assert applied["less_heard_percentile"] == 33
+
+    def test_dials_are_bounded_0_100(self) -> None:
+        with pytest.raises(ValueError, match="must be 0-100"):
+            params_module.apply_defaults({"new_ratio": 150})

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -50,9 +50,13 @@ class TestApplyDefaults:
         assert result["familiarity"] == 50
 
     def test_preserves_all_provided(self) -> None:
+        # apply_defaults returns every registry parameter, so provided values are
+        # preserved (a superset that also carries the rediscovery dials' defaults).
         provided = {"hit_depth": 25, "familiarity": 80}
         result = params_module.apply_defaults(provided)
-        assert result == provided
+        assert result.items() >= provided.items()
+        assert result["new_ratio"] == 50
+        assert result["less_heard_percentile"] == 33
 
     def test_rejects_removed_similar_artist_ratio(self) -> None:
         # The dead parameter must be rejected, not silently accepted (#133).

--- a/tests/test_rediscovery.py
+++ b/tests/test_rediscovery.py
@@ -1,0 +1,234 @@
+"""Tests for the pure rediscovery generator logic (#rediscovery, design T3)."""
+
+from __future__ import annotations
+
+import uuid
+
+import resonance.generators.rediscovery as rediscovery_module
+import resonance.types as types_module
+
+
+def _cand(
+    *,
+    artist_id: uuid.UUID,
+    track_id: uuid.UUID | None = None,
+    title: str = "t",
+    artist_name: str = "a",
+    listen_count: int = 0,
+    in_library: bool = True,
+    popularity_score: int = 50,
+    source: types_module.TrackSource = types_module.TrackSource.LIBRARY,
+) -> rediscovery_module.CandidateTrack:
+    return rediscovery_module.CandidateTrack(
+        track_id=track_id or uuid.uuid4(),
+        title=title,
+        artist_name=artist_name,
+        artist_id=artist_id,
+        is_target_artist=True,
+        listen_count=listen_count,
+        in_library=in_library,
+        popularity_score=popularity_score,
+        source=source,
+    )
+
+
+class TestSelectDeepCutTrackIds:
+    def test_bottom_third_selected(self) -> None:
+        # 8 tracks; 33rd pctile -> nearest-rank idx 2 (value 2); count<=2 -> 3 tracks.
+        tids = [uuid.uuid4() for _ in range(8)]
+        counts = [1, 1, 2, 3, 5, 8, 13, 21]
+        play_counts = dict(zip(tids, counts, strict=True))
+        deep = rediscovery_module.select_deep_cut_track_ids(play_counts, percentile=33)
+        assert deep == {tids[0], tids[1], tids[2]}
+
+    def test_play_count_floor_excludes_unplayed(self) -> None:
+        # A never-played track (count 0) is not a rediscovery -- excluded entirely,
+        # and it doesn't count toward the distinct-track guard either.
+        played = [uuid.uuid4() for _ in range(4)]
+        unplayed = uuid.uuid4()
+        play_counts = {**dict.fromkeys(played, 1), unplayed: 0}
+        # bump so they aren't all equal
+        play_counts[played[3]] = 9
+        deep = rediscovery_module.select_deep_cut_track_ids(play_counts, percentile=50)
+        assert unplayed not in deep
+
+    def test_thin_seed_guard_drops_artist(self) -> None:
+        # Fewer than 4 distinct played tracks -> no deep cuts (degenerate pctile).
+        tids = [uuid.uuid4() for _ in range(3)]
+        play_counts = dict(zip(tids, [1, 1, 2], strict=True))
+        assert (
+            rediscovery_module.select_deep_cut_track_ids(play_counts, percentile=33)
+            == set()
+        )
+
+    def test_guard_boundary_exactly_four_passes(self) -> None:
+        tids = [uuid.uuid4() for _ in range(4)]
+        play_counts = dict(zip(tids, [1, 2, 3, 4], strict=True))
+        deep = rediscovery_module.select_deep_cut_track_ids(play_counts, percentile=33)
+        # nearest-rank idx 1 -> value 2 -> count<=2 -> 2 tracks.
+        assert deep == {tids[0], tids[1]}
+
+    def test_heavy_rotation_artist_still_yields_deep_cuts(self) -> None:
+        # An artist you play a lot still has a "bottom third" -- deep cuts are
+        # relative to the artist's own distribution, not an absolute play threshold.
+        tids = [uuid.uuid4() for _ in range(6)]
+        play_counts = dict(zip(tids, [40, 55, 60, 90, 120, 200], strict=True))
+        deep = rediscovery_module.select_deep_cut_track_ids(play_counts, percentile=33)
+        assert tids[0] in deep and tids[5] not in deep
+
+
+class TestSplitBudget:
+    def test_balanced(self) -> None:
+        assert rediscovery_module.split_budget(new_ratio=50, max_tracks=10) == (5, 5)
+
+    def test_all_deep_cuts(self) -> None:
+        assert rediscovery_module.split_budget(new_ratio=0, max_tracks=10) == (0, 10)
+
+    def test_all_new(self) -> None:
+        assert rediscovery_module.split_budget(new_ratio=100, max_tracks=10) == (10, 0)
+
+    def test_rounding_remainder_to_deep(self) -> None:
+        # round(3.3) = 3 -> 3 new, 7 deep; total exact.
+        assert rediscovery_module.split_budget(new_ratio=33, max_tracks=10) == (3, 7)
+
+
+class TestScoreAndSelect:
+    def test_partitions_new_and_deep_streams(self) -> None:
+        new_artist = uuid.uuid4()
+        seed_artist = uuid.uuid4()
+        new_tracks = [
+            _cand(artist_id=new_artist, in_library=False, popularity_score=80)
+            for _ in range(5)
+        ]
+        seed_tracks = [_cand(artist_id=seed_artist, listen_count=2) for _ in range(5)]
+        deep_ids = {c.track_id for c in seed_tracks}
+        result = rediscovery_module.score_and_select(
+            candidates=[*new_tracks, *seed_tracks],
+            new_artist_ids={new_artist},
+            deep_cut_track_ids=deep_ids,
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=50,
+            max_tracks=6,
+            previous_track_ids=set(),
+            freshness_target=None,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        picked = {t.track_id for t in result.tracks}
+        assert len(result.tracks) == 6
+        # 3 from each stream at 50/50.
+        new_picked = picked & {c.track_id for c in new_tracks}
+        deep_picked = picked & deep_ids
+        assert len(new_picked) == 3
+        assert len(deep_picked) == 3
+
+    def test_deep_track_not_in_deep_ids_is_excluded(self) -> None:
+        # A seed artist's track that didn't qualify as a deep cut is not a candidate.
+        seed_artist = uuid.uuid4()
+        deep = _cand(artist_id=seed_artist, listen_count=1)
+        loud = _cand(artist_id=seed_artist, listen_count=99)  # not a deep cut
+        result = rediscovery_module.score_and_select(
+            candidates=[deep, loud],
+            new_artist_ids=set(),
+            deep_cut_track_ids={deep.track_id},
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=0,
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        picked = {t.track_id for t in result.tracks}
+        assert deep.track_id in picked
+        assert loud.track_id not in picked
+
+    def test_short_new_stream_redistributes_to_deep(self) -> None:
+        # new_ratio wants 3 new but only 1 new artist track exists; deep absorbs
+        # the slack so the playlist still fills to max_tracks.
+        new_artist = uuid.uuid4()
+        seed_artist = uuid.uuid4()
+        new_tracks = [_cand(artist_id=new_artist, in_library=False)]
+        seed_tracks = [_cand(artist_id=seed_artist, listen_count=1) for _ in range(9)]
+        result = rediscovery_module.score_and_select(
+            candidates=[*new_tracks, *seed_tracks],
+            new_artist_ids={new_artist},
+            deep_cut_track_ids={c.track_id for c in seed_tracks},
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=50,
+            max_tracks=6,
+            previous_track_ids=set(),
+            freshness_target=None,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        assert len(result.tracks) == 6  # 1 new + 5 deep (slack redistributed)
+
+    def test_all_new_ratio_selects_only_new(self) -> None:
+        new_artist = uuid.uuid4()
+        seed_artist = uuid.uuid4()
+        new_tracks = [_cand(artist_id=new_artist, in_library=False) for _ in range(4)]
+        seed_tracks = [_cand(artist_id=seed_artist, listen_count=1) for _ in range(4)]
+        result = rediscovery_module.score_and_select(
+            candidates=[*new_tracks, *seed_tracks],
+            new_artist_ids={new_artist},
+            deep_cut_track_ids={c.track_id for c in seed_tracks},
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=100,
+            max_tracks=4,
+            previous_track_ids=set(),
+            freshness_target=None,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        picked = {t.track_id for t in result.tracks}
+        assert picked == {c.track_id for c in new_tracks}
+
+    def test_absolute_window_exempts_deep_cuts_from_freshness(self) -> None:
+        # freshness_target=100 (all new) but deep cuts are exempt -> a previously
+        # surfaced deep cut persists across regenerate.
+        seed_artist = uuid.uuid4()
+        deep_tracks = [_cand(artist_id=seed_artist, listen_count=1) for _ in range(4)]
+        prev = {c.track_id for c in deep_tracks}  # all were in the prior version
+        result = rediscovery_module.score_and_select(
+            candidates=list(deep_tracks),
+            new_artist_ids=set(),
+            deep_cut_track_ids=prev,
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=0,
+            max_tracks=4,
+            previous_track_ids=prev,
+            freshness_target=100,
+            exempt_deep_cuts_from_freshness=True,
+        )
+        # Exempt: repeats survive despite freshness_target=100.
+        assert len(result.tracks) == 4
+
+    def test_relative_window_applies_freshness_to_deep_cuts(self) -> None:
+        # Same setup but NOT exempt (relative window) -> repeats are filtered out.
+        seed_artist = uuid.uuid4()
+        deep_tracks = [_cand(artist_id=seed_artist, listen_count=1) for _ in range(4)]
+        prev = {c.track_id for c in deep_tracks}
+        result = rediscovery_module.score_and_select(
+            candidates=list(deep_tracks),
+            new_artist_ids=set(),
+            deep_cut_track_ids=prev,
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=0,
+            max_tracks=4,
+            previous_track_ids=prev,
+            freshness_target=100,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        # All were repeats and freshness=100 allows 0 repeats -> empty.
+        assert result.tracks == []
+
+    def test_empty_candidates(self) -> None:
+        result = rediscovery_module.score_and_select(
+            candidates=[],
+            new_artist_ids=set(),
+            deep_cut_track_ids=set(),
+            params={"familiarity": 50, "hit_depth": 50},
+            new_ratio=50,
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+            exempt_deep_cuts_from_freshness=False,
+        )
+        assert result.tracks == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3866,6 +3866,79 @@ class TestResolvePool:
 
         assert [r.artist_id for r in pool] == [a1]  # event wins, artist dup dropped
 
+    async def test_listening_range_resolves_seeds_in_order(self) -> None:
+        import resonance.generators.pool as pool_module
+
+        a1, a2 = uuid.uuid4(), uuid.uuid4()
+        user_id = uuid.uuid4()
+        # _seed_artists_in_window does session.execute(...).all() -> [(artist, cnt)].
+        seed_result = MagicMock()
+        seed_result.all.return_value = [(a1, 5), (a2, 3)]
+        session = AsyncMock()
+        session.execute.return_value = seed_result
+
+        refs = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "enabled": True,
+                    "window": {"kind": "relative", "lookback_days": 14},
+                    "seed_artist_count": 20,
+                }
+            ]
+        }
+        pool = await worker_module.resolve_pool(session, refs, user_id=user_id)
+
+        # Seeds enter in the query's rank order, tagged LISTENING_RANGE provenance.
+        assert [r.artist_id for r in pool] == [a1, a2]
+        assert all(r.via is pool_module.PoolProvenance.LISTENING_RANGE for r in pool)
+
+    async def test_listening_range_requires_user_id(self) -> None:
+        session = AsyncMock()
+        refs = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "window": {"kind": "relative", "lookback_days": 14},
+                }
+            ]
+        }
+        with pytest.raises(ValueError, match="requires user_id"):
+            await worker_module.resolve_pool(session, refs)
+
+    async def test_listening_range_ordered_after_events(self) -> None:
+        import resonance.generators.pool as pool_module
+
+        ev_artist, seed_artist = uuid.uuid4(), uuid.uuid4()
+        eid = uuid.uuid4()
+        user_id = uuid.uuid4()
+        ea = MagicMock()
+        ea.artist_id = ev_artist
+        seed_result = MagicMock()
+        seed_result.all.return_value = [(seed_artist, 4)]
+        session = AsyncMock()
+        # Order of execute calls: EventArtist scalars, candidate scalars, seed query.
+        session.execute.side_effect = [
+            _scalars_result([ea]),
+            _scalars_result([]),
+            seed_result,
+        ]
+
+        refs = {
+            "sources": [
+                {"kind": "event", "event_id": str(eid), "enabled": True},
+                {
+                    "kind": "listening_range",
+                    "window": {"kind": "relative", "lookback_days": 14},
+                },
+            ]
+        }
+        pool = await worker_module.resolve_pool(session, refs, user_id=user_id)
+
+        assert [r.artist_id for r in pool] == [ev_artist, seed_artist]
+        assert pool[0].via is pool_module.PoolProvenance.EVENT
+        assert pool[1].via is pool_module.PoolProvenance.LISTENING_RANGE
+
 
 # ---------------------------------------------------------------------------
 # Related-artist enrichment (#133)

--- a/tests/test_worker_rediscovery.py
+++ b/tests/test_worker_rediscovery.py
@@ -1,0 +1,193 @@
+"""Tests for the worker's rediscovery selection glue (#rediscovery, T4/T8).
+
+``worker._select_rediscovery`` is the pure derivation step: from a profile's
+input_references + the already-fetched candidates + lifetime listen counts, it
+derives the new-artist set (via_seed discoveries), each seed artist's deep-cut
+track ids, and the window-driven freshness exemption, then delegates to
+``rediscovery.score_and_select`` (tested separately). These tests exercise the
+derivation, not the SQL (the worker tests are mock-based).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import resonance.generators.concert_prep as concert_prep_module
+import resonance.types as types_module
+import resonance.worker as worker_module
+
+
+def _cand(
+    *,
+    artist_id: uuid.UUID,
+    track_id: uuid.UUID,
+    listen_count: int,
+    in_library: bool,
+    source: types_module.TrackSource,
+) -> concert_prep_module.CandidateTrack:
+    return concert_prep_module.CandidateTrack(
+        track_id=track_id,
+        title="t",
+        artist_name="a",
+        artist_id=artist_id,
+        is_target_artist=True,
+        listen_count=listen_count,
+        in_library=in_library,
+        popularity_score=50,
+        source=source,
+    )
+
+
+def _relative_refs(new_artist: uuid.UUID) -> dict[str, object]:
+    return {
+        "sources": [
+            {
+                "kind": "listening_range",
+                "enabled": True,
+                "window": {"kind": "relative", "lookback_days": 14},
+            },
+            {
+                "kind": "artist",
+                "artist_id": str(new_artist),
+                "enabled": True,
+                "via_seed": "lineup",
+            },
+        ]
+    }
+
+
+class TestSelectRediscovery:
+    def test_partitions_via_seed_new_from_listened_seeds(self) -> None:
+        new_artist = uuid.uuid4()
+        seed_artist = uuid.uuid4()
+        # New (discovery) tracks: never heard.
+        new_tracks = [
+            _cand(
+                artist_id=new_artist,
+                track_id=uuid.uuid4(),
+                listen_count=0,
+                in_library=False,
+                source=types_module.TrackSource.DISCOVERY,
+            )
+            for _ in range(3)
+        ]
+        # Seed (listened) tracks with a play distribution.
+        seed_tids = [uuid.uuid4() for _ in range(5)]
+        seed_counts = [1, 2, 3, 8, 20]
+        seed_tracks = [
+            _cand(
+                artist_id=seed_artist,
+                track_id=tid,
+                listen_count=count,
+                in_library=True,
+                source=types_module.TrackSource.LIBRARY,
+            )
+            for tid, count in zip(seed_tids, seed_counts, strict=True)
+        ]
+        listen_counts = dict(zip(seed_tids, seed_counts, strict=True))
+
+        result = worker_module._select_rediscovery(
+            candidates=[*new_tracks, *seed_tracks],
+            input_references=_relative_refs(new_artist),
+            listen_counts=listen_counts,
+            params={
+                "familiarity": 50,
+                "hit_depth": 50,
+                "new_ratio": 50,
+                "less_heard_percentile": 33,
+            },
+            max_tracks=4,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+
+        picked = {t.track_id for t in result.tracks}
+        new_picked = picked & {c.track_id for c in new_tracks}
+        deep_picked = picked & set(seed_tids)
+        # 50/50 split of 4 -> 2 new + 2 deep.
+        assert len(new_picked) == 2
+        assert len(deep_picked) == 2
+        # Deep cuts are the bottom-third of the seed distribution (counts 1 and 2),
+        # never the heavy-rotation tracks (8, 20).
+        assert deep_picked == {seed_tids[0], seed_tids[1]}
+
+    def test_thin_seed_artist_contributes_no_deep_cuts(self) -> None:
+        new_artist = uuid.uuid4()
+        thin_seed = uuid.uuid4()
+        # Only 3 distinct played tracks -> thin-seed guard drops it from deep cuts.
+        thin_tids = [uuid.uuid4() for _ in range(3)]
+        thin_tracks = [
+            _cand(
+                artist_id=thin_seed,
+                track_id=tid,
+                listen_count=1,
+                in_library=True,
+                source=types_module.TrackSource.LIBRARY,
+            )
+            for tid in thin_tids
+        ]
+        new_tracks = [
+            _cand(
+                artist_id=new_artist,
+                track_id=uuid.uuid4(),
+                listen_count=0,
+                in_library=False,
+                source=types_module.TrackSource.DISCOVERY,
+            )
+            for _ in range(3)
+        ]
+        result = worker_module._select_rediscovery(
+            candidates=[*new_tracks, *thin_tracks],
+            input_references=_relative_refs(new_artist),
+            listen_counts=dict.fromkeys(thin_tids, 1),
+            params={"familiarity": 50, "hit_depth": 50, "new_ratio": 0},
+            max_tracks=10,
+            previous_track_ids=set(),
+            freshness_target=None,
+        )
+        picked = {t.track_id for t in result.tracks}
+        # The thin seed contributes NO deep cuts (guard drops it) -- none of its
+        # tracks are selected, even though new_ratio=0 asked for all deep cuts.
+        assert picked & set(thin_tids) == set()
+        # The deep stream's empty slack redistributes to the new stream, so the
+        # playlist still fills rather than coming back empty.
+        assert picked == {c.track_id for c in new_tracks}
+
+    def test_absolute_window_exempts_deep_cuts_from_freshness(self) -> None:
+        seed_artist = uuid.uuid4()
+        seed_tids = [uuid.uuid4() for _ in range(4)]
+        seed_tracks = [
+            _cand(
+                artist_id=seed_artist,
+                track_id=tid,
+                listen_count=1,
+                in_library=True,
+                source=types_module.TrackSource.LIBRARY,
+            )
+            for tid in seed_tids
+        ]
+        refs = {
+            "sources": [
+                {
+                    "kind": "listening_range",
+                    "enabled": True,
+                    "window": {
+                        "kind": "absolute",
+                        "start": "2025-07-01T00:00:00+00:00",
+                        "end": "2025-07-15T00:00:00+00:00",
+                    },
+                }
+            ]
+        }
+        result = worker_module._select_rediscovery(
+            candidates=list(seed_tracks),
+            input_references=refs,
+            listen_counts=dict.fromkeys(seed_tids, 1),
+            params={"familiarity": 50, "hit_depth": 50, "new_ratio": 0},
+            max_tracks=4,
+            # every deep cut was in the prior version; freshness_target=100 would
+            # normally drop them all, but the absolute window exempts deep cuts.
+            previous_track_ids=set(seed_tids),
+            freshness_target=100,
+        )
+        assert len(result.tracks) == 4


### PR DESCRIPTION
## Summary

Adds a **REDISCOVERY** generator: "more but different" from a movable time-range slice of your listening history. It mixes never-heard on-genre artists (materialized up front by #133 enrichment) with less-heard deep cuts from the seed artists you already spin, balanced by a `new_ratio` dial. The seed is a time RANGE over listening history (last 2 weeks, ~a month ago, this time last year, or custom), not fixed at now.

Designed + eng-reviewed before implementation (approved design, 5 findings folded as R1–R5).

<details>
<summary>How to Review</summary>

Three logical commits:

1. **`refactor(generators)`** — extract the round-robin spread, freshness filter, and per-track scoring glue from `concert_prep` into `scoring` as generator-agnostic primitives (typed against a structural `_Selectable` protocol). `concert_prep` delegates; behavior is byte-identical (existing tests pass). This is the reuse seam for the new generator.
2. **`feat(rediscovery): ...generator`** — the feature. `pool.py` gains the `listening_range` source kind + `ListeningWindow` + `resolve_window_bounds`; `parameters.py` registers the type + dials; `worker.py` resolves the window to seed artists and dispatches REDISCOVERY to a two-stream selection; `rediscovery.py` holds the pure two-stream logic.
3. **`feat(rediscovery): CLI...`** — `--window` presets on `profile create`; API validation tests.

Suggested order: commit-by-commit.
</details>

<details>
<summary>Design decisions (R1–R5)</summary>

- **R1 param split**: numeric dials (`new_ratio`=50, `less_heard_percentile`=33) are 0–100 ints in `parameter_values`; the window + `deep_cut_basis`/`novelty_basis` flags are recipe data in `input_references` (on the source, so the enrich round-trip can't drop them).
- **R2 enrich-then-partition**: new artists enter the pool via the existing #133 enrichment (`via_seed`), not generation-time expansion. `new_ratio` partitions the materialized pool. Flow: create → enrich → generate.
- **R3 window source kind**: `listening_range` is a new pool source kind (the reusable seed-window primitive; keeps deferred Approach C cheap).
- **R4 hybrid window**: `absolute` freezes the seed + exempts deep cuts from the freshness drop (rediscovered cuts persist); `relative` rolls the seed forward with normal freshness.
- **R5 thin-seed guard**: an artist with < 4 distinct played tracks is dropped from the deep-cut stream (the percentile of `[1,1,2]` is degenerate).

`deep_cut_basis`/`novelty_basis` default `lifetime`; the `window` basis path is a plumbed seam (v1 scores lifetime-only).
</details>

<details>
<summary>Test Plan</summary>

- [x] 1774 tests pass (~45 new: seed-window parse/resolve, deep-cut percentile + thin-seed guard, budget split + slack redistribution, window-kind freshness exemption, resolve_pool listening_range resolution, worker two-stream derivation, API create/validation)
- [x] `concert_prep` regression: existing generator tests unchanged and green after the primitive extraction
- [x] mypy strict clean (99 files); ruff check + format clean
- [ ] Live dogfood (create → enrich → generate for last-2wk / this-time-last-year) — the design's post-merge tuning step
</details>

<details>
<summary>Impact</summary>

- New generator type; existing `concert_prep` path unchanged (additive dispatch).
- Both ListeningEvent indexes the seed query needs already exist — no migration.
- `apply_defaults` now returns the two new dials for every profile type (harmless: concert_prep scoring ignores them).
</details>