### PR TITLE
fix(rediscovery): blank seed preview (TDZ on generateBtn aborted the editor JS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "resonance-ui",
       "version": "0.0.0",
       "devDependencies": {
+        "happy-dom": "^20.10.6",
         "vitest": "^2.1.0"
       }
     },
@@ -805,6 +806,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -928,6 +956,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -991,6 +1032,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1072,6 +1126,25 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/loupe": {
@@ -1290,6 +1363,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -1439,6 +1519,16 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1454,6 +1544,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "happy-dom": "^20.10.6",
     "vitest": "^2.1.0"
   }
 }

--- a/src/resonance/static/lineup.js
+++ b/src/resonance/static/lineup.js
@@ -666,10 +666,15 @@ const windowErrorEl = document.getElementById("window-error");
 const seedCountEl = document.getElementById("seed-count");
 
 /* Generate is disabled while the window is invalid (custom end < start) or the
- * window resolves to no listening data — both would crash or no-op generation. */
+ * window resolves to no listening data — both would crash or no-op generation.
+ * Looks the button up lazily rather than closing over the `generateBtn` const:
+ * this runs during module init (and on pill clicks) BEFORE that const is
+ * evaluated later in the file, so a closure reference would hit the temporal dead
+ * zone and abort the whole script — leaving the seed preview blank. */
 function updateGenerateEnabled() {
-  if (!isRediscovery || !generateBtn) return;
-  generateBtn.disabled = !windowValid || previewEmpty;
+  if (!isRediscovery) return;
+  const btn = document.getElementById("generate-btn");
+  if (btn) btn.disabled = !windowValid || previewEmpty;
 }
 
 function setActivePreset(presetId) {

--- a/tests/js/lineup.controller.test.js
+++ b/tests/js/lineup.controller.test.js
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+//
+// Controller smoke tests for lineup.js (#rediscovery-ui). The pure logic lives in
+// lineup.core.js (lineup.core.test.js); this file exercises the DOM controller by
+// importing it against a mock DOM + mock fetch. It exists because a temporal-dead-
+// zone bug (updateGenerateEnabled closed over the `generateBtn` const declared
+// LATER in the file, referenced during module-init) threw at import and aborted the
+// whole script — so the rediscovery seed preview never loaded (blank box on prod).
+// A top-level throw rejects the dynamic import(), so "loads without throwing" is the
+// regression guard.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const EDITOR_DOM = (generatorType) => `
+  <p><a class="backlink" href="/playlists">Back</a></p>
+  <div class="editor-top">
+    <input id="name" value="New Rediscovery">
+    <span class="autosave" id="autosave" hidden><span class="dot"></span> <span class="autosave-label">Saved</span></span>
+  </div>
+  <div class="lineup-conflict" id="lineup-conflict" hidden>
+    <button id="conflict-reload"></button>
+  </div>
+  <div class="filter-presets">
+    <button type="button" class="preset-btn" data-window-preset="last_2_weeks">Last 2 Weeks</button>
+    <button type="button" class="preset-btn" data-window-preset="a_month_ago">A Month Ago</button>
+    <button type="button" class="preset-btn" data-window-preset="this_time_last_year">This Time Last Year</button>
+    <button type="button" class="preset-btn" data-window-preset="custom">Custom</button>
+  </div>
+  <div class="custom-window" id="custom-window" hidden>
+    <input type="date" id="window-start">
+    <input type="date" id="window-end">
+    <div class="cw-error" id="window-error" hidden></div>
+  </div>
+  <input type="number" id="seed-count" value="20">
+  <div class="seed-preview" id="seed-preview"></div>
+  <input type="number" id="add-related-n" value="15">
+  <button type="button" class="ghost" id="add-related-btn">Find related artists</button>
+  <div id="lineup-groups"></div>
+  <div class="new-stream-hint" id="new-stream-hint" hidden><button id="hint-find-related"></button></div>
+  <button type="button" class="primary" id="generate-btn">Generate Playlist</button>
+  <script id="lineup-data" type="application/json">${JSON.stringify({
+    generator_type: generatorType,
+    version: 1,
+    groups: [],
+    name: "New Rediscovery",
+    parameter_values: {},
+    profile_id: "test-profile",
+    listening_range: { window: { kind: "relative", lookback_days: 14 }, seed_artist_count: 20 },
+  })}</script>
+`;
+
+function setupDom(generatorType) {
+  document.body.innerHTML = EDITOR_DOM(generatorType);
+  window.LINEUP_PROFILE_ID = "test-profile";
+  window.LINEUP_SIMILAR_AVAILABLE = true;
+  window.LINEUP_GENERATOR_TYPE = generatorType;
+}
+
+function mockFetch() {
+  const fetchMock = vi.fn(async (url) => {
+    if (String(url).includes("/seed-preview")) {
+      return {
+        ok: true,
+        text: async () =>
+          '<div id="seed-preview-inner" data-empty="false">You&rsquo;ll rediscover 3 artists: TOOL, Rainbow, Dopelord</div>',
+      };
+    }
+    return { ok: true, json: async () => ({ version: 1 }) };
+  });
+  global.fetch = fetchMock;
+  return fetchMock;
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("lineup.js controller — rediscovery", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("imports without throwing and populates the seed preview on init", async () => {
+    setupDom("rediscovery");
+    const fetchMock = mockFetch();
+    // The import IS the regression check: the TDZ bug threw here, rejecting this.
+    await import("../../src/resonance/static/lineup.js");
+    await settle();
+    const preview = document.getElementById("seed-preview");
+    expect(preview.innerHTML).toContain("You");
+    expect(preview.innerHTML).toContain("rediscover");
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).includes("/seed-preview"))
+    ).toBe(true);
+  });
+
+  it("wires the Generate button (handler attaches after init runs)", async () => {
+    // The TDZ bug also aborted the script before the generate-btn handler + render()
+    // ran. If import succeeds, module eval reached the end of the file.
+    setupDom("rediscovery");
+    mockFetch();
+    await expect(
+      import("../../src/resonance/static/lineup.js")
+    ).resolves.toBeDefined();
+    await settle();
+    // Generate is disabled while the preview is unresolved/empty; after a populated
+    // preview it is enabled — proving updateGenerateEnabled ran without throwing.
+    const btn = document.getElementById("generate-btn");
+    expect(btn.disabled).toBe(false);
+  });
+});
+
+describe("lineup.js controller — concert_prep", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("imports without throwing and never fetches the seed preview", async () => {
+    setupDom("concert_prep");
+    const fetchMock = mockFetch();
+    await import("../../src/resonance/static/lineup.js");
+    await settle();
+    // concert_prep is not rediscovery: the window init/preview must not run.
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).includes("/seed-preview"))
+    ).toBe(false);
+    expect(document.getElementById("seed-preview").innerHTML).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

The rediscovery editor's seed-preview box rendered **blank** on prod (owner caught it — [screenshot in review]). Root cause: `updateGenerateEnabled()` closed over the `generateBtn` const declared **later** in `lineup.js`, but it's called during module init and on pill clicks. That's a temporal-dead-zone `ReferenceError` — it threw at import and aborted the rest of the script, so `refreshSeedPreview()` never ran (blank box), the Generate handler never attached, and `render()` never ran. Window-change PATCH-on-click died the same way.

**Fix:** look the button up lazily via `getElementById` inside `updateGenerateEnabled`, removing the declaration-order dependency.

**Why it slipped #165's QA:** I validated the seed-preview *endpoint* and PATCH directly via the CLI, which bypasses the browser JS entirely. This PR adds a happy-dom controller smoke test that imports `lineup.js` against a mock DOM — a top-level throw rejects the dynamic `import()`, so it reproduces the exact failure (verified: fails with "Cannot access 'generateBtn' before initialization" on the old code) and guards the load path going forward.

<details><summary>Test Plan</summary>

- [x] npm test — 42 pass (3 new controller tests)
- [x] Confirmed the new test FAILS on the buggy code (TDZ) and PASSES on the fix
- [ ] Post-deploy: load the rediscovery editor on prod, confirm the seed preview populates
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)