### PR TITLE
feat(rediscovery): end-user UI for creating rediscovery playlists

### DIFF
--- a/src/resonance/generators/parameters.py
+++ b/src/resonance/generators/parameters.py
@@ -45,6 +45,20 @@ class GeneratorTypeConfig:
     # event for concert prep). None means no default seed -- the caller supplies
     # sources. Value is a ``pool.PoolSourceKind``.
     default_pool_seed: str | None = None
+    # Editor slider ordering (#rediscovery-ui). ``lead_parameters`` render first,
+    # ``advanced_parameters`` behind an "Advanced" disclosure. Both are ordered
+    # (unlike the unordered ``featured_parameters`` set) and together should equal
+    # ``featured_parameters``: only a type's featured dials render in the editor,
+    # so inert dials (e.g. new_ratio for concert_prep) never show. Empty
+    # ``lead_parameters`` falls back to the featured set in registry order.
+    lead_parameters: tuple[str, ...] = ()
+    advanced_parameters: tuple[str, ...] = ()
+
+    def ordered_lead(self) -> tuple[str, ...]:
+        """Lead slider names, defaulting to featured params in registry order."""
+        if self.lead_parameters:
+            return self.lead_parameters
+        return tuple(n for n in PARAMETER_REGISTRY if n in self.featured_parameters)
 
 
 PARAMETER_REGISTRY: dict[str, ParameterDefinition] = {
@@ -102,6 +116,7 @@ GENERATOR_TYPE_CONFIG: dict[types_module.GeneratorType, GeneratorTypeConfig] = {
         required_inputs=frozenset(),
         description="Generate a playlist to prepare for a concert",
         default_pool_seed=pool_module.PoolSourceKind.EVENT.value,
+        lead_parameters=("familiarity", "hit_depth"),
     ),
     types_module.GeneratorType.REDISCOVERY: GeneratorTypeConfig(
         featured_parameters=frozenset(
@@ -120,6 +135,11 @@ GENERATOR_TYPE_CONFIG: dict[types_module.GeneratorType, GeneratorTypeConfig] = {
         # the registry defaults; stated explicitly so the type's intended vibe is
         # documented at the config, not inferred from the registry.
         default_param_values={"new_ratio": 50, "less_heard_percentile": 33},
+        # Lead with the two dials that define rediscovery (new-vs-deep-cut split +
+        # deep-cut depth); familiarity/hit_depth tuck behind "Advanced" so four peer
+        # sliders don't flatten the hierarchy (#rediscovery-ui design decision 2).
+        lead_parameters=("new_ratio", "less_heard_percentile"),
+        advanced_parameters=("familiarity", "hit_depth"),
     ),
 }
 

--- a/src/resonance/generators/seed_window.py
+++ b/src/resonance/generators/seed_window.py
@@ -1,0 +1,62 @@
+"""Seed-window DB helper: top listened artists in a time range (#rediscovery).
+
+The DB half of the reusable seed-window primitive. Its pure counterpart --
+``pool.resolve_window_bounds`` -- turns a :class:`pool.ListeningWindow` into
+concrete ``(start, end)`` bounds; this module turns those bounds into the user's
+top seed artists.
+
+It lives in its own lightweight module (sqlalchemy + music models only, no
+connectors/arq) so both the worker generation path and the web seed-preview
+endpoint can import it without pulling in the whole worker import graph.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+
+import resonance.models.music as music_models
+
+if TYPE_CHECKING:
+    import datetime
+    import uuid
+
+    import sqlalchemy.ext.asyncio as sa_async
+
+
+async def seed_artists_in_window(
+    session: sa_async.AsyncSession,
+    user_id: uuid.UUID,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    limit: int,
+) -> list[uuid.UUID]:
+    """Top artists by distinct-track listens in ``[start, end]`` (#rediscovery).
+
+    Ranks by ``COUNT(DISTINCT track_id)`` per artist (not raw scrobbles), matching
+    the ``track_coverage`` definition elsewhere, so one repeat-played track can't
+    dominate the seed set. Bounds are inclusive on both ends. Returns artist ids
+    highest-count-first, capped at ``limit``.
+    """
+    result = await session.execute(
+        sa.select(
+            music_models.Track.artist_id,
+            sa.func.count(sa.distinct(music_models.ListeningEvent.track_id)).label(
+                "cnt"
+            ),
+        )
+        .join(
+            music_models.Track,
+            music_models.Track.id == music_models.ListeningEvent.track_id,
+        )
+        .where(
+            music_models.ListeningEvent.user_id == user_id,
+            music_models.ListeningEvent.listened_at >= start,
+            music_models.ListeningEvent.listened_at <= end,
+        )
+        .group_by(music_models.Track.artist_id)
+        .order_by(sa.desc("cnt"))
+        .limit(limit)
+    )
+    return [row[0] for row in result.all()]

--- a/src/resonance/static/lineup.core.js
+++ b/src/resonance/static/lineup.core.js
@@ -157,3 +157,124 @@ export function serializeInputReferences(groups) {
   }
   return { sources: sources, exclude_artist_ids: Object.keys(excludeSet) };
 }
+
+/* ===== Rediscovery window (#rediscovery-ui) =====
+ *
+ * The rediscovery editor's recipe is a listening-history window + dials, not a
+ * hand-picked lineup. These pure helpers own the window's client state and its
+ * serialization into the same stored input_references shape the server parses
+ * (a listening_range source, plus any enrich-discovered via_seed artists).
+ */
+
+const DAY_MS = 86400000;
+
+export const SEED_COUNT_MIN = 5;
+export const SEED_COUNT_MAX = 50;
+export const SEED_COUNT_DEFAULT = 20;
+
+/* Window preset pills, in display order. "custom" reveals two date inputs; the
+ * other three are one-tap presets. Only "last_2_weeks" persists its identity
+ * (as a relative window); the two absolute presets round-trip as "custom" (see
+ * presetIdForWindow). */
+export const REDISCOVERY_PRESETS = [
+  { id: "last_2_weeks", label: "Last 2 Weeks" },
+  { id: "a_month_ago", label: "A Month Ago" },
+  { id: "this_time_last_year", label: "This Time Last Year" },
+  { id: "custom", label: "Custom" },
+];
+
+/* Format an epoch-ms instant to a YYYY-MM-DD (UTC) date string. */
+export function isoDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/* Build an absolute window from two YYYY-MM-DD strings. The end snaps to
+ * end-of-day so the end date is included (the backend bounds are inclusive), and
+ * so a same-day window (start === end) is still a valid non-empty range. */
+export function absoluteWindow(startDate, endDate) {
+  return {
+    kind: "absolute",
+    start: startDate + "T00:00:00",
+    end: endDate + "T23:59:59",
+  };
+}
+
+/* Resolve a preset id to a stored window object against `now` (epoch ms).
+ * "last_2_weeks" is relative (rolls forward on every generate); the two
+ * "…ago" presets snap to concrete absolute day-bounds at selection time (a
+ * frozen artifact). "custom" returns null — the caller builds it from the date
+ * inputs via absoluteWindow. */
+export function windowFromPreset(presetId, now) {
+  if (presetId === "last_2_weeks") {
+    return { kind: "relative", lookback_days: 14 };
+  }
+  if (presetId === "a_month_ago") {
+    return absoluteWindow(isoDate(now - 44 * DAY_MS), isoDate(now - 16 * DAY_MS));
+  }
+  if (presetId === "this_time_last_year") {
+    return absoluteWindow(isoDate(now - 379 * DAY_MS), isoDate(now - 351 * DAY_MS));
+  }
+  return null;
+}
+
+/* Which pill is active for a stored window. A relative window is the rolling
+ * "Last 2 Weeks" preset; any absolute window reads as "Custom" with its dates —
+ * preset identity for the two absolute presets is intentionally not persisted
+ * (the backend rebuilds the window from typed fields only), matching the design's
+ * relative-vs-custom round-trip contract. A missing window defaults to the
+ * rolling preset. */
+export function presetIdForWindow(window) {
+  if (!window || window.kind === "relative") return "last_2_weeks";
+  return "custom";
+}
+
+/* The YYYY-MM-DD (start, end) pair to prefill the custom date inputs from a
+ * window. A relative window has no stored dates (empty strings); the controller
+ * fills them from the resolved preset when the user switches to Custom. */
+export function windowDates(window) {
+  if (!window || window.kind !== "absolute") return { start: "", end: "" };
+  return {
+    start: (window.start || "").slice(0, 10),
+    end: (window.end || "").slice(0, 10),
+  };
+}
+
+/* Clamp a raw seed-count input to [MIN, MAX], falling back to the default on a
+ * non-numeric value. */
+export function clampSeedCount(n) {
+  const v = parseInt(n, 10);
+  if (!Number.isFinite(v)) return SEED_COUNT_DEFAULT;
+  return Math.max(SEED_COUNT_MIN, Math.min(SEED_COUNT_MAX, v));
+}
+
+/* Is a window valid to preview/generate? Relative needs a positive lookback;
+ * absolute needs start strictly before end. Drives the Generate-disable guard. */
+export function isWindowValid(window) {
+  if (!window) return false;
+  if (window.kind === "relative") return (window.lookback_days || 0) > 0;
+  if (window.kind === "absolute") {
+    return Boolean(window.start && window.end && window.start < window.end);
+  }
+  return false;
+}
+
+/* Serialize the rediscovery recipe into stored input_references. The
+ * listening_range source leads; enrich-discovered via_seed artists (carried as
+ * `related` groups) and their excludes are PRESERVED via serializeInputReferences,
+ * so editing the window never drops the enriched new-artist stream. v1 scores
+ * lifetime-only, so the basis flags are constant. */
+export function serializeRediscovery(window, seedCount, groups) {
+  const base = serializeInputReferences(groups || []);
+  const listeningRange = {
+    kind: "listening_range",
+    enabled: true,
+    window: window,
+    seed_artist_count: seedCount,
+    deep_cut_basis: "lifetime",
+    novelty_basis: "lifetime",
+  };
+  return {
+    sources: [listeningRange, ...base.sources],
+    exclude_artist_ids: base.exclude_artist_ids,
+  };
+}

--- a/src/resonance/static/lineup.css
+++ b/src/resonance/static/lineup.css
@@ -285,3 +285,91 @@ button.primary {
   padding: 10px 18px; font-family: var(--body-font); font-weight: 500; font-size: 0.95rem; cursor: pointer;
 }
 button.primary:disabled { opacity: 0.6; cursor: default; }
+
+/* ===== Rediscovery window panel (#rediscovery-ui) ===== */
+
+.rediscovery-panel { display: flex; flex-direction: column; gap: var(--space-md); }
+
+/* Preset pills reuse .filter-presets/.preset-btn from filters.css (radius-full,
+ * primary-active). Just give the group breathing room in this context. */
+.window-presets { margin-bottom: 0; }
+
+/* Custom date range */
+.custom-window {
+  display: flex; flex-wrap: wrap; align-items: flex-end; gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  background: var(--surface-alt);
+}
+.custom-window .cw-field {
+  display: flex; flex-direction: column; gap: 4px;
+  font-size: 0.8rem; color: var(--text-muted);
+}
+.custom-window .cw-field input[type="date"] {
+  margin: 0; height: 38px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  background: var(--surface); color: var(--text); padding: 0 10px; font-size: 0.9rem;
+}
+.custom-window .cw-error {
+  flex-basis: 100%; color: var(--error); font-size: 0.8rem;
+}
+
+/* Seed count */
+.seed-count-field { display: flex; flex-direction: column; gap: 4px; }
+.seed-count-field label { font-weight: 700; font-size: 0.9rem; }
+.seed-count-field input[type="number"] {
+  width: 5rem; margin: 4px 0 0; height: 38px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  background: var(--surface); color: var(--text); padding: 0 10px; font-size: 0.9rem;
+}
+
+/* Seed preview — the emotional payoff, visually distinct from the editable
+ * lineup so the user doesn't try to uncheck a derived seed. */
+.seed-preview {
+  border: 1px solid var(--border); border-left: 3px solid var(--primary);
+  border-radius: var(--radius-md); background: var(--surface-alt);
+  padding: var(--space-sm) var(--space-md); min-height: 3rem;
+  transition: opacity var(--dur-short, 200ms) ease-in-out;
+}
+.seed-preview.loading { opacity: 0.5; }
+.seed-window-echo {
+  font-size: 0.78rem; color: var(--text-muted); font-variant-numeric: tabular-nums;
+  margin-bottom: var(--space-xs);
+}
+.seed-preview-head { font-size: 0.9rem; font-weight: 500; margin-bottom: var(--space-xs); }
+.seed-preview-head .seed-count { font-variant-numeric: tabular-nums; }
+.seed-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: var(--space-2xs) var(--space-sm);
+}
+.seed-item { font-size: 0.85rem; }
+.seed-item .seed-name { font-weight: 500; }
+.seed-item .seed-meta { color: var(--text-muted); font-size: 0.75rem; }
+.seed-item:not(:last-child) .seed-name::after { content: ","; color: var(--text-muted); font-weight: 400; }
+.seed-more { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-2xs); }
+.seed-empty { font-size: 0.85rem; color: var(--text-muted); font-style: italic; }
+
+/* Find-related row (rediscovery variant of the add-related control) */
+.find-related-row { display: flex; align-items: center; gap: var(--space-xs); }
+.find-related-row input[type="number"] {
+  width: 4rem; margin: 0; height: 38px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  background: var(--surface); color: var(--text); padding: 0 10px; font-size: 0.9rem;
+}
+
+/* "All deep cuts" hint next to Generate when the new stream is empty */
+.new-stream-hint {
+  font-size: 0.85rem; color: var(--text-muted);
+  margin-bottom: var(--space-sm);
+}
+.new-stream-hint .linklike {
+  border: none; background: none; color: var(--primary); cursor: pointer;
+  font-size: 0.85rem; font-weight: 500; padding: 0; text-decoration: underline;
+}
+
+/* Advanced parameters disclosure */
+.advanced-params > summary {
+  cursor: pointer; font-size: 0.85rem; color: var(--text-muted);
+  margin-bottom: var(--space-sm);
+}
+.advanced-params[open] > summary { margin-bottom: var(--space-md); }

--- a/src/resonance/static/lineup.js
+++ b/src/resonance/static/lineup.js
@@ -7,19 +7,27 @@
  * this module is the DOM + network controller.
  */
 import {
+  absoluteWindow,
   addEventGroup,
   addManualArtist,
   allArtistIds,
   artistMeta,
+  clampSeedCount,
   escapeHtml,
   groupKey,
   hasArtist,
   isEmpty,
+  isoDate,
+  isWindowValid,
+  presetIdForWindow,
   removeArtistFromGroup,
   removeGroup,
   serializeInputReferences,
+  serializeRediscovery,
   setEventArtists,
   toggleArtist,
+  windowDates,
+  windowFromPreset,
 } from "./lineup.core.js";
 
 const dataEl = document.getElementById("lineup-data");
@@ -29,6 +37,33 @@ const similarAvailable = window.LINEUP_SIMILAR_AVAILABLE === true;
 
 const state = { groups: initial.groups || [], version: initial.version || 0 };
 let conflicted = false;
+
+/* ---- rediscovery window mode (#rediscovery-ui) ---- */
+const isRediscovery = window.LINEUP_GENERATOR_TYPE === "rediscovery";
+// Window recipe + seed count. Hydrated from the stored listening_range source, or
+// defaulted to the rolling "Last 2 Weeks" preset for a fresh draft.
+let windowState =
+  (initial.listening_range && initial.listening_range.window) || {
+    kind: "relative",
+    lookback_days: 14,
+  };
+let seedCount =
+  (initial.listening_range && initial.listening_range.seed_artist_count) || 20;
+// Preview drives the Generate-disable guard: an invalid window or a window with
+// no listening data cannot generate. `previewDirty` gates refreshing the preview
+// to persisted-window changes only (the endpoint reads the stored window).
+let windowValid = isWindowValid(windowState);
+let previewEmpty = false;
+let previewDirty = false;
+
+/* The stored input_references for the current mode: rediscovery leads with the
+ * window source (preserving enrich discoveries); concert_prep uses the lineup. */
+function currentInputRefs() {
+  if (isRediscovery) {
+    return serializeRediscovery(windowState, seedCount, state.groups);
+  }
+  return serializeInputReferences(state.groups);
+}
 
 const groupsEl = document.getElementById("lineup-groups");
 const emptyEl = document.getElementById("lineup-empty");
@@ -217,6 +252,19 @@ function render() {
     if (openKeys.has(d.getAttribute("data-group-key"))) d.open = true;
   }
   if (emptyEl) emptyEl.hidden = !isEmpty(state.groups);
+  if (isRediscovery) updateNewStreamHint();
+}
+
+/* Show the "all deep cuts" hint when a rediscovery pool has no enrich-discovered
+ * new artists yet (a silent empty new stream makes new_ratio a no-op). Hint, not
+ * a block — all-deep-cuts is a legitimate output. */
+function updateNewStreamHint() {
+  const hint = document.getElementById("new-stream-hint");
+  if (!hint) return;
+  const hasNew = state.groups.some(
+    (g) => g.kind === "related" && g.artists.length > 0
+  );
+  hint.hidden = hasNew;
 }
 
 /* ---- persistence (PATCH) ---- */
@@ -241,7 +289,7 @@ async function flushSave(extra) {
   pending = false;
   const body = Object.assign(
     {
-      input_references: serializeInputReferences(state.groups),
+      input_references: currentInputRefs(),
       expected_version: state.version,
     },
     extra || {}
@@ -270,6 +318,13 @@ async function flushSave(extra) {
   const data = await resp.json();
   if (typeof data.version === "number") state.version = data.version;
   setSaving(false);
+  // The seed preview reads the PERSISTED window, so refresh it only after a
+  // window/seed-count change has committed (previewDirty), never on a name/param
+  // save.
+  if (isRediscovery && previewDirty) {
+    previewDirty = false;
+    refreshSeedPreview();
+  }
   return data;
 }
 
@@ -494,7 +549,7 @@ if (eventSelect) {
 function isDefaultName() {
   if (!nameInput) return false;
   const v = nameInput.value.trim();
-  return v === "" || v === "New Playlist";
+  return v === "" || v === "New Playlist" || v === "New Rediscovery";
 }
 
 function maybeAutoName(title, venue) {
@@ -601,12 +656,150 @@ if (conflictReload) {
   conflictReload.addEventListener("click", () => window.location.reload());
 }
 
+/* ---- rediscovery window controls (#rediscovery-ui) ---- */
+
+const seedPreviewEl = document.getElementById("seed-preview");
+const customWindowEl = document.getElementById("custom-window");
+const windowStartEl = document.getElementById("window-start");
+const windowEndEl = document.getElementById("window-end");
+const windowErrorEl = document.getElementById("window-error");
+const seedCountEl = document.getElementById("seed-count");
+
+/* Generate is disabled while the window is invalid (custom end < start) or the
+ * window resolves to no listening data — both would crash or no-op generation. */
+function updateGenerateEnabled() {
+  if (!isRediscovery || !generateBtn) return;
+  generateBtn.disabled = !windowValid || previewEmpty;
+}
+
+function setActivePreset(presetId) {
+  for (const btn of document.querySelectorAll("[data-window-preset]")) {
+    btn.classList.toggle(
+      "preset-active",
+      btn.getAttribute("data-window-preset") === presetId
+    );
+  }
+  if (customWindowEl) customWindowEl.hidden = presetId !== "custom";
+}
+
+const DAY_MS = 86400000;
+
+/* Concrete YYYY-MM-DD (start, end) for any window, resolving a relative window to
+ * [now - lookback, now] so switching to Custom pre-fills valid dates. */
+function resolvedDatesForWindow(w, now) {
+  if (!w) return { start: "", end: "" };
+  if (w.kind === "absolute") return windowDates(w);
+  const days = w.lookback_days || 14;
+  return { start: isoDate(now - days * DAY_MS), end: isoDate(now) };
+}
+
+async function refreshSeedPreview() {
+  if (!seedPreviewEl) return;
+  seedPreviewEl.classList.add("loading");
+  let resp;
+  try {
+    resp = await fetch("/playlists/" + profileId + "/seed-preview", {
+      credentials: "same-origin",
+    });
+  } catch (e) {
+    seedPreviewEl.classList.remove("loading");
+    return;
+  }
+  seedPreviewEl.classList.remove("loading");
+  if (!resp.ok) return;
+  seedPreviewEl.innerHTML = await resp.text();
+  const inner = document.getElementById("seed-preview-inner");
+  previewEmpty = inner ? inner.getAttribute("data-empty") === "true" : false;
+  updateGenerateEnabled();
+}
+
+/* Apply a window change: validate, reflect the custom-date error, and (if valid)
+ * persist + mark the preview dirty so it refreshes after the PATCH commits. */
+function applyWindow(newWindow, presetId) {
+  windowState = newWindow;
+  windowValid = isWindowValid(windowState);
+  if (windowErrorEl) {
+    windowErrorEl.hidden = windowValid || presetId !== "custom";
+  }
+  updateGenerateEnabled();
+  if (!windowValid) return; // never PATCH an invalid window (the API 400s it)
+  previewDirty = true;
+  scheduleSave();
+}
+
+function windowFromCustomInputs() {
+  const start = windowStartEl ? windowStartEl.value : "";
+  const end = windowEndEl ? windowEndEl.value : "";
+  if (!start || !end) return null;
+  return absoluteWindow(start, end);
+}
+
+for (const presetBtn of document.querySelectorAll("[data-window-preset]")) {
+  presetBtn.addEventListener("click", () => {
+    const presetId = presetBtn.getAttribute("data-window-preset");
+    setActivePreset(presetId);
+    if (presetId === "custom") {
+      // Pre-fill empty custom inputs from the current window so Custom starts
+      // valid (design decision 4).
+      if (windowStartEl && windowEndEl && (!windowStartEl.value || !windowEndEl.value)) {
+        const d = resolvedDatesForWindow(windowState, Date.now());
+        windowStartEl.value = windowStartEl.value || d.start;
+        windowEndEl.value = windowEndEl.value || d.end;
+      }
+      applyWindow(windowFromCustomInputs(), "custom");
+      return;
+    }
+    const w = windowFromPreset(presetId, Date.now());
+    // Reflect an absolute preset's dates into the custom inputs so a later switch
+    // to Custom is pre-filled + tweakable.
+    const d = windowDates(w);
+    if (windowStartEl) windowStartEl.value = d.start;
+    if (windowEndEl) windowEndEl.value = d.end;
+    applyWindow(w, presetId);
+  });
+}
+
+for (const dateEl of [windowStartEl, windowEndEl]) {
+  if (dateEl) {
+    dateEl.addEventListener("change", () =>
+      applyWindow(windowFromCustomInputs(), "custom")
+    );
+  }
+}
+
+if (seedCountEl) {
+  seedCountEl.addEventListener("change", () => {
+    seedCount = clampSeedCount(seedCountEl.value);
+    seedCountEl.value = String(seedCount);
+    previewDirty = true;
+    scheduleSave();
+  });
+}
+
+const hintFind = document.getElementById("hint-find-related");
+if (hintFind) {
+  hintFind.addEventListener("click", () => runEnrich("lineup", hintFind));
+}
+
+if (isRediscovery) {
+  setActivePreset(presetIdForWindow(windowState));
+  if (seedCountEl) seedCountEl.value = String(seedCount);
+  const initialDates = windowDates(windowState);
+  if (windowStartEl && initialDates.start) windowStartEl.value = initialDates.start;
+  if (windowEndEl && initialDates.end) windowEndEl.value = initialDates.end;
+  updateGenerateEnabled();
+  refreshSeedPreview();
+}
+
 /* Generate: persist, then trigger generation and go to the status page. */
 const generateBtn = document.getElementById("generate-btn");
 if (generateBtn) {
   generateBtn.addEventListener("click", async () => {
     if (conflicted) return;
-    if (isEmpty(state.groups)) {
+    // Rediscovery's pool comes from the window (seeds are derived), so an empty
+    // groups list is fine — the window guard (disabled state) covers validity.
+    // concert_prep needs at least one hand-picked source.
+    if (!isRediscovery && isEmpty(state.groups)) {
       if (emptyEl) {
         emptyEl.textContent = "Add at least one event or artist before generating.";
         emptyEl.hidden = false;
@@ -614,14 +807,20 @@ if (generateBtn) {
       return;
     }
     generateBtn.disabled = true;
-    // Last-resort naming so nothing ever generates as "New Playlist": prefer the
-    // first event, else a dated fallback. (Event-add already auto-names; this
-    // covers an artist-only pool the user never named.)
+    // Last-resort naming so nothing ever generates as a bare default: rediscovery
+    // names from its window, concert_prep from the first event, else a dated
+    // fallback. (Event-add already auto-names; this covers pools the user never
+    // named.)
     if (isDefaultName()) {
-      const ev = state.groups.find((g) => g.kind === "event");
-      const fallback = ev
-        ? "Concert Prep: " + ev.title
-        : "Playlist " + new Date().toISOString().slice(0, 10);
+      let fallback;
+      if (isRediscovery) {
+        fallback = "Rediscovery " + new Date().toISOString().slice(0, 10);
+      } else {
+        const ev = state.groups.find((g) => g.kind === "event");
+        fallback = ev
+          ? "Concert Prep: " + ev.title
+          : "Playlist " + new Date().toISOString().slice(0, 10);
+      }
       nameInput.value = fallback;
       await flushSave({ name: fallback });
     }

--- a/src/resonance/templates/partials/rediscovery_seed_preview.html
+++ b/src/resonance/templates/partials/rediscovery_seed_preview.html
@@ -1,0 +1,35 @@
+{# Rediscovery seed preview (#rediscovery-ui T5). Read-only: the deep-cut seed
+   artists the current window resolves to. Root carries data-empty so the editor
+   can disable Generate on a window with no listening data. Names are
+   Jinja-autoescaped (server-side render), safer than client string-building. #}
+<div id="seed-preview-inner" data-empty="{{ 'true' if empty else 'false' }}">
+  {% if start and end %}
+  <div class="seed-window-echo">
+    {% if start.year == end.year %}
+      {{ start.strftime('%b %-d') }}&ndash;{{ end.strftime('%b %-d, %Y') }}
+    {% else %}
+      {{ start.strftime('%b %-d, %Y') }}&ndash;{{ end.strftime('%b %-d, %Y') }}
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {% if empty %}
+  <div class="seed-empty">
+    No listening data in this window. Pick a different window
+    {% if start and end %}than {{ start.strftime('%b %-d') }}&ndash;{{ end.strftime('%b %-d') }}{% endif %}
+    to rediscover something.
+  </div>
+  {% else %}
+  <div class="seed-preview-head">You&rsquo;ll rediscover <span class="seed-count">{{ total }}</span> artist{{ '' if total == 1 else 's' }}:</div>
+  <ul class="seed-list">
+    {% for a in artists %}
+    <li class="seed-item">
+      <span class="seed-name">{{ a.name }}</span>{% if a.meta %} <span class="seed-meta">{{ a.meta }}</span>{% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% if more > 0 %}
+  <div class="seed-more">+{{ more }} more</div>
+  {% endif %}
+  {% endif %}
+</div>

--- a/src/resonance/templates/playlists_new.html
+++ b/src/resonance/templates/playlists_new.html
@@ -1,9 +1,29 @@
 {% extends "base.html" %}
 {% block title %}Edit Playlist — resonance{% endblock %}
 {% block head %}
+<link rel="stylesheet" href="/static/filters.css">
 <link rel="stylesheet" href="/static/lineup.css">
 {% endblock %}
+
+{% macro param_slider(name, param) %}
+<div class="param">
+    <div class="param-head">
+        <strong>{{ param.display_name }}</strong>
+        <small class="lineup-hint">{{ param.description }}</small>
+    </div>
+    <input type="range" data-param="{{ name }}" min="0" max="100"
+           value="{{ parameter_values.get(name, param.default_value) }}"
+           oninput="this.parentElement.querySelector('.val').textContent = this.value">
+    <div class="slider-scale">
+        <small class="lbl-lo">{{ param.labels[0] }}</small>
+        <small class="val">{{ parameter_values.get(name, param.default_value) }}</small>
+        <small class="lbl-hi">{{ param.labels[1] }}</small>
+    </div>
+</div>
+{% endmacro %}
+
 {% block content %}
+{% set is_rediscovery = generator_type == 'rediscovery' %}
 <p><a class="backlink" href="/playlists">&larr; Back to Playlists</a></p>
 
 <div class="editor-top">
@@ -18,8 +38,51 @@
     <button type="button" id="conflict-reload">Reload</button>
 </div>
 
-<!-- Lineup -->
 <article>
+    {% if is_rediscovery %}
+    <header>Rediscover <small class="lineup-hint">— pick a window; we'll surface what you used to play, then rediscover it.</small></header>
+
+    <div class="rediscovery-panel">
+        <div class="filter-presets window-presets" role="group" aria-label="Listening window">
+            <button type="button" class="preset-btn" data-window-preset="last_2_weeks">Last 2 Weeks</button>
+            <button type="button" class="preset-btn" data-window-preset="a_month_ago">A Month Ago</button>
+            <button type="button" class="preset-btn" data-window-preset="this_time_last_year">This Time Last Year</button>
+            <button type="button" class="preset-btn" data-window-preset="custom">Custom</button>
+        </div>
+
+        <div class="custom-window" id="custom-window" hidden>
+            <label class="cw-field">From <input type="date" id="window-start"></label>
+            <label class="cw-field">To <input type="date" id="window-end"></label>
+            <div class="cw-error" id="window-error" hidden>End date must be on or after the start date.</div>
+        </div>
+
+        <div class="seed-count-field">
+            <label for="seed-count">Seed artists
+                <input type="number" id="seed-count" min="5" max="50" value="20">
+            </label>
+            <small class="lineup-hint">How many of that window's top artists to build the deep cuts from.</small>
+        </div>
+
+        <div class="seed-preview" id="seed-preview" aria-live="polite"></div>
+
+        {% if similar_available %}
+        <div class="find-related-row">
+            <input type="number" id="add-related-n" value="15" min="1" max="50"
+                   aria-label="How many related artists to find">
+            <button type="button" class="ghost" id="add-related-btn">Find related artists</button>
+        </div>
+        {% else %}
+        <div class="enrich-note" style="border:1px dashed var(--border-strong);border-radius:var(--radius-md);">
+            Connect a similar-artists service (ListenBrainz) to add never-heard new artists.
+            <a href="/connections">Connect →</a>
+        </div>
+        {% endif %}
+
+        <!-- Enrich-discovered new artists render here (read-mostly related groups). -->
+        <div id="lineup-groups"></div>
+    </div>
+
+    {% else %}
     <header>Lineup <small class="lineup-hint">— who's in this playlist. Uncheck an artist to leave them out.</small></header>
 
     <div class="lineup-add">
@@ -61,27 +124,24 @@
 
     <div class="lineup-empty" id="lineup-empty" hidden>No artists yet — add an event or artist above.</div>
     <div id="lineup-groups"></div>
+    {% endif %}
 </article>
 
 <!-- Parameters -->
 <article>
     <header>Parameters</header>
-    {% for name, param in parameters.items() %}
-    <div class="param">
-        <div class="param-head">
-            <strong>{{ param.display_name }}</strong>
-            <small class="lineup-hint">{{ param.description }}</small>
-        </div>
-        <input type="range" data-param="{{ name }}" min="0" max="100"
-               value="{{ parameter_values.get(name, param.default_value) }}"
-               oninput="this.parentElement.querySelector('.val').textContent = this.value">
-        <div class="slider-scale">
-            <small class="lbl-lo">{{ param.labels[0] }}</small>
-            <small class="val">{{ parameter_values.get(name, param.default_value) }}</small>
-            <small class="lbl-hi">{{ param.labels[1] }}</small>
-        </div>
-    </div>
+    {% for name, param in param_sections[0].params %}
+        {{ param_slider(name, param) }}
     {% endfor %}
+
+    {% if param_sections[1].params %}
+    <details class="advanced-params">
+        <summary>Advanced</summary>
+        {% for name, param in param_sections[1].params %}
+            {{ param_slider(name, param) }}
+        {% endfor %}
+    </details>
+    {% endif %}
 
     <div style="max-width: 12rem;">
         <label for="max_tracks">
@@ -91,12 +151,20 @@
     </div>
 </article>
 
+{% if is_rediscovery %}
+<div class="new-stream-hint" id="new-stream-hint" hidden>
+    No new artists found yet — this will be all deep cuts.
+    <button type="button" class="linklike" id="hint-find-related">Find related artists?</button>
+</div>
+{% endif %}
+
 <button type="button" class="primary" id="generate-btn">Generate Playlist</button>
 
 <script id="lineup-data" type="application/json">{{ lineup | tojson }}</script>
 <script>
   window.LINEUP_PROFILE_ID = "{{ profile_id }}";
   window.LINEUP_SIMILAR_AVAILABLE = {{ 'true' if similar_available else 'false' }};
+  window.LINEUP_GENERATOR_TYPE = "{{ generator_type }}";
 </script>
 <script type="module" src="/static/lineup.js"></script>
 {% endblock %}

--- a/src/resonance/ui/playlists.py
+++ b/src/resonance/ui/playlists.py
@@ -16,6 +16,7 @@ import resonance.api.v1.artists as artists_api
 import resonance.api.v1.generators as generators_api
 import resonance.dependencies as deps_module
 import resonance.generators.pool as pool_module
+import resonance.generators.seed_window as seed_window_module
 import resonance.models.concert as concert_models
 import resonance.models.generator as generator_models
 import resonance.models.music as music_models
@@ -390,7 +391,7 @@ async def _hydrate_lineup(
             }
         )
 
-    return {
+    result: dict[str, object] = {
         "profile_id": str(profile.id),
         "version": profile.version,
         "name": profile.name,
@@ -398,6 +399,29 @@ async def _hydrate_lineup(
         "parameter_values": profile.parameter_values,
         "groups": groups,
     }
+
+    # Rediscovery window (#rediscovery-ui T6b): surface the stored listening_range
+    # window + seed count so the editor's window panel restores its preset/dates on
+    # reload. Round-trip is preset IDENTITY-lossy by design (relative -> the rolling
+    # preset, absolute -> Custom with its dates); the client maps kind to a pill.
+    lr = pool_module.find_listening_range_source(refs)
+    if lr is not None:
+        window: dict[str, object] = {"kind": lr.window.kind}
+        if lr.window.kind == "relative":
+            window["lookback_days"] = lr.window.lookback_days
+        else:
+            window["start"] = (
+                lr.window.start.isoformat() if lr.window.start is not None else None
+            )
+            window["end"] = (
+                lr.window.end.isoformat() if lr.window.end is not None else None
+            )
+        result["listening_range"] = {
+            "window": window,
+            "seed_artist_count": lr.seed_artist_count,
+        }
+
+    return result
 
 
 def _is_uuid(value: str) -> bool:
@@ -430,15 +454,33 @@ async def new_playlist_page(
     sources: list[dict[str, object]] = []
     if event_id and _is_uuid(event_id):
         sources.append({"kind": "event", "event_id": event_id, "enabled": True})
+    # A rediscovery draft seeds its pool from a listening-history window so the
+    # editor's window panel renders immediately and the draft is a valid pool
+    # (a listening_range is an enabled source, #rediscovery-ui T1). Default to the
+    # rolling "Last 2 Weeks" relative window. Only seed it when the caller didn't
+    # already supply an event source.
+    is_rediscovery = gen_type_enum is types_module.GeneratorType.REDISCOVERY
+    if is_rediscovery and not sources:
+        sources.append(
+            {
+                "kind": "listening_range",
+                "enabled": True,
+                "window": {"kind": "relative", "lookback_days": 14},
+                "seed_artist_count": 20,
+                "deep_cut_basis": "lifetime",
+                "novelty_basis": "lifetime",
+            }
+        )
     input_references: dict[str, object] = {
         "sources": sources,
         "exclude_artist_ids": [],
     }
 
+    default_name = "New Rediscovery" if is_rediscovery else "New Playlist"
     name = (
         await _default_playlist_name(db, input_references)
-        if sources
-        else "New Playlist"
+        if event_id and _is_uuid(event_id)
+        else default_name
     )
     profile = generator_models.GeneratorProfile(
         user_id=user_id,
@@ -474,8 +516,34 @@ async def edit_playlist_page(
     if profile is None:
         raise fastapi.HTTPException(status_code=404, detail="Profile not found")
 
+    import resonance.generators.parameters as params_module
+
     ctx = await _new_playlist_context(request, db)
     lineup = await _hydrate_lineup(db, profile)
+
+    # Only the type's featured dials render, split lead vs "Advanced" (#rediscovery-ui
+    # T6a): concert_prep shows familiarity/hit_depth; rediscovery leads with
+    # new_ratio/less_heard and tucks familiarity/hit_depth behind the disclosure.
+    # Filtering here is also what stops concert_prep from rendering the inert
+    # rediscovery dials it showed when the template looped the whole registry.
+    config = params_module.GENERATOR_TYPE_CONFIG.get(profile.generator_type)
+    if config is not None:
+        lead_names = config.ordered_lead()
+        advanced_names = config.advanced_parameters
+    else:
+        lead_names = tuple(params_module.PARAMETER_REGISTRY)
+        advanced_names = ()
+    reg = params_module.PARAMETER_REGISTRY
+    param_sections = [
+        {
+            "advanced": False,
+            "params": [(n, reg[n]) for n in lead_names if n in reg],
+        },
+        {
+            "advanced": True,
+            "params": [(n, reg[n]) for n in advanced_names if n in reg],
+        },
+    ]
     # Whether a similar-artists service is connected (drives the enrich hint).
     conn_result = await db.execute(
         sa.select(user_models.ServiceConnection.id).where(
@@ -496,8 +564,88 @@ async def edit_playlist_page(
         profile_name=profile.name,
         parameter_values=profile.parameter_values,
         similar_available=similar_available,
+        param_sections=param_sections,
+        generator_type=profile.generator_type.value,
     )
     return common.templates.TemplateResponse(request, "playlists_new.html", ctx)
+
+
+# Max seed artists rendered in the preview before collapsing to "+N more".
+_SEED_PREVIEW_DISPLAY_CAP = 30
+
+
+@router.get("/playlists/{profile_id}/seed-preview", response_model=None)
+async def seed_preview_partial(
+    request: fastapi.Request,
+    user_id: Annotated[uuid.UUID, fastapi.Depends(common.require_user)],
+    db: Annotated[sa_async.AsyncSession, fastapi.Depends(deps_module.get_db)],
+    profile_id: uuid.UUID,
+) -> fastapi.responses.HTMLResponse:
+    """Read-only preview of what a rediscovery window resolves to (#rediscovery-ui T5).
+
+    Resolves the profile's *currently stored* listening_range window to the top
+    seed artists (the deep-cut side of the recipe), so the panel can show "You'll
+    rediscover: …" as live tuning feedback. Reads the persisted window (the editor
+    PATCHes it before refreshing), so no window is passed in the request. Renders
+    the resolved date range as an echo and a first-class empty state for a window
+    with no listening data (which drives Generate-disable client-side).
+    """
+    result = await db.execute(
+        sa.select(generator_models.GeneratorProfile).where(
+            generator_models.GeneratorProfile.id == profile_id,
+            generator_models.GeneratorProfile.user_id == user_id,
+        )
+    )
+    profile = result.scalar_one_or_none()
+    if profile is None:
+        raise fastapi.HTTPException(status_code=404, detail="Profile not found")
+
+    lr = pool_module.find_listening_range_source(profile.input_references)
+    ctx = common.base_context(request)
+    if lr is None:
+        # Not a rediscovery profile (or window not set yet): nothing to preview.
+        ctx.update(artists=[], start=None, end=None, total=0, more=0, empty=True)
+        return common.templates.TemplateResponse(
+            request, "partials/rediscovery_seed_preview.html", ctx
+        )
+
+    now = datetime.datetime.now(datetime.UTC)
+    start, end = pool_module.resolve_window_bounds(lr.window, now)
+    seed_ids = await seed_window_module.seed_artists_in_window(
+        db, user_id, start, end, lr.seed_artist_count
+    )
+
+    artists: list[dict[str, object]] = []
+    if seed_ids:
+        display_ids = seed_ids[:_SEED_PREVIEW_DISPLAY_CAP]
+        artist_result = await db.execute(
+            sa.select(music_models.Artist).where(
+                music_models.Artist.id.in_(display_ids)
+            )
+        )
+        by_id = {a.id: a for a in artist_result.scalars().all()}
+        for aid in display_ids:
+            artist = by_id.get(aid)
+            if artist is None:
+                continue
+            summary = artists_api.format_artist_summary(artist)
+            genres = summary.get("genres")
+            meta = ", ".join(genres) if isinstance(genres, list) and genres else ""
+            artists.append({"id": str(aid), "name": artist.name, "meta": meta})
+
+    total = len(seed_ids)
+    more = max(0, total - len(artists))
+    ctx.update(
+        artists=artists,
+        start=start,
+        end=end,
+        total=total,
+        more=more,
+        empty=(total == 0),
+    )
+    return common.templates.TemplateResponse(
+        request, "partials/rediscovery_seed_preview.html", ctx
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/resonance/worker.py
+++ b/src/resonance/worker.py
@@ -54,6 +54,7 @@ import resonance.generators.genre as genre_module
 import resonance.generators.parameters as params_module
 import resonance.generators.pool as pool_module
 import resonance.generators.rediscovery as rediscovery_module
+import resonance.generators.seed_window as seed_window_module
 import resonance.heartbeat as heartbeat_module
 import resonance.logging as logging_module
 import resonance.migrations as migrations_module
@@ -817,33 +818,14 @@ async def _seed_artists_in_window(
 ) -> list[uuid.UUID]:
     """Top artists by distinct-track listens in ``[start, end]`` (#rediscovery).
 
-    Ranks by ``COUNT(DISTINCT track_id)`` per artist (not raw scrobbles), matching
-    the ``track_coverage`` definition elsewhere, so one repeat-played track can't
-    dominate the seed set. Bounds are inclusive on both ends. Returns artist ids
-    highest-count-first, capped at ``limit``. The DB half of the seed-window
-    primitive; the pure bounds computation is ``pool.resolve_window_bounds``.
+    Thin wrapper over :func:`generators.seed_window.seed_artists_in_window` (the
+    query moved to its own lightweight module so the web seed-preview endpoint can
+    reuse it without importing the whole worker graph, #rediscovery-ui T5). The
+    pure bounds computation is ``pool.resolve_window_bounds``.
     """
-    result = await session.execute(
-        sa.select(
-            music_models.Track.artist_id,
-            sa.func.count(sa.distinct(music_models.ListeningEvent.track_id)).label(
-                "cnt"
-            ),
-        )
-        .join(
-            music_models.Track,
-            music_models.Track.id == music_models.ListeningEvent.track_id,
-        )
-        .where(
-            music_models.ListeningEvent.user_id == user_id,
-            music_models.ListeningEvent.listened_at >= start,
-            music_models.ListeningEvent.listened_at <= end,
-        )
-        .group_by(music_models.Track.artist_id)
-        .order_by(sa.desc("cnt"))
-        .limit(limit)
+    return await seed_window_module.seed_artists_in_window(
+        session, user_id, start, end, limit
     )
-    return [row[0] for row in result.all()]
 
 
 async def resolve_pool(

--- a/tests/js/lineup.core.test.js
+++ b/tests/js/lineup.core.test.js
@@ -1,20 +1,27 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  absoluteWindow,
   addEventGroup,
   addManualArtist,
   allArtistIds,
   artistMeta,
+  clampSeedCount,
   escapeHtml,
   groupKey,
   hasArtist,
   isEmpty,
+  isWindowValid,
+  presetIdForWindow,
   pruneEmpty,
   removeArtistFromGroup,
   removeGroup,
   serializeInputReferences,
+  serializeRediscovery,
   setEventArtists,
   toggleArtist,
+  windowDates,
+  windowFromPreset,
 } from "../../src/resonance/static/lineup.core.js";
 
 const row = (id, included = true) => ({ id, name: id, meta: "", included });
@@ -185,5 +192,147 @@ describe("serializeInputReferences", () => {
       sources: [],
       exclude_artist_ids: [],
     });
+  });
+});
+
+/* ===== Rediscovery window (#rediscovery-ui) ===== */
+
+// A fixed instant so preset date math is deterministic: 2026-07-20 00:00:00 UTC.
+const NOW = Date.UTC(2026, 6, 20);
+
+describe("windowFromPreset", () => {
+  it("last_2_weeks is a rolling relative window", () => {
+    expect(windowFromPreset("last_2_weeks", NOW)).toEqual({
+      kind: "relative",
+      lookback_days: 14,
+    });
+  });
+  it("a_month_ago snaps to absolute now-44..now-16 day bounds", () => {
+    expect(windowFromPreset("a_month_ago", NOW)).toEqual({
+      kind: "absolute",
+      start: "2026-06-06T00:00:00",
+      end: "2026-07-04T23:59:59",
+    });
+  });
+  it("this_time_last_year snaps to absolute now-379..now-351 bounds", () => {
+    expect(windowFromPreset("this_time_last_year", NOW)).toEqual({
+      kind: "absolute",
+      start: "2025-07-06T00:00:00",
+      end: "2025-08-03T23:59:59",
+    });
+  });
+  it("returns null for custom (built from the date inputs)", () => {
+    expect(windowFromPreset("custom", NOW)).toBeNull();
+  });
+});
+
+describe("absoluteWindow", () => {
+  it("snaps end to end-of-day so the end date is inclusive", () => {
+    expect(absoluteWindow("2025-01-01", "2025-01-31")).toEqual({
+      kind: "absolute",
+      start: "2025-01-01T00:00:00",
+      end: "2025-01-31T23:59:59",
+    });
+  });
+});
+
+describe("presetIdForWindow", () => {
+  it("relative -> the rolling preset", () => {
+    expect(presetIdForWindow({ kind: "relative", lookback_days: 14 })).toBe(
+      "last_2_weeks"
+    );
+  });
+  it("absolute -> custom (preset identity not persisted)", () => {
+    expect(presetIdForWindow(absoluteWindow("2025-01-01", "2025-01-31"))).toBe(
+      "custom"
+    );
+  });
+  it("missing window -> the rolling preset default", () => {
+    expect(presetIdForWindow(null)).toBe("last_2_weeks");
+    expect(presetIdForWindow(undefined)).toBe("last_2_weeks");
+  });
+});
+
+describe("windowDates", () => {
+  it("extracts YYYY-MM-DD from an absolute window", () => {
+    expect(windowDates(absoluteWindow("2025-03-04", "2025-03-18"))).toEqual({
+      start: "2025-03-04",
+      end: "2025-03-18",
+    });
+  });
+  it("is empty for a relative or missing window", () => {
+    expect(windowDates({ kind: "relative", lookback_days: 14 })).toEqual({
+      start: "",
+      end: "",
+    });
+    expect(windowDates(null)).toEqual({ start: "", end: "" });
+  });
+});
+
+describe("clampSeedCount", () => {
+  it("clamps to [5, 50]", () => {
+    expect(clampSeedCount(1)).toBe(5);
+    expect(clampSeedCount(999)).toBe(50);
+    expect(clampSeedCount(20)).toBe(20);
+  });
+  it("falls back to 20 on non-numeric input", () => {
+    expect(clampSeedCount("")).toBe(20);
+    expect(clampSeedCount("abc")).toBe(20);
+  });
+  it("parses numeric strings", () => {
+    expect(clampSeedCount("30")).toBe(30);
+  });
+});
+
+describe("isWindowValid", () => {
+  it("relative needs a positive lookback", () => {
+    expect(isWindowValid({ kind: "relative", lookback_days: 14 })).toBe(true);
+    expect(isWindowValid({ kind: "relative", lookback_days: 0 })).toBe(false);
+  });
+  it("absolute needs start before end", () => {
+    expect(isWindowValid(absoluteWindow("2025-01-01", "2025-01-31"))).toBe(true);
+    // same-day is still valid (00:00:00 < 23:59:59)
+    expect(isWindowValid(absoluteWindow("2025-01-01", "2025-01-01"))).toBe(true);
+    expect(
+      isWindowValid({ kind: "absolute", start: "2025-02-01T00:00:00", end: "2025-01-01T23:59:59" })
+    ).toBe(false);
+  });
+  it("null/unknown is invalid", () => {
+    expect(isWindowValid(null)).toBe(false);
+    expect(isWindowValid({ kind: "weekly" })).toBe(false);
+  });
+});
+
+describe("serializeRediscovery", () => {
+  it("leads with the listening_range source and preserves via_seed discoveries", () => {
+    const window = { kind: "relative", lookback_days: 14 };
+    const groups = [
+      { kind: "related", scope: "lineup", artists: [row("r1"), row("r2", false)] },
+    ];
+    const out = serializeRediscovery(window, 20, groups);
+    expect(out.sources[0]).toEqual({
+      kind: "listening_range",
+      enabled: true,
+      window: { kind: "relative", lookback_days: 14 },
+      seed_artist_count: 20,
+      deep_cut_basis: "lifetime",
+      novelty_basis: "lifetime",
+    });
+    expect(out.sources.slice(1)).toEqual([
+      { kind: "artist", artist_id: "r1", enabled: true, via_seed: "lineup" },
+      { kind: "artist", artist_id: "r2", enabled: true, via_seed: "lineup" },
+    ]);
+    expect(out.exclude_artist_ids).toEqual(["r2"]);
+  });
+  it("emits only the window source when there are no discoveries", () => {
+    const out = serializeRediscovery(
+      absoluteWindow("2025-01-01", "2025-01-31"),
+      30,
+      []
+    );
+    expect(out.sources).toHaveLength(1);
+    expect(out.sources[0].kind).toBe("listening_range");
+    expect(out.sources[0].seed_artist_count).toBe(30);
+    expect(out.exclude_artist_ids).toEqual([]);
   });
 });

--- a/tests/test_lineup_builder.py
+++ b/tests/test_lineup_builder.py
@@ -343,6 +343,10 @@ class TestLineupDataXSS:
             "similar_available": False,
             "events": [],
             "parameters": {},
+            # edit_playlist_page now passes per-type slider sections + the type
+            # (#rediscovery-ui); the concert_prep path renders no rediscovery panel.
+            "param_sections": [{"params": []}, {"params": []}],
+            "generator_type": "concert_prep",
             "lineup": lineup,
         }
         html = common_ui.templates.get_template("playlists_new.html").render(ctx)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -42,6 +42,41 @@ class TestGeneratorTypeConfig:
         config = params_module.GENERATOR_TYPE_CONFIG[gen_type]
         assert config.default_pool_seed == "event"
 
+    def test_concert_prep_lead_and_no_advanced(self) -> None:
+        # concert_prep leads with its two featured dials and hides nothing behind
+        # Advanced -- and never renders the inert rediscovery dials (#rediscovery-ui).
+        config = params_module.GENERATOR_TYPE_CONFIG[
+            types_module.GeneratorType.CONCERT_PREP
+        ]
+        assert config.ordered_lead() == ("familiarity", "hit_depth")
+        assert config.advanced_parameters == ()
+        rendered = set(config.ordered_lead()) | set(config.advanced_parameters)
+        assert "new_ratio" not in rendered
+        assert "less_heard_percentile" not in rendered
+
+    def test_rediscovery_leads_with_its_defining_dials(self) -> None:
+        # Rediscovery leads with new_ratio/less_heard and tucks familiarity/hit_depth
+        # behind Advanced (design decision 2). Lead + advanced == featured.
+        config = params_module.GENERATOR_TYPE_CONFIG[
+            types_module.GeneratorType.REDISCOVERY
+        ]
+        assert config.ordered_lead() == ("new_ratio", "less_heard_percentile")
+        assert config.advanced_parameters == ("familiarity", "hit_depth")
+        assert set(config.ordered_lead()) | set(config.advanced_parameters) == set(
+            config.featured_parameters
+        )
+
+    def test_ordered_lead_defaults_to_featured_in_registry_order(self) -> None:
+        # A config without explicit lead_parameters falls back to its featured set
+        # in registry order (the documented default behavior).
+        config = params_module.GeneratorTypeConfig(
+            featured_parameters=frozenset({"hit_depth", "familiarity"}),
+            required_inputs=frozenset(),
+            description="test",
+        )
+        # Registry order is familiarity before hit_depth.
+        assert config.ordered_lead() == ("familiarity", "hit_depth")
+
 
 class TestApplyDefaults:
     def test_fills_missing_with_defaults(self) -> None:

--- a/tests/test_rediscovery_ui.py
+++ b/tests/test_rediscovery_ui.py
@@ -1,0 +1,97 @@
+"""Template-render tests for the rediscovery editor panel (#rediscovery-ui).
+
+Renders ``playlists_new.html`` directly (no app/DB) to prove the conditional
+panel swaps by generator_type: rediscovery gets the window panel, concert_prep
+keeps the lineup add-controls. The seed-preview endpoint and full create flow are
+covered by live QA (there is no async client/DB fixture in this suite).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import resonance.generators.parameters as params_module
+import resonance.types as types_module
+import resonance.ui.common as common_ui
+
+
+def _render(generator_type: str, *, similar_available: bool = True) -> str:
+    """Render the editor template with a minimal, real-shaped context."""
+    config = params_module.GENERATOR_TYPE_CONFIG[
+        types_module.GeneratorType(generator_type)
+    ]
+    reg = params_module.PARAMETER_REGISTRY
+    param_sections = [
+        {"params": [(n, reg[n]) for n in config.ordered_lead()]},
+        {"params": [(n, reg[n]) for n in config.advanced_parameters]},
+    ]
+    ctx: dict[str, Any] = {
+        "request": SimpleNamespace(url=SimpleNamespace(path="/playlists/x/edit")),
+        "user_id": "u",
+        "user_tz": "UTC",
+        "user_role": "owner",
+        "actual_role": "owner",
+        "viewing_as": None,
+        "profile_id": "x",
+        "profile_name": "My Playlist",
+        "parameter_values": {},
+        "similar_available": similar_available,
+        "events": [],
+        "parameters": {},
+        "param_sections": param_sections,
+        "generator_type": generator_type,
+        "lineup": {"version": 0, "groups": []},
+    }
+    return common_ui.templates.get_template("playlists_new.html").render(ctx)
+
+
+class TestRediscoveryPanel:
+    def test_renders_window_pills_and_seed_preview(self) -> None:
+        html = _render("rediscovery")
+        assert 'data-window-preset="last_2_weeks"' in html
+        assert 'data-window-preset="a_month_ago"' in html
+        assert 'data-window-preset="this_time_last_year"' in html
+        assert 'data-window-preset="custom"' in html
+        assert 'id="seed-preview"' in html
+        assert 'id="seed-count"' in html
+        assert 'id="custom-window"' in html
+
+    def test_uses_rediscover_header_not_lineup_copy(self) -> None:
+        html = _render("rediscovery")
+        assert "Rediscover" in html
+        # The event dropdown (lineup add-control) must not appear for rediscovery.
+        assert 'id="add-event-select"' not in html
+
+    def test_leads_with_rediscovery_dials_advanced_hides_the_rest(self) -> None:
+        html = _render("rediscovery")
+        # Lead dials render; familiarity/hit_depth are behind the Advanced <details>.
+        assert 'data-param="new_ratio"' in html
+        assert 'data-param="less_heard_percentile"' in html
+        assert "<summary>Advanced</summary>" in html
+        assert 'data-param="familiarity"' in html  # present, but inside Advanced
+
+    def test_find_related_button_when_similar_available(self) -> None:
+        html = _render("rediscovery", similar_available=True)
+        assert "Find related artists" in html
+        assert 'id="new-stream-hint"' in html
+
+
+class TestConcertPrepPanelUnchanged:
+    def test_renders_lineup_controls_not_window_panel(self) -> None:
+        html = _render("concert_prep")
+        assert 'id="add-event-select"' in html
+        assert 'id="artist-search"' in html
+        # No rediscovery window panel for concert_prep.
+        assert "data-window-preset" not in html
+        assert 'id="seed-preview"' not in html
+
+    def test_shows_only_featured_dials(self) -> None:
+        html = _render("concert_prep")
+        assert 'data-param="familiarity"' in html
+        assert 'data-param="hit_depth"' in html
+        # The inert rediscovery dials must not render for concert_prep.
+        assert 'data-param="new_ratio"' not in html
+        assert 'data-param="less_heard_percentile"' not in html
+        # No Advanced disclosure (concert_prep has no advanced params).
+        assert "<summary>Advanced</summary>" not in html

--- a/tests/test_rediscovery_ui.py
+++ b/tests/test_rediscovery_ui.py
@@ -95,3 +95,76 @@ class TestConcertPrepPanelUnchanged:
         assert 'data-param="less_heard_percentile"' not in html
         # No Advanced disclosure (concert_prep has no advanced params).
         assert "<summary>Advanced</summary>" not in html
+
+
+class TestSeedPreviewPartial:
+    """Directly render the seed-preview partial to catch Jinja/format errors
+    (strftime, the date-range echo, the data-empty flag) without an app/DB."""
+
+    def _render_preview(self, ctx_extra: dict[str, Any]) -> str:
+        ctx: dict[str, Any] = {
+            "request": SimpleNamespace(url=SimpleNamespace(path="/x")),
+            "user_id": "u",
+            "user_tz": "UTC",
+            "user_role": "owner",
+            "actual_role": "owner",
+            "viewing_as": None,
+        }
+        ctx.update(ctx_extra)
+        return common_ui.templates.get_template(
+            "partials/rediscovery_seed_preview.html"
+        ).render(ctx)
+
+    def test_populated_window_lists_artists_and_echoes_dates(self) -> None:
+        import datetime
+
+        html = self._render_preview(
+            {
+                "artists": [
+                    {"id": "a", "name": "Boards of Canada", "meta": "idm, ambient"},
+                    {"id": "b", "name": "Aphex Twin", "meta": ""},
+                ],
+                "start": datetime.datetime(2025, 7, 6, tzinfo=datetime.UTC),
+                "end": datetime.datetime(2025, 8, 3, tzinfo=datetime.UTC),
+                "total": 2,
+                "more": 0,
+                "empty": False,
+            }
+        )
+        assert 'data-empty="false"' in html
+        assert "Boards of Canada" in html
+        assert "Aphex Twin" in html
+        assert "Jul" in html and "Aug" in html  # date-range echo rendered
+
+    def test_more_suffix_when_truncated(self) -> None:
+        import datetime
+
+        html = self._render_preview(
+            {
+                "artists": [{"id": "a", "name": "One", "meta": ""}],
+                "start": datetime.datetime(2026, 6, 6, tzinfo=datetime.UTC),
+                "end": datetime.datetime(2026, 7, 4, tzinfo=datetime.UTC),
+                "total": 31,
+                "more": 30,
+                "empty": False,
+            }
+        )
+        assert "+30 more" in html
+        # Same-year range collapses to one year label.
+        assert html.count("2026") == 1
+
+    def test_empty_window_marks_data_empty(self) -> None:
+        import datetime
+
+        html = self._render_preview(
+            {
+                "artists": [],
+                "start": datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC),
+                "end": datetime.datetime(2020, 1, 14, tzinfo=datetime.UTC),
+                "total": 0,
+                "more": 0,
+                "empty": True,
+            }
+        )
+        assert 'data-empty="true"' in html
+        assert "No listening data" in html


### PR DESCRIPTION
## Summary

End-user UI for creating a **rediscovery** playlist, reusing the #133 server-backed profile editor. Pick a listening-history window, see what you'll rediscover, tune the mix, materialize a never-heard new-artist stream, and generate — all as server-backed edits to the profile (the recipe is the system of record).

The REDISCOVERY generator backend shipped in #162; this is the front door for it. Everything rediscovery-specific is gated on `generator_type`, so the concert_prep editor path is unchanged.

What the user gets on `/playlists/new?type=rediscovery`:
- **Window pills** — Last 2 Weeks (rolling) · A Month Ago · This Time Last Year · Custom (two date inputs). Reuses the existing `.preset-btn` pills.
- **Live seed preview** — "You'll rediscover: …" resolves the current window to its top artists, debounced auto-refresh, with a resolved date-range echo.
- **New vs Deep Cuts** + **Deep Cut Depth** sliders lead; familiarity/hit_depth tuck behind an Advanced disclosure.
- **Find related artists** (ghost) materializes the new-artist stream; **Generate** is the sole primary. An "all deep cuts" hint appears when the new stream is empty.
- Empty/invalid window is a first-class empty state and disables Generate (the generator errors on a zero-listen window).

<details>
<summary>How to Review</summary>

Four logical commits, reviewable in order:

1. **Backend** (`d0ff5d7`) — draft auto-seeds a default `listening_range` window; per-type slider grouping (`lead_parameters`/`advanced_parameters` on `GeneratorTypeConfig`, rendered via `param_sections`) which also stops concert_prep from showing the inert rediscovery dials; `_hydrate_lineup` surfaces the window for round-trip; a read-only seed-preview endpoint + partial; and the seed-artist query extracted to `generators/seed_window.py` so the web path doesn't import the whole worker graph.
2. **Core JS** (`9426452`) — pure window state/serializer in `lineup.core.js`, unit-tested (windowFromPreset, presetIdForWindow round-trip, serializeRediscovery preserving via_seed discoveries, clamp/validity).
3. **Panel** (`4e0fca0`) — conditional template panel, `lineup.js` controller wiring (gated on `isRediscovery`), and CSS. Note the seed-preview refresh fires only *after* the window PATCH commits (the endpoint reads the persisted window).
4. **Partial tests** (`HEAD`) — direct render of the seed-preview Jinja.

Suggested focus: the round-trip contract (relative → Last 2 Weeks, absolute → Custom; preset identity for the two absolute presets is intentionally not persisted, matching the design), and the Generate-disable guard (invalid window OR empty preview).
</details>

<details>
<summary>Test Plan</summary>

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/` — clean (100 files)
- [x] `uv run pytest` — 1786 passed
- [x] `npm test` (vitest) — 39 passed (16 new window tests)
- [x] New coverage: per-type param grouping, conditional panel render (both types), seed-preview partial render (date echo, +N more, empty state), route registration + import chain
- [ ] **Live end-to-end** (draft → PATCH window → seed-preview → enrich → generate) — best run on prod after deploy, where real listening data exercises the populated seed-preview path

No DB/async-client fixture exists in this suite, so the endpoint is covered by unit + render + wiring tests; the populated-data path is a post-deploy prod check.
</details>

<details>
<summary>Impact</summary>

- **New capability**: rediscovery playlists are now creatable in the UI (previously backend/CLI only).
- **concert_prep behavior change**: its editor now shows only its featured dials (familiarity/hit_depth). Previously the template looped the whole registry, so concert_prep rendered the inert new_ratio/less_heard sliders. Those dials do nothing for concert_prep, so this is a correctness fix, not a regression.
- **Concurrency**: no new first-concurrent-write path — window edits and enrich go through the same #133 optimistic-version-guarded PATCH/enrich; the seed-preview endpoint is read-only.
- **API-first**: no new client-only state; the panel mutates `input_references` server-side, and the seed preview is a real endpoint.
- No migrations. No config changes.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
