### PR TITLE
fix(rediscovery): render seed preview as a flowing list, not wonky chips

### DIFF
--- a/src/resonance/static/lineup.css
+++ b/src/resonance/static/lineup.css
@@ -338,15 +338,10 @@ button.primary:disabled { opacity: 0.6; cursor: default; }
 }
 .seed-preview-head { font-size: 0.9rem; font-weight: 500; margin-bottom: var(--space-xs); }
 .seed-preview-head .seed-count { font-variant-numeric: tabular-nums; }
-.seed-list {
-  list-style: none; margin: 0; padding: 0;
-  display: flex; flex-wrap: wrap; gap: var(--space-2xs) var(--space-sm);
-}
-.seed-item { font-size: 0.85rem; }
-.seed-item .seed-name { font-weight: 500; }
-.seed-item .seed-meta { color: var(--text-muted); font-size: 0.75rem; }
-.seed-item:not(:last-child) .seed-name::after { content: ","; color: var(--text-muted); font-weight: 400; }
-.seed-more { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-2xs); }
+/* Flowing comma-separated sentence — reads like a magazine blurb and wraps like
+   normal text (an earlier flex-chip + comma-::after hybrid rendered wonky). */
+.seed-list { margin: 0; font-size: 0.85rem; line-height: 1.55; }
+.seed-more { color: var(--text-muted); font-style: italic; }
 .seed-empty { font-size: 0.85rem; color: var(--text-muted); font-style: italic; }
 
 /* Find-related row (rediscovery variant of the add-related control) */

--- a/src/resonance/templates/partials/rediscovery_seed_preview.html
+++ b/src/resonance/templates/partials/rediscovery_seed_preview.html
@@ -21,15 +21,6 @@
   </div>
   {% else %}
   <div class="seed-preview-head">You&rsquo;ll rediscover <span class="seed-count">{{ total }}</span> artist{{ '' if total == 1 else 's' }}:</div>
-  <ul class="seed-list">
-    {% for a in artists %}
-    <li class="seed-item">
-      <span class="seed-name">{{ a.name }}</span>{% if a.meta %} <span class="seed-meta">{{ a.meta }}</span>{% endif %}
-    </li>
-    {% endfor %}
-  </ul>
-  {% if more > 0 %}
-  <div class="seed-more">+{{ more }} more</div>
-  {% endif %}
+  <p class="seed-list">{{ artists | map(attribute='name') | join(', ') }}{% if more > 0 %} <span class="seed-more">and {{ more }} more</span>{% endif %}</p>
   {% endif %}
 </div>

--- a/tests/test_rediscovery_ui.py
+++ b/tests/test_rediscovery_ui.py
@@ -132,8 +132,8 @@ class TestSeedPreviewPartial:
             }
         )
         assert 'data-empty="false"' in html
-        assert "Boards of Canada" in html
-        assert "Aphex Twin" in html
+        # Flowing comma-separated sentence, not a chip list.
+        assert "Boards of Canada, Aphex Twin" in html
         assert "Jul" in html and "Aug" in html  # date-range echo rendered
 
     def test_more_suffix_when_truncated(self) -> None:
@@ -149,7 +149,7 @@ class TestSeedPreviewPartial:
                 "empty": False,
             }
         )
-        assert "+30 more" in html
+        assert "and 30 more" in html
         # Same-year range collapses to one year label.
         assert html.count("2026") == 1
 


### PR DESCRIPTION
## Summary

Follow-up to the preview fix. The seed preview mixed a flex-wrapped `<ul>/<li>` chip layout with comma `::after` separators, so each artist name showed a stray separator mark and the list wrapped awkwardly (owner: "the UI for the artists is a little wonky").

Replaced it with a plain flowing comma-separated sentence — "Black Sabbath, Ghost, Type O Negative … and N more" — which reads editorially and wraps like normal text. Dropped the per-artist genre meta from the preview (names are enough there).

- Template + CSS only; partial-render test updated. pytest 11 (rediscovery-ui), ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)